### PR TITLE
Handled discount logic for product with price over-ridden at attribute combination level

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Prices/PricingService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Prices/PricingService.cs
@@ -559,10 +559,10 @@ namespace Grand.Business.Catalog.Services.Prices
                     }
                 }
             }
+            //summarize price of all attributes
+            double attributesTotalPrice = 0;
             if (!finalPrice.HasValue)
-            {
-                //summarize price of all attributes
-                double attributesTotalPrice = 0;
+            {               
                 if (attributes != null && attributes.Any())
                 {
                     var attributeValues = product.ParseProductAttributeValues(attributes);
@@ -587,33 +587,35 @@ namespace Grand.Business.Catalog.Services.Prices
                         }
                     }
                 }
-                if (!product.EnteredPrice)
-                {
-                    var qty = 0;
-                    if (_shoppingCartSettings.GroupTierPrices)
-                    {
-                        qty = customer.ShoppingCartItems
-                            .Where(x => x.ProductId == product.Id)
-                            .Where(x => x.ShoppingCartTypeId == shoppingCartType)
-                            .Sum(x => x.Quantity);
-                    }
-                    if (qty == 0)
-                        qty = quantity;
-
-                    var getfinalPrice = await GetFinalPrice(product,
-                        customer,
-                        currency,
-                        attributesTotalPrice,
-                        includeDiscounts,
-                        qty,
-                        rentalStartDate,
-                        rentalEndDate);
-
-                    finalPrice = getfinalPrice.finalPrice;
-                    discountAmount = getfinalPrice.discountAmount;
-                    appliedDiscounts = getfinalPrice.appliedDiscounts;
-                }
             }
+
+            if (!product.EnteredPrice)
+            {
+                var qty = 0;
+                if (_shoppingCartSettings.GroupTierPrices)
+                {
+                    qty = customer.ShoppingCartItems
+                        .Where(x => x.ProductId == product.Id)
+                        .Where(x => x.ShoppingCartTypeId == shoppingCartType)
+                        .Sum(x => x.Quantity);
+                }
+                if (qty == 0)
+                    qty = quantity;
+
+                var getfinalPrice = await GetFinalPrice(product,
+                    customer,
+                    currency,
+                    finalPrice ??= 0 + attributesTotalPrice,
+                    includeDiscounts,
+                    qty,
+                    rentalStartDate,
+                    rentalEndDate);
+
+                finalPrice = getfinalPrice.finalPrice;
+                discountAmount = getfinalPrice.discountAmount;
+                appliedDiscounts = getfinalPrice.appliedDiscounts;
+            }
+
 
             finalPrice ??= 0;
 


### PR DESCRIPTION
Resolves #395 
Type: **bugfix**

## Issue
Product with price over-ridden at attribute combination level is not getting any discount when coupon code is applied.

## Solution
Handled discount logic for product with price over-ridden at attribute combination in Pricing service

## Breaking changes
none.

## Testing
1. Apply coupon code when product with price over-ridden at attribute combination level is in cart.
2. Discount should apply for the product .
