### PR TITLE
Fix code scanning alert no. 18: User-controlled bypass of sensitive method

### DIFF
--- a/src/API/Grand.Api/Controllers/OData/ProductController.cs
+++ b/src/API/Grand.Api/Controllers/OData/ProductController.cs
@@ -707,9 +707,9 @@ public class ProductController : BaseODataController
     public async Task<IActionResult> DeleteProductAttributeMapping([FromRoute] string key,
         [FromBody] ProductAttributeMappingDeleteDto model)
     {
-        if (model == null) return BadRequest();
-
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
+
+        if (model == null) return BadRequest();
 
         var product = await _mediator.Send(new GetGenericQuery<ProductDto, Product>(key));
         if (!product.Any()) return NotFound();


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/18](https://github.com/grandnode/grandnode2/security/code-scanning/18)

To fix the problem, we need to ensure that the authorization check is performed regardless of whether the `model` parameter is null or not. This can be achieved by rearranging the code so that the authorization check is done before the null check. This way, even if the `model` is null, the authorization check will still be executed.

- Move the authorization check `_permissionService.Authorize(PermissionSystemName.Products)` before the null check for the `model` parameter.
- Ensure that the authorization check is the first condition to be evaluated in the method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
