### PR TITLE
Fix code scanning alert no. 234: URL redirection from remote source

### DIFF
--- a/src/Web/Grand.Web/Controllers/CommonController.cs
+++ b/src/Web/Grand.Web/Controllers/CommonController.cs
@@ -270,8 +270,11 @@ public class CommonController : BasePublicController
         if (string.IsNullOrEmpty(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
+        // List of valid URLs
+        var validUrls = new List<string> { Url.RouteUrl("HomePage"), Url.RouteUrl("AnotherSafePage") };
+
         //prevent open redirection attack
-        if (!Url.IsLocalUrl(returnUrl))
+        if (!Url.IsLocalUrl(returnUrl) || !validUrls.Contains(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
         return Redirect(returnUrl);
@@ -292,8 +295,11 @@ public class CommonController : BasePublicController
         if (string.IsNullOrEmpty(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
+        // List of valid URLs
+        var validUrls = new List<string> { Url.RouteUrl("HomePage"), Url.RouteUrl("AnotherSafePage") };
+
         //prevent open redirection attack
-        if (!Url.IsLocalUrl(returnUrl))
+        if (!Url.IsLocalUrl(returnUrl) || !validUrls.Contains(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
         //whether customers are allowed to select tax display type
@@ -328,8 +334,11 @@ public class CommonController : BasePublicController
         if (string.IsNullOrEmpty(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
+        // List of valid URLs
+        var validUrls = new List<string> { Url.RouteUrl("HomePage"), Url.RouteUrl("AnotherSafePage") };
+
         //prevent open redirection attack
-        if (!Url.IsLocalUrl(returnUrl))
+        if (!Url.IsLocalUrl(returnUrl) || !validUrls.Contains(returnUrl))
             returnUrl = Url.RouteUrl("HomePage");
 
         return Redirect(returnUrl);


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/234](https://github.com/grandnode/grandnode2/security/code-scanning/234)

To fix the problem, we should ensure that the `returnUrl` parameter is validated against a known list of safe URLs or ensure it is a relative URL. This can be done by maintaining a list of authorized redirects and checking the `returnUrl` against this list before performing the redirection. If the `returnUrl` is not in the list, it should default to a safe URL like the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
