### PR TITLE
fix product attribute image square tooltip

### DIFF
--- a/src/Web/Grand.Web/Views/Product/_ProductAttributes.cshtml
+++ b/src/Web/Grand.Web/Views/Product/_ProductAttributes.cshtml
@@ -198,7 +198,7 @@
                                             </template>
                                             <template v-else>
                                                 <input :id="'product_attribute_' + attribute.Id + '_' + attributeValue.Id" type="radio" :name="'product_attribute_' + attribute.Id" :value="attributeValue.Id" :checked="attributeValue.IsPreSelected" :data-disable="attributeValue.Id" @@change="standardProductAttributes.attrchange" />
-                                                <span class="color-container"> <span class="color" :style="'background: url(' + attributeValue.ImageSquaresPictureModel.ImageUrl + ') 50% 50% no-repeat;'"></span> </span>
+                                                <span :id="'imgSqr_' + attributeValue.Id" class="color-container"> <span class="color" :style="'background: url(' + attributeValue.ImageSquaresPictureModel.ImageUrl + ') 50% 50% no-repeat;'"></span> </span>
                                                 <b-tooltip :target="'imgSqr_' + attributeValue.Id" placement="bottom">
                                                     <div class="image-square-tooltip">
                                                         <img :src="attributeValue.ImageSquaresPictureModel.FullSizeImageUrl" :alt="attributeValue.Name + ' [' + attributeValue.PriceAdjustment + ']'" />


### PR DESCRIPTION
Type: **bugfix**

## Issue
When product attribute control type was image square,and if you setted additional fee not 0 for options,then there wasn't shown tooltips when mouse hover image square options in product details page.

## Solution
Add missing id for image square

## Breaking changes

## Testing
1. Add product attribute for one product,and set control type to image square.
2. Add option for the product attribute,and set additional fee not 0.
3. Show product details in shop page,move mouse hover the image square option.
