### PR TITLE
Setting the dates to null values on delete to handle the model state error

### DIFF
--- a/src/Web/Grand.Web.Admin/Areas/Admin/Views/Product/Partials/CreateOrUpdate.Prices.cshtml
+++ b/src/Web/Grand.Web.Admin/Areas/Admin/Views/Product/Partials/CreateOrUpdate.Prices.cshtml
@@ -282,6 +282,10 @@
                     confirmation: false,
                     mode: "inline"
                 },
+                remove:function(e){ 
+                 e.model.StartDateTime= null;
+                 e.model.EndDateTime= null;
+                },
                 scrollable: false,
                 columns: [
                 @if (!adminAreaSettings.HideStoreColumn)


### PR DESCRIPTION
Resolves #433 
Type: **bugfix**

## Issue
Not able to delete the Product Tier Price when we assign the start date end time.

## Solution
Issue is when we try to delete the Product Tier Price item with start time and end time it is , start time and end is going as GMT time and we are facing the model state error . So avoid that when we delete the item setting the start and end date to null.

## Breaking changes
No

## Testing
1. Navigate to admin panel.
2. Choose products from catalog menu and then pick any product go to prices tab and create a tire price with start and end time.
3. Once creation of product price is done , we can delete the tire price item without any issue.
