### PR TITLE
added HTML encoding for the Bundled product item name.

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeFormatter.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeFormatter.cs
@@ -94,6 +94,10 @@ namespace Grand.Business.Catalog.Services.Products
                 if (product.ProductTypeId == ProductType.BundledProduct)
                 {
                     var i = 0;
+                    if (result.Length > 0)
+                    {
+                        result.Append(separator);
+                    }
                     foreach (var bundle in product.BundleProducts)
                     {
                         var p1 = await _productService.GetProductById(bundle.ProductId);
@@ -101,7 +105,14 @@ namespace Grand.Business.Catalog.Services.Products
                         if (i > 0)
                             result.Append(separator);
 
-                        result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {p1.GetTranslation(x => x.Name, langId)} </a>");
+                        if (htmlEncode)
+                        {
+                            result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {WebUtility.HtmlEncode(p1.GetTranslation(x => x.Name, langId))} </a>");
+                        }
+                        else
+                        {
+                            result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {p1.GetTranslation(x => x.Name, langId)} </a>");
+                        }
                         var formattedAttribute = await PrepareFormattedAttribute(p1, customAttributes, langId, separator, htmlEncode,
                             renderPrices, allowHyperlinks, showInAdmin);
                         if (formattedAttribute.Length > 0)


### PR DESCRIPTION
Resolves #365
Type: **bugfix|**

## Issue
When we order a bundled product, with any one or more bundled items having special characters in the name, the order invoice fails to generate. The Scryber library throws an error. 

## Solution
Add Html encoding for the bundled product name

## Breaking changes
none.

## Testing
1. Order a bundled product. At least one bundled item need to have a special character in the name.
2. Go to orders in admin and try to generate the invoice pdf. An error will be thrown
