### PR TITLE
show hyperlink only if the product is individually visible.

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeFormatter.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeFormatter.cs
@@ -105,13 +105,13 @@ namespace Grand.Business.Catalog.Services.Products
                         if (i > 0)
                             result.Append(separator);
 
-                        if (htmlEncode)
+                        if (p1.VisibleIndividually)
                         {
-                            result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {WebUtility.HtmlEncode(p1.GetTranslation(x => x.Name, langId))} </a>");
+                            result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {(htmlEncode ? WebUtility.HtmlEncode(p1.GetTranslation(x => x.Name, langId)) : p1.GetTranslation(x => x.Name, langId))} </a>");
                         }
                         else
                         {
-                            result.Append($"<a href=\"{p1.GetSeName(langId)}\"> {p1.GetTranslation(x => x.Name, langId)} </a>");
+                            result.Append($"{(htmlEncode ? WebUtility.HtmlEncode(p1.GetTranslation(x => x.Name, langId)) : p1.GetTranslation(x => x.Name, langId))}");
                         }
                         var formattedAttribute = await PrepareFormattedAttribute(p1, customAttributes, langId, separator, htmlEncode,
                             renderPrices, allowHyperlinks, showInAdmin);


### PR DESCRIPTION
Resolves #376
Type: **bugfix**

## Issue
The href on the bundled items will not work if the items are set to "Visible Individual" to false.

## Solution
Check if the bundled item is Visible Individual, and decide to have anchor tags, if it's true only.

Code change: Moved the if else for htmlEncode check, as a conditional operator, for better readability.

## Breaking changes
none.

## Testing
1.  Add a bundled product to cart
2. Set any one of the bundled item to Not visible Individually.
3. Go to cart, and try to click on the bundled item link
4. It will go to home page.
5. After the fix, if the product is not visible, href wont be added.
