### PR TITLE
Address name field is shown even after disabling it under the customer setting

### DIFF
--- a/src/Web/Grand.Web.Admin/Services/CustomerViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/CustomerViewModelService.cs
@@ -1171,7 +1171,7 @@ namespace Grand.Web.Admin.Services
             if (model.Address == null)
                 model.Address = new AddressModel();
 
-            model.Address.NameEnabled = true;
+            model.Address.NameEnabled = _addressSettings.NameEnabled;
             model.Address.FirstNameEnabled = true;
             model.Address.FirstNameRequired = true;
             model.Address.LastNameEnabled = true;

--- a/src/Web/Grand.Web.Admin/Services/OrderViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/OrderViewModelService.cs
@@ -596,7 +596,7 @@ namespace Grand.Web.Admin.Services
 
             model.BillingAddress = await order.BillingAddress.ToModel(_countryService);
             model.BillingAddress.FormattedCustomAddressAttributes = await _addressAttributeParser.FormatAttributes(_workContext.WorkingLanguage, order.BillingAddress.Attributes);
-            model.BillingAddress.NameEnabled = true;
+            model.BillingAddress.NameEnabled = _addressSettings.NameEnabled;
             model.BillingAddress.FirstNameEnabled = true;
             model.BillingAddress.FirstNameRequired = true;
             model.BillingAddress.LastNameEnabled = true;
@@ -635,7 +635,7 @@ namespace Grand.Web.Admin.Services
                     {
                         model.ShippingAddress = await order.ShippingAddress.ToModel(_countryService);
                         model.ShippingAddress.FormattedCustomAddressAttributes = await _addressAttributeParser.FormatAttributes(_workContext.WorkingLanguage, order.ShippingAddress.Attributes);
-                        model.ShippingAddress.NameEnabled = true;
+                        model.ShippingAddress.NameEnabled = _addressSettings.NameEnabled;
                         model.ShippingAddress.FirstNameEnabled = true;
                         model.ShippingAddress.FirstNameRequired = true;
                         model.ShippingAddress.LastNameEnabled = true;
@@ -895,7 +895,7 @@ namespace Grand.Web.Admin.Services
                 Address = await address.ToModel(_countryService)
             };
             model.Address.Id = address.Id;
-            model.Address.NameEnabled = true;
+            model.Address.NameEnabled = _addressSettings.NameEnabled;
             model.Address.FirstNameEnabled = true;
             model.Address.FirstNameRequired = true;
             model.Address.LastNameEnabled = true;


### PR DESCRIPTION
Resolves #324 
Type: **bugfix**

## Issue
Address name field is shown even after disabling it under the customer setting

## Solution
Replaced default true to  _addressSettings.NameEnabled field to check whether name enabled or not 

## Breaking changes
none.

## Testing
1. Navigate to customer settings .
2. Goto Address Form Field section.
3. Based on the 'Address name' enabled Flag 'Address name' should populate.
