### PR TITLE
Fix of possible typo - OData, API - ProductLayout, BrandLayout

### DIFF
--- a/src/API/Grand.Api/Infrastructure/DependencyEdmModel.cs
+++ b/src/API/Grand.Api/Infrastructure/DependencyEdmModel.cs
@@ -54,8 +54,8 @@ namespace Grand.Api.Infrastructure
 
             builder.EntitySet<LayoutDto>("CategoryLayout");
             builder.EntitySet<LayoutDto>("CollectionLayout");
-            builder.EntitySet<LayoutDto>("ProductlLayout");
-            builder.EntitySet<LayoutDto>("BrandlLayout");
+            builder.EntitySet<LayoutDto>("ProductLayout");
+            builder.EntitySet<LayoutDto>("BrandLayout");
             builder.EntityType<LayoutDto>().Count().Filter().OrderBy().Page();
 
             #endregion


### PR DESCRIPTION
OData Client generated classes fail to fetch the layouts with the typo

## Issue

There is a possible typo with the Layout namespaces.  
When classes are generated from /odata/$metadata these namespaces will not work to fetch the layouts from Grandnode

_Using the rest api without generated odata clients does work still..._

## Solution

Typo changes in the DependencyEdmModel

## Breaking changes

No breaking changes - I believe - it is advised to _Update OData Connected Services_ in your consumer app.

## Testing

After the change, and after updating the consumer app, it is possible to fetch layouts just fine

```cs
var layouts = ProductLayout.Execute();
```