### PR TITLE
Push-notification process registration API call not properly handled in error condition

### DIFF
--- a/src/Web/Grand.Web/wwwroot/theme/script/public.push.notifications.js
+++ b/src/Web/Grand.Web/wwwroot/theme/script/public.push.notifications.js
@@ -35,11 +35,11 @@
 
         const messaging = firebase.messaging();
         var url = this.url;
+        let success = false;
+        let value = "";
 
         messaging.requestPermission()
             .then(function () {
-                let success = false;
-                let value = "";
 
                 messaging.getToken()
                     .then(function (currentToken) {


### PR DESCRIPTION
Resolves #308  
Type: **bugfix**

## Issue
Push-notification process registration API call not properly handled in error condition, Two local variables are not available in error condition, So a console error getting logged in home page

## Solution
Moved success and value variable to little above so that those are available in error condition as well.

## Breaking changes
None.

## Testing
1. Navigate to Home page.
2. Check console logs , the following error "Uncaught (in promise) ReferenceError: success is not defined
    at public.push.notifications.js:73:48" shouldn't print in consle

