### PR TITLE
Fix code scanning alert no. 235: URL redirection from remote source

### DIFF
--- a/src/Web/Grand.Web/Controllers/CommonController.cs
+++ b/src/Web/Grand.Web/Controllers/CommonController.cs
@@ -316,7 +316,8 @@ public class CommonController : BasePublicController
         [FromServices] StoreInformationSettings storeInformationSettings,
         [FromServices] IThemeContextFactory themeContextFactory, string themeName, string returnUrl = "")
     {
-        if (!storeInformationSettings.AllowCustomerToSelectTheme) return Redirect(returnUrl);
+        var validUrls = new List<string> { Url.RouteUrl("HomePage"), Url.RouteUrl("AnotherPage") }; // Add other valid URLs here
+        if (!storeInformationSettings.AllowCustomerToSelectTheme) return Redirect(validUrls.Contains(returnUrl) ? returnUrl : Url.RouteUrl("HomePage"));
 
         var themeContext = themeContextFactory.GetThemeContext("");
         if (themeContext != null) await themeContext.SetTheme(themeName);
@@ -325,7 +326,7 @@ public class CommonController : BasePublicController
         await _mediator.Publish(new ChangeThemeEvent(_workContext.CurrentCustomer, themeName));
 
         //home page
-        if (string.IsNullOrEmpty(returnUrl))
+        if (string.IsNullOrEmpty(returnUrl) || !validUrls.Contains(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
         //prevent open redirection attack


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/235](https://github.com/grandnode/grandnode2/security/code-scanning/235)

To fix the problem, we need to ensure that the `returnUrl` is either a relative URL or matches a known good URL. This can be done by maintaining a list of authorized URLs and validating the `returnUrl` against this list. If the `returnUrl` is not in the list, we should redirect to a default safe URL, such as the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
