### PR TITLE
Fixed some Widget Zone in Vendor part that was using vc:admin-widget …

### DIFF
--- a/src/Web/Grand.Web.Vendor/Areas/Vendor/Views/VendorInfo/Partials/CreateOrUpdate.TabInfo.cshtml
+++ b/src/Web/Grand.Web.Vendor/Areas/Vendor/Views/VendorInfo/Partials/CreateOrUpdate.TabInfo.cshtml
@@ -103,4 +103,4 @@
         </div>
     </div>
 }
-<vc:admin-widget widget-zone="vendor_details_info_bottom" additional-data="Model"/>
+<vc:vendor-widget widget-zone="vendor_vendor_details_info_bottom" additional-data="Model" />

--- a/src/Web/Grand.Web.Vendor/Areas/Vendor/Views/VendorInfo/Partials/CreateOrUpdate.TabSeo.cshtml
+++ b/src/Web/Grand.Web.Vendor/Areas/Vendor/Views/VendorInfo/Partials/CreateOrUpdate.TabSeo.cshtml
@@ -1,8 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Mvc.Razor
 @model VendorModel
 
-<vc:admin-widget widget-zone="vendor_details_seo_top" additional-data="Model"/>
-
+<vc:vendor-widget widget-zone="vendor_vendor_details_seo_top" additional-data="Model" />
 @{
     Func<int, HelperResult>
         template = @<div class="form-body">
@@ -71,4 +70,4 @@
         </div>
     </localized-editor>
 </div>
-<vc:admin-widget widget-zone="vendor_details_seo_bottom" additional-data="Model"/>
+<vc:vendor-widget widget-zone="vendor_vendor_details_seo_bottom" additional-data="Model" />


### PR DESCRIPTION
## Issue
Was not possible to add Widget Plugin in:

- vendor_vendor_details_info_bottom
- vendor_vendor_details_seo_top
- vendor_vendor_details_seo_bottom

## Solution
Changed
<**vc:admin-widget** widget-zone="..." additional-data="Model"/>
To
<**vc:vendor-widget** widget-zone="..." additional-data="Model" />

## Breaking changes
If you have a breaking changes, list them here, otherwise list none.

## Testing
1. Try to add a Widget Plugin in zones above
