### PR TITLE
product id appended to form

### DIFF
--- a/src/Web/Grand.Web/Views/Product/Partials/AuctionInfo.cshtml
+++ b/src/Web/Grand.Web/Views/Product/Partials/AuctionInfo.cshtml
@@ -33,7 +33,7 @@
         {
             <div class="btn-group w-100 mt-3">
                 <input name="HighestBidValue" type="number" class="form-control" value="@(Model.HighestBidValue > 0 ? (Model.HighestBidValue + 1).ToString(CultureInfo.InvariantCulture) : (Model.StartPrice + 1).ToString(CultureInfo.InvariantCulture))" />
-                <button id="bid-button-@Model.Id" class="btn btn-info add-to-cart-button d-inline-flex align-items-center" data-productid="@Model.Id" onclick="AxiosCart.addbid('@Url.RouteUrl("AddBid", new { productId = Model.Id })', '#product-details-form'); return false;">
+                <button id="bid-button-@Model.Id" class="btn btn-info add-to-cart-button d-inline-flex align-items-center" data-productid="@Model.Id" onclick="AxiosCart.addbid('@Url.RouteUrl("AddBid", new { productId = Model.Id })', @($"'#product-details-form-{Model.Id}'")); return false;">
                     <b-icon icon="hammer" class="mx-1"></b-icon><span>@Loc["ShoppingCart.Bid"]</span>
                 </button>
             </div>


### PR DESCRIPTION
Resolves #387  
Type: **bugfix**

## Issue
Bid option is not working in product detail page when auction product type is chosen. Because  AxiosCart.addbid function not able to identify form without product-id 

## Solution
Appended product id to form so that , AxiosCart.addbid function will execute successfully  
## Breaking changes
None

## Testing
1. Create a product with Auction product type with min and max bid price.
2. Navigate to product detail page and tap on Bid option. A successful bid option will get populated