### PR TITLE
Use POST method

### DIFF
--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -736,7 +736,7 @@ namespace Grand.Web.Controllers
         #endregion
 
         #region Calendar
-        [HttpGet]
+        [HttpPost]
         public virtual async Task<IActionResult> GetDatesForMonth(string productId, int month, string parameter, int year, [FromServices] IProductReservationService productReservationService)
         {
             var allReservations = await productReservationService.GetProductReservationsByProductId(productId, true, null);


### PR DESCRIPTION
Resolves #issueNumber  
Type: **bugfix**

## Issue
Reservation dates aren't displayed in the product's shop page if Product type is set to Reservation. Bad request errors are displayed while opening shop pages for Reservation products.

## Solution
[HttpGet] attribute GetDatesForMonth action in ProductController is incorrect because fillAvailableDates, fillAvailableDatesFrom and fillAvailableDatesTo functions in public.common.js send POST requests to the backend controller.

## Breaking changes
None

## Testing
1. Create new Product and set product type to Reservation.
2. Generate Reservation Calendar for the Product.
3. Check available reservation dates for the Product in the product's shop page.
