### PR TITLE
Fix code scanning alert no. 237: URL redirection from remote source

### DIFF
--- a/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
@@ -150,9 +150,11 @@ public class HomeController : BaseAdminController
                 SystemCustomerFieldNames.AdminAreaStoreScopeConfiguration, "");
 
         //home page
-        if (string.IsNullOrEmpty(returnUrl) || !Url.IsLocalUrl(returnUrl))
+        if (string.IsNullOrEmpty(returnUrl))
             returnUrl = Url.Action("Index", "Home", new { area = Constants.AreaAdmin });
-
+        //prevent open redirection attack
+        if (!Url.IsLocalUrl(returnUrl))
+            return RedirectToAction("Index", "Home", new { area = Constants.AreaAdmin });
         return Redirect(returnUrl);
     }
 


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/237](https://github.com/grandnode/grandnode2/security/code-scanning/237)

To fix the problem, we need to ensure that the `returnUrl` parameter is validated to prevent open redirection attacks. Specifically, we should check if the `returnUrl` is a local URL before using it in a redirect. If it is not a local URL, we should redirect to a safe default URL.

- Add a check using `Url.IsLocalUrl(returnUrl)` in the `ChangeStore` method.
- If the `returnUrl` is not local, set it to a safe default URL.
- This change should be made in the `ChangeStore` method in the file `src/Web/Grand.Web.Admin/Controllers/HomeController.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
