### PR TITLE
Fix code scanning alert no. 237: URL redirection from remote source

### DIFF
--- a/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
@@ -150,7 +150,7 @@ public class HomeController : BaseAdminController
                 SystemCustomerFieldNames.AdminAreaStoreScopeConfiguration, "");
 
         //home page
-        if (!Url.IsLocalUrl(returnUrl))
+        if (string.IsNullOrEmpty(returnUrl) || !Url.IsLocalUrl(returnUrl))
             returnUrl = Url.Action("Index", "Home", new { area = Constants.AreaAdmin });
 
         return Redirect(returnUrl);


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/237](https://github.com/grandnode/grandnode2/security/code-scanning/237)

To fix the problem, we need to ensure that the `returnUrl` is validated properly before using it in a redirect. Specifically, we should:
1. Check if the `returnUrl` is a local URL using `Url.IsLocalUrl(returnUrl)`.
2. If it is not a local URL or is empty/null, redirect to a safe default URL.

This ensures that the redirection is always to a safe and known URL, preventing open redirection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
