### PR TITLE
Fix for pictures - picture thumbs can not be deleted from local storage

### DIFF
--- a/src/Business/Grand.Business.Storage/Services/PictureService.cs
+++ b/src/Business/Grand.Business.Storage/Services/PictureService.cs
@@ -149,10 +149,13 @@ namespace Grand.Business.Storage.Services
                 {
                     try
                     {
-                        if (!File.Exists(currentFileName))
+                        if (File.Exists(currentFileName))
                             File.Delete(currentFileName);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        _logger.InsertLog(Domain.Logging.LogLevel.Error, ex.Message);
+                    }
                 }
             }
             return Task.CompletedTask;


### PR DESCRIPTION
Resolves #100  
Type: bugfix

## Issue
The current logic is to delete an image when it does not exist, so the image will never be removed

## Solution
Change the logic to delete an image when it exists.

## Breaking changes
N/A

## Testing
N/A
