### PR TITLE
Fixed the product changed warning when save product after modified at…

### DIFF
--- a/src/Web/Grand.Web.Admin/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.TabAttributeCombinations.cshtml
+++ b/src/Web/Grand.Web.Admin/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.TabAttributeCombinations.cshtml
@@ -55,23 +55,48 @@
             },
             dataSource: {
                 transport: {
-                    read: {
-                        url: "@Html.Raw(Url.Action("ProductAttributeCombinationList", "Product", new { productId = Model.Id, area = Constants.AreaAdmin }))",
-                        type: "POST",
-                        dataType: "json",
-                        data: addAntiForgeryToken
+                    read: function(options) {
+                        $.ajax({
+                            url: "@Html.Raw(Url.Action("ProductAttributeCombinationList", "Product", new { productId = Model.Id, area = Constants.AreaAdmin }))",
+                            type: "POST",
+                            dataType: "json",
+                            data: addAntiForgeryToken(options.data),
+                            success: function(result) {
+                                options.success(result);
+                                $('input[name="Ticks"]').val(result.ExtraData.ProductTicks);
+                            },
+                            error: function(result) {
+                                options.error(result);
+                            }
+                        });
                     },
-                    update: {
-                        url: "@Html.Raw(Url.Action("ProductAttributeCombinationUpdate", "Product", new { area = Constants.AreaAdmin }))",
-                        type: "POST",
-                        dataType: "json",
-                        data: addAntiForgeryToken
+                    update: function(options) {
+                        $.ajax({
+                            url: "@Html.Raw(Url.Action("ProductAttributeCombinationUpdate", "Product", new { area = Constants.AreaAdmin }))",
+                            type: "POST",
+                            dataType: "json",
+                            data: addAntiForgeryToken(options.data),
+                            success: function(result) {
+                                options.success(result);
+                            },
+                            error: function(result) {
+                                options.error(result);
+                            }
+                        });
                     },
-                    destroy: {
-                        url: "@Html.Raw(Url.Action("ProductAttributeCombinationDelete", "Product", new { area = Constants.AreaAdmin }))",
-                        type: "POST",
-                        dataType: "json",
-                        data: addAntiForgeryToken
+                    destroy: function(options) {
+                        $.ajax({
+                            url: "@Html.Raw(Url.Action("ProductAttributeCombinationDelete", "Product", new { area = Constants.AreaAdmin }))",
+                            type: "POST",
+                            dataType: "json",
+                            data: addAntiForgeryToken(options.data),
+                            success: function(result) {
+                                options.success(result);
+                            },
+                            error: function(result) {
+                                options.error(result);
+                            }
+                        });
                     }
                 },
                 schema: {
@@ -95,7 +120,7 @@
                     }
                 },
                 requestEnd: function(e) {
-                    if (e.type == "update") {
+                    if (e.type == "update" || e.type == "destroy") {
                         this.read();
                     }
                 },

--- a/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
@@ -2373,7 +2373,7 @@ namespace Grand.Web.Admin.Controllers
             await productAttributeService.DeleteProductAttributeCombination(combination, productId);
             if (product.ManageInventoryMethodId == ManageInventoryMethod.ManageStockByAttributes)
             {
-                var pr = await _productService.GetProductById(productId);
+                var pr = await _productService.GetProductById(productId, true);
                 pr.StockQuantity = pr.ProductAttributeCombinations.Sum(x => x.StockQuantity);
                 pr.ReservedQuantity = pr.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
                 await _inventoryManageService.UpdateStockProduct(pr, false);

--- a/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
@@ -2344,7 +2344,8 @@ namespace Grand.Web.Admin.Controllers
             var combinationsModel = await _productViewModelService.PrepareProductAttributeCombinationModel(product);
             var gridModel = new DataSourceResult {
                 Data = combinationsModel,
-                Total = combinationsModel.Count
+                Total = combinationsModel.Count,
+                ExtraData = new { ProductTicks = product.UpdatedOnUtc.Ticks.ToString() }
             };
             return Json(gridModel);
         }

--- a/src/Web/Grand.Web.Admin/Services/ProductViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/ProductViewModelService.cs
@@ -2545,7 +2545,7 @@ namespace Grand.Web.Admin.Services
 
                 if (product.ManageInventoryMethodId == ManageInventoryMethod.ManageStockByAttributes)
                 {
-                    var pr = await _productService.GetProductById(model.ProductId);
+                    var pr = await _productService.GetProductById(model.ProductId, true);
                     pr.StockQuantity = pr.ProductAttributeCombinations.Sum(x => x.StockQuantity);
                     pr.ReservedQuantity = pr.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
                     await _inventoryManageService.UpdateStockProduct(pr, false);


### PR DESCRIPTION
Fixed the product changed warning when save product after modified attribute combination

Resolves #300   
Type: **bugfix**

## Issue
When save product after modified attribute combination there is a warning: "You can't edit the product because has been changed. Please refresh page and try to change again". If continue to click save, then "Product attributes" and "Attribute combinations" will could not add new or delete forever.

Modify attribute combination will change "UpdatedOnUtc" field of product, and when save product will verify the "Ticks" on page is equal "UpdatedOnUtc", but the "Ticks" is not newest.

## Solution
Add newest "Product Ticks" to "Attribute Combination List", and change the hidden value "Ticks" on page after request list.

## Breaking changes


## Testing

    1. Edit product, Click Tab "Inventory", Change "Manage inventory method" to "Track inventory by product attributes", Save it.
    2. Add some "Product attributes" and checked "Allow to use in attribute combinations", add some "Attribute value".
    3. Modify (Add / Delete / Generate / Clear) "Attribute combinations".
    4. Click "Save" or "Save and Continue Edit".
