### PR TITLE
Change password compare message

### DIFF
--- a/src/Web/Grand.Web/Validators/Install/InstallValidator.cs
+++ b/src/Web/Grand.Web/Validators/Install/InstallValidator.cs
@@ -14,7 +14,8 @@ namespace Grand.Web.Validators.Install
             RuleFor(x => x.AdminEmail).EmailAddress();
             RuleFor(x => x.AdminPassword).NotEmpty();
             RuleFor(x => x.ConfirmPassword).NotEmpty();
-            RuleFor(x => x.AdminPassword).Equal(x => x.ConfirmPassword);
+            RuleFor(x => x.AdminPassword).Equal(x => x.ConfirmPassword)
+                .WithMessage("Passwords must be equals");
         }
     }
 }


### PR DESCRIPTION
Type: feature

## Issue
In the install page, if passwords are different it is exposing the password on error message

## Solution
Set a generic error "Passwords must be equals".

## Testing
Go to install page
Set different password and confirm password
Click on Install
