### PR TITLE
Populate a WorkContext in the created scope

### DIFF
--- a/src/Business/Grand.Business.Checkout/Commands/Handlers/Orders/PlaceOrderCommandHandler.cs
+++ b/src/Business/Grand.Business.Checkout/Commands/Handlers/Orders/PlaceOrderCommandHandler.cs
@@ -205,7 +205,7 @@ namespace Grand.Business.Checkout.Commands.Handlers.Orders
                     //check order status
                     await _mediator.Send(new CheckOrderStatusCommand() { Order = result.PlacedOrder });
 
-                    //raise event       
+                    //raise event
                     await _mediator.Publish(new OrderPlacedEvent(result.PlacedOrder));
 
                     if (result.PlacedOrder.PaymentStatusId == PaymentStatus.Paid)
@@ -599,7 +599,7 @@ namespace Grand.Business.Checkout.Commands.Handlers.Orders
             details.OrderShippingTotalInclTax = orderShippingTotalInclTax.Value;
             details.OrderShippingTotalExclTax = orderShippingTotalExclTax.Value;
 
-            //payment 
+            //payment
             var paymentMethodSystemName = _workContext.CurrentCustomer.GetUserFieldFromEntity<string>(SystemCustomerFieldNames.SelectedPaymentMethod, _workContext.CurrentStore.Id);
             details.PaymentMethodSystemName = paymentMethodSystemName;
             double paymentAdditionalFee = await _paymentService.GetAdditionalHandlingFee(details.Cart, paymentMethodSystemName);
@@ -1099,12 +1099,18 @@ namespace Grand.Business.Checkout.Commands.Handlers.Orders
         }
 
         /// <summary>
-        /// Send notification order 
+        /// Send notification order
         /// </summary>
         /// <param name="order">Order</param>
         protected virtual async Task SendNotification(IServiceScopeFactory scopeFactory, Order order, Customer customer, Customer originalCustomerIfImpersonated)
         {
             using var scope = scopeFactory.CreateScope();
+
+            var workContext = scope.ServiceProvider.GetService<IWorkContext>();
+            await workContext.SetCurrentCustomer(customer);
+            await workContext.SetWorkingLanguage(customer);
+            await workContext.SetWorkingCurrency(customer);
+            await workContext.SetTaxDisplayType(customer);
 
             var orderService = scope.ServiceProvider.GetRequiredService<IOrderService>();
             var messageProviderService = scope.ServiceProvider.GetRequiredService<IMessageProviderService>();


### PR DESCRIPTION
## Issue #128 

When trying to send a `OrderPlaced.CustomerNotification` MessageTemplate to the customer, I found that the `{{Order.PaymentMethod}}` variable is always empty.

After debugging the problem I found that in the `GetOrderTokensCommandHandler` the _paymentService returns the IPaymentMethod with `FriendlyName` always being an empty string

here: [GetOrderTokensCommandHandler.cs line 139](https://github.com/grandnode/grandnode2/blob/master/src/Business/Grand.Business.System/Commands/Handlers/Messages/GetOrderTokensCommandHandler.cs#L139)

```cs
var paymentMethod = _paymentService.LoadPaymentMethodBySystemName(request.Order.PaymentMethodSystemName);
liquidOrder.PaymentMethod = paymentMethod != null ? paymentMethod.FriendlyName : request.Order.PaymentMethodSystemName;
```

The issue turned out to be that in most Payment plugins `FriendlyName` uses the ITranslationService which had an IWorkContext with the WorkingLanguage set to null.

Found out that there is a new Scope in the [PlaceOrderCommandHandler.cs line 1107, SendNotification()](https://github.com/grandnode/grandnode2/blob/master/src/Business/Grand.Business.Checkout/Commands/Handlers/Orders/PlaceOrderCommandHandler.cs#L1107) and the WorkContext is not initialized. It is normally done by the WorkContextMiddleWare (which is not running here)

## Solution

Fetched a new WorkContext from the ServiceScopeFactory, populated it with the Customer that is passed to the SendNotification method. Now every item that gets created in the Scope will have a proper WorkContext.

_(Payment plugins may rely on more things that uses the WorkContext, but they are already relying on ITranslationService)_

```cs
var workContext = scope.ServiceProvider.GetService<IWorkContext>();
await workContext.SetCurrentCustomer(customer);
await workContext.SetWorkingLanguage(customer);
await workContext.SetWorkingCurrency(customer);
await workContext.SetTaxDisplayType(customer);
```

## Breaking changes

This should not cause any braking changes, but you can decide it better

## Testing
1. Before applying my changes - add an `{{Order.PaymentMethod}}` to any of the `OrderPlaced` templates, Use CashOnDeliver - for example, check the order placed confirmation, the template value will be empty  

2. Do the same things after the applied changes - it will work
