### PR TITLE
Check out order conformation back button click event added

### DIFF
--- a/src/Web/Grand.Web/Views/Checkout/_ConfirmOrder.cshtml
+++ b/src/Web/Grand.Web/Views/Checkout/_ConfirmOrder.cshtml
@@ -26,7 +26,7 @@
                 </b-form-checkbox>
                 <div class="alert alert-info my-2" :show="vmorder.acceptTerms">@Loc["Checkout.TermsOfService.PleaseAccept"]</div>
             </div>
-            <button class="btn btn-secondary" id="new-back-confirm_order">@Loc["Common.Back"]</button>
+            <button class="btn btn-secondary" id="new-back-confirm_order"  @@click="vmorder.backStep(vmorder.previousStep)">@Loc["Common.Back"]</button>
             <button class="btn btn-info" @@click="vmorder.termsCheck()">
                 @Loc["Common.Confirm"]
             </button>


### PR DESCRIPTION
Resolves #306 
Type: **bugfix**

## Issue
In Checkout page on order conformation step. if terms and conditions is enabled back button is not working
## Solution
Added missing click event to the button
 
## Breaking changes
none.

## Testing
1. Enable terms and conditions at checkout setting in CMS .
2. Navigate to order conformation page after selecting payment method.
3. At order conformation step back button should navigate to payment selection method.
