### PR TITLE
Using "InvariantCulture" when passing floating point values to b-form-rating

### DIFF
--- a/src/Web/Grand.Web/Views/Catalog/_VendorReviewOverview.cshtml
+++ b/src/Web/Grand.Web/Views/Catalog/_VendorReviewOverview.cshtml
@@ -10,7 +10,7 @@
 @if (Model.AllowCustomerReviews)
 {
     <div class="vendor-reviews-overview d-inline-flex align-items-center flex-wrap" @if (Model.TotalReviews > 0) { <text> itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating" </text>  }>
-        @{ 
+        @{
             double ratingValue = 0;
             if (Model.TotalReviews != 0)
             {
@@ -18,7 +18,7 @@
             }
         }
                     <div class="rating">
-                        <b-form-rating id="rating-inline" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue)"></b-form-rating>
+                        <b-form-rating id="rating-inline" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))"></b-form-rating>
                         <span class="h6 mb-0 text-info">@Model.TotalReviews @Loc["Reviews.Overview.Reviews"]</span>
                         @if (Model.TotalReviews > 0)
                         {

--- a/src/Web/Grand.Web/Views/Product/_ProductReviewOverview.cshtml
+++ b/src/Web/Grand.Web/Views/Product/_ProductReviewOverview.cshtml
@@ -9,7 +9,7 @@
 }
 <div class="product-reviews-overview d-inline-flex align-items-center flex-wrap" @if (Model.TotalReviews > 0) { <text> itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating" </text> }>
     <div class="product-review-box d-inline-block order-1">
-        @{ 
+        @{
             double ratingValue = 0;
             if (Model.TotalReviews != 0)
             {
@@ -17,7 +17,7 @@
             }
         }
             <div class="rating">
-                <b-form-rating id="rating-inline-overview-@Model.ProductId" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue)"></b-form-rating>
+                <b-form-rating id="rating-inline-overview-@Model.ProductId" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))"></b-form-rating>
                 @if (Model.TotalReviews > 0)
                 {
                     <div class="product-review-links order-3">

--- a/src/Web/Grand.Web/Views/Shared/_CatalogProductListView.cshtml
+++ b/src/Web/Grand.Web/Views/Shared/_CatalogProductListView.cshtml
@@ -1,4 +1,5 @@
-﻿@model ProductOverviewModel
+﻿@using System.Globalization
+@model ProductOverviewModel
 @{
     //prepare "Add to cart" Axios link
     string addtocartlink = "";
@@ -76,7 +77,7 @@
                     }
                     <template>
                         <div class="rating">
-                            <b-form-rating id="rating-inline-list-@Model.Id" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue)"></b-form-rating>
+                            <b-form-rating id="rating-inline-list-@Model.Id" class="p-0" variant="warning" no-border size="sm" show-value precision="2" readonly inline value="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))"></b-form-rating>
                             <b-link href="@Url.RouteUrl("Product", new { SeName = Model.SeName })">@Model.ReviewOverviewModel.TotalReviews @Loc["Reviews.Overview.Reviews"]</b-link>
                         </div>
                     </template>

--- a/src/Web/Grand.Web/Views/Shared/_CatalogProductView.cshtml
+++ b/src/Web/Grand.Web/Views/Shared/_CatalogProductView.cshtml
@@ -1,4 +1,5 @@
-﻿@model ProductOverviewModel
+﻿@using System.Globalization
+@model ProductOverviewModel
 @{
     //prepare "Add to cart" Axios link
     string addtocartlink = "";
@@ -75,7 +76,7 @@
                 }
                 <template>
                     <div class="rating">
-                        <b-form-rating id="rating-inline-grid-@Model.Id" aria-label="Rating" class="p-0" variant="warning" no-border size="sm" show-value aria-valuenow="@(ratingValue)" precision="2" readonly inline value="@(ratingValue)"></b-form-rating>
+                        <b-form-rating id="rating-inline-grid-@Model.Id" aria-label="Rating" class="p-0" variant="warning" no-border size="sm" show-value aria-valuenow="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))" precision="2" readonly inline value="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))"></b-form-rating>
                         <b-link href="@Url.RouteUrl("Product", new { SeName = Model.SeName })">@Model.ReviewOverviewModel.TotalReviews @Loc["Reviews.Overview.Reviews"]</b-link>
                     </div>
                 </template>
@@ -296,4 +297,4 @@
             }
         </div>
     </div>
-</article> 
+</article>


### PR DESCRIPTION
## Issue

If the current culture uses comma as a decimal separator the b-form-rating component does not show the value properly - it truncates the fractions. 4,83333 -> becomes 4.00

![2021-10-10_17h56_56](https://user-images.githubusercontent.com/302959/136705069-9ca84e3c-fabd-4d0e-801e-52c27a4de143.png)

There are a lot of countries with comma as a separator  
Among them are Spain, France, Norway, the Czech Republic, Denmark, and more.  
[many more outside Europe](https://www.smartick.com/blog/math/learning-resources/decimal-separators/)

## Solution

Forcing `InvariantCulture` works fine. It is already used in the template for the microdata tag for Google

```html
<span itemprop="reviewCount" style="display: none;">(@ratingValuee.ToString("0.0", new CultureInfo("en-US")))</span>
```

Similarly I changed the `ratingValues` to display like this

```html
...show-value precision="2" readonly inline value="@(ratingValue.ToString("0.00", CultureInfo.InvariantCulture))"
```

Also only need to be done in places where the floating point value is calulated by C# code. When the calculation is done in the frontend,  vuejs just understands the results properly

## Breaking changes

There should be no breaking changes

## Testing

1. Have a culture that uses comma, f.ex: French
2. Add 2 reviews to a product. A rating with 5, and a rating with 4
3. Original code will show 4.00 as a rating for the product (also the stars)
4. After the pull request it will show 4.50 (also the stars)