### PR TITLE
Change ambiguous reference to use a new array so that type is specified

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/ExportImport/ProductImportDataObject.cs
+++ b/src/Business/Grand.Business.Catalog/Services/ExportImport/ProductImportDataObject.cs
@@ -33,6 +33,8 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
     private readonly ITaxCategoryService _taxService;
     private readonly IWarehouseService _warehouseService;
     private readonly ISeNameService _seNameService;
+    private static readonly char[] separators = new[] { ',' };
+
     public ProductImportDataObject(
         IProductService productService,
         IPictureService pictureService,
@@ -172,7 +174,7 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
 
     private async Task PrepareProductCategories(Product product, string categoryIds)
     {
-        foreach (var id in categoryIds.Split([';'], StringSplitOptions.RemoveEmptyEntries)
+        foreach (var id in categoryIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                      .Select(x => x.Trim()))
         {
             if (product.ProductCategories.FirstOrDefault(x => x.CategoryId == id) != null) continue;
@@ -190,7 +192,7 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
 
     private async Task PrepareProductCollections(Product product, string collectionIds)
     {
-        foreach (var id in collectionIds.Split([';'], StringSplitOptions.RemoveEmptyEntries)
+        foreach (var id in collectionIds.Split(separators, StringSplitOptions.RemoveEmptyEntries)
                      .Select(x => x.Trim()))
         {
             if (product.ProductCollections.FirstOrDefault(x => x.CollectionId == id) != null) continue;

--- a/src/Business/Grand.Business.Catalog/Services/ExportImport/ProductImportDataObject.cs
+++ b/src/Business/Grand.Business.Catalog/Services/ExportImport/ProductImportDataObject.cs
@@ -33,7 +33,6 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
     private readonly ITaxCategoryService _taxService;
     private readonly IWarehouseService _warehouseService;
     private readonly ISeNameService _seNameService;
-    private static readonly char[] separators = new[] { ',' };
 
     public ProductImportDataObject(
         IProductService productService,
@@ -174,7 +173,7 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
 
     private async Task PrepareProductCategories(Product product, string categoryIds)
     {
-        foreach (var id in categoryIds.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+        foreach (var id in categoryIds.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                      .Select(x => x.Trim()))
         {
             if (product.ProductCategories.FirstOrDefault(x => x.CategoryId == id) != null) continue;
@@ -192,7 +191,7 @@ public class ProductImportDataObject : IImportDataObject<ProductDto>
 
     private async Task PrepareProductCollections(Product product, string collectionIds)
     {
-        foreach (var id in collectionIds.Split(separators, StringSplitOptions.RemoveEmptyEntries)
+        foreach (var id in collectionIds.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                      .Select(x => x.Trim()))
         {
             if (product.ProductCollections.FirstOrDefault(x => x.CollectionId == id) != null) continue;

--- a/src/Business/Grand.Business.System/Services/BackgroundServices/ScheduleTasks/QueuedMessagesSendScheduleTask.cs
+++ b/src/Business/Grand.Business.System/Services/BackgroundServices/ScheduleTasks/QueuedMessagesSendScheduleTask.cs
@@ -13,7 +13,7 @@ public class QueuedMessagesSendScheduleTask : IScheduleTask
     private readonly IEmailSender _emailSender;
     private readonly ILogger<QueuedMessagesSendScheduleTask> _logger;
     private readonly IQueuedEmailService _queuedEmailService;
-
+    private static readonly char[] separators = new[] { ',' };
 
     public QueuedMessagesSendScheduleTask(IQueuedEmailService queuedEmailService,
         IEmailSender emailSender, ILogger<QueuedMessagesSendScheduleTask> logger,
@@ -37,10 +37,10 @@ public class QueuedMessagesSendScheduleTask : IScheduleTask
         {
             var bcc = string.IsNullOrWhiteSpace(queuedEmail.Bcc)
                 ? null
-                : queuedEmail.Bcc.Split([';'], StringSplitOptions.RemoveEmptyEntries);
+                : queuedEmail.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
             var cc = string.IsNullOrWhiteSpace(queuedEmail.CC)
                 ? null
-                : queuedEmail.CC.Split([';'], StringSplitOptions.RemoveEmptyEntries);
+                : queuedEmail.CC.Split(separators, StringSplitOptions.RemoveEmptyEntries);
 
             try
             {

--- a/src/Business/Grand.Business.System/Services/BackgroundServices/ScheduleTasks/QueuedMessagesSendScheduleTask.cs
+++ b/src/Business/Grand.Business.System/Services/BackgroundServices/ScheduleTasks/QueuedMessagesSendScheduleTask.cs
@@ -13,7 +13,6 @@ public class QueuedMessagesSendScheduleTask : IScheduleTask
     private readonly IEmailSender _emailSender;
     private readonly ILogger<QueuedMessagesSendScheduleTask> _logger;
     private readonly IQueuedEmailService _queuedEmailService;
-    private static readonly char[] separators = new[] { ',' };
 
     public QueuedMessagesSendScheduleTask(IQueuedEmailService queuedEmailService,
         IEmailSender emailSender, ILogger<QueuedMessagesSendScheduleTask> logger,
@@ -37,10 +36,10 @@ public class QueuedMessagesSendScheduleTask : IScheduleTask
         {
             var bcc = string.IsNullOrWhiteSpace(queuedEmail.Bcc)
                 ? null
-                : queuedEmail.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+                : queuedEmail.Bcc.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             var cc = string.IsNullOrWhiteSpace(queuedEmail.CC)
                 ? null
-                : queuedEmail.CC.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+                : queuedEmail.CC.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
             try
             {

--- a/src/Core/Grand.Domain/Blogs/BlogExtensions.cs
+++ b/src/Core/Grand.Domain/Blogs/BlogExtensions.cs
@@ -2,6 +2,8 @@
 
 public static class BlogExtensions
 {
+    private static readonly char[] separators = new[] { ',' };
+
     public static string[] ParseTags(this BlogPost blogPost)
     {
         ArgumentNullException.ThrowIfNull(blogPost);
@@ -9,7 +11,7 @@ public static class BlogExtensions
         var parsedTags = new List<string>();
         if (!string.IsNullOrEmpty(blogPost.Tags))
         {
-            var tags2 = blogPost.Tags.Split([','], StringSplitOptions.RemoveEmptyEntries);
+            var tags2 = blogPost.Tags.Split(separators, StringSplitOptions.RemoveEmptyEntries);
             foreach (var tag2 in tags2)
             {
                 var tmp = tag2.Trim();

--- a/src/Core/Grand.Domain/Blogs/BlogExtensions.cs
+++ b/src/Core/Grand.Domain/Blogs/BlogExtensions.cs
@@ -2,8 +2,6 @@
 
 public static class BlogExtensions
 {
-    private static readonly char[] separators = new[] { ',' };
-
     public static string[] ParseTags(this BlogPost blogPost)
     {
         ArgumentNullException.ThrowIfNull(blogPost);
@@ -11,7 +9,7 @@ public static class BlogExtensions
         var parsedTags = new List<string>();
         if (!string.IsNullOrEmpty(blogPost.Tags))
         {
-            var tags2 = blogPost.Tags.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            var tags2 = blogPost.Tags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var tag2 in tags2)
             {
                 var tmp = tag2.Trim();

--- a/src/Core/Grand.Domain/Catalog/ProductExtensions.cs
+++ b/src/Core/Grand.Domain/Catalog/ProductExtensions.cs
@@ -63,7 +63,7 @@ public static class ProductExtensions
         var result = new List<int>();
         if (!string.IsNullOrWhiteSpace(product.AllowedQuantities))
             product.AllowedQuantities
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .ToList()
                 .ForEach(qtyStr =>
                 {
@@ -414,7 +414,7 @@ public static class ProductExtensions
         var ids = new List<string>();
 
         foreach (var idStr in product.RequiredProductIds
-                     .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                     .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                      .Select(x => x.Trim()))
             ids.Add(idStr);
 

--- a/src/Plugins/DiscountRules.Standard/Areas/Admin/Controllers/HasAllProductsController.cs
+++ b/src/Plugins/DiscountRules.Standard/Areas/Admin/Controllers/HasAllProductsController.cs
@@ -199,7 +199,7 @@ public class HasAllProductsController : BaseAdminPluginController
         if (string.IsNullOrWhiteSpace(productIds)) return new JsonResult(new { Text = result });
         var ids = new List<string>();
         var rangeArray = productIds
-            .Split([','], StringSplitOptions.RemoveEmptyEntries)
+            .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())
             .ToList();
 

--- a/src/Plugins/DiscountRules.Standard/Areas/Admin/Controllers/HasOneProductController.cs
+++ b/src/Plugins/DiscountRules.Standard/Areas/Admin/Controllers/HasOneProductController.cs
@@ -199,7 +199,7 @@ public class HasOneProductController : BaseAdminPluginController
         if (string.IsNullOrWhiteSpace(productIds)) return new JsonResult(new { Text = result });
         var ids = new List<string>();
         var rangeArray = productIds
-            .Split([','], StringSplitOptions.RemoveEmptyEntries)
+            .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(x => x.Trim())
             .ToList();
 

--- a/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
@@ -1002,7 +1002,7 @@ public class CustomerController : BaseAdminController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             customers.AddRange(await _customerService.GetCustomersByIds(ids));

--- a/src/Web/Grand.Web.Admin/Controllers/OrderController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/OrderController.cs
@@ -172,7 +172,7 @@ public class OrderController(
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             orders.AddRange(await orderService.GetOrdersByIds(ids));
@@ -398,7 +398,7 @@ public class OrderController(
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             orders.AddRange(await orderService.GetOrdersByIds(ids));

--- a/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/ProductController.cs
@@ -356,7 +356,7 @@ public class ProductController : BaseAdminController
         {
             var ids = new List<string>();
             var rangeArray = productIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim())
                 .ToList();
 
@@ -1500,7 +1500,7 @@ public class ProductController : BaseAdminController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             products.AddRange(await _productService.GetProductsByIds(ids, true));

--- a/src/Web/Grand.Web.Admin/Controllers/SettingController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/SettingController.cs
@@ -695,7 +695,7 @@ public class SettingController(
         securitySettings.AdminAreaAllowedIpAddresses ??= [];
         securitySettings.AdminAreaAllowedIpAddresses.Clear();
         if (!string.IsNullOrEmpty(model.SecuritySettings.AdminAreaAllowedIpAddresses))
-            foreach (var s in model.SecuritySettings.AdminAreaAllowedIpAddresses.Split([','],
+            foreach (var s in model.SecuritySettings.AdminAreaAllowedIpAddresses.Split(new[] { ',' },
                          StringSplitOptions.RemoveEmptyEntries))
                 if (!string.IsNullOrWhiteSpace(s))
                     securitySettings.AdminAreaAllowedIpAddresses.Add(s.Trim());

--- a/src/Web/Grand.Web.Admin/Controllers/ShipmentController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/ShipmentController.cs
@@ -530,7 +530,7 @@ public class ShipmentController : BaseAdminController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             shipments.AddRange(await _shipmentService.GetShipmentsByIds(ids));

--- a/src/Web/Grand.Web.Admin/Services/CustomerViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/CustomerViewModelService.cs
@@ -1169,7 +1169,7 @@ public class CustomerViewModelService : ICustomerViewModelService
         var result = new List<string>();
         if (!string.IsNullOrWhiteSpace(customerTags))
         {
-            var values = customerTags.Split([','], StringSplitOptions.RemoveEmptyEntries);
+            var values = customerTags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var val1 in values)
                 if (!string.IsNullOrEmpty(val1.Trim()))
                     result.Add(val1.Trim());

--- a/src/Web/Grand.Web.Admin/Services/OrderViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/OrderViewModelService.cs
@@ -1051,7 +1051,7 @@ public class OrderViewModelService : IOrderViewModelService
                     var cblAttributes = model.SelectedAttributes.FirstOrDefault(x => x.Key == attribute.Id)?.Value;
                     if (!string.IsNullOrEmpty(cblAttributes))
                         foreach (var item in cblAttributes
-                                     .Split([','], StringSplitOptions.RemoveEmptyEntries))
+                                     .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                             customattributes = ProductExtensions.AddProductAttribute(
                                 customattributes,
                                 attribute, item).ToList();
@@ -1266,7 +1266,7 @@ public class OrderViewModelService : IOrderViewModelService
         var result = new List<string>();
         if (!string.IsNullOrWhiteSpace(orderTags))
         {
-            var values = orderTags.Split([','], StringSplitOptions.RemoveEmptyEntries);
+            var values = orderTags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var val1 in values)
                 if (!string.IsNullOrEmpty(val1.Trim()))
                     result.Add(val1.Trim());

--- a/src/Web/Grand.Web.Admin/Services/ProductViewModelService.cs
+++ b/src/Web/Grand.Web.Admin/Services/ProductViewModelService.cs
@@ -1733,7 +1733,7 @@ public class ProductViewModelService(
                         if (!string.IsNullOrEmpty(cblAttributes))
                         {
                             var anyValueSelected = false;
-                            foreach (var item in cblAttributes.Split([','],
+                            foreach (var item in cblAttributes.Split(new[] { ',' },
                                          StringSplitOptions.RemoveEmptyEntries))
                                 if (!string.IsNullOrEmpty(item))
                                 {
@@ -2086,7 +2086,7 @@ public class ProductViewModelService(
                     {
                         var cblAttributes = model.SelectedAttributes.FirstOrDefault(x => x.Key == attribute.Id)?.Value;
                         if (!string.IsNullOrEmpty(cblAttributes))
-                            foreach (var item in cblAttributes.Split([','],
+                            foreach (var item in cblAttributes.Split(new[] { ',' },
                                          StringSplitOptions.RemoveEmptyEntries))
                                 if (!string.IsNullOrEmpty(item))
                                     customAttributes = ProductExtensions.AddProductAttribute(customAttributes,
@@ -2546,7 +2546,7 @@ public class ProductViewModelService(
         var result = new List<string>();
         if (!string.IsNullOrWhiteSpace(productTags))
         {
-            var values = productTags.Split([','], StringSplitOptions.RemoveEmptyEntries);
+            var values = productTags.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var val1 in values)
                 if (!string.IsNullOrEmpty(val1.Trim()))
                     result.Add(val1.Trim());

--- a/src/Web/Grand.Web.Common/Filters/LanguageAttribute.cs
+++ b/src/Web/Grand.Web.Common/Filters/LanguageAttribute.cs
@@ -49,8 +49,7 @@ public class LanguageAttribute : TypeFilterAttribute
         private readonly IWorkContext _workContext;
         private readonly ILanguageService _languageService;
         private readonly AppConfig _config;
-        private static readonly char[] separators = new[] { '/' };
-
+        
         #endregion
 
         #region Methods
@@ -106,7 +105,7 @@ public class LanguageAttribute : TypeFilterAttribute
             _ = new PathString(url).StartsWithSegments(pathBase, out var result);
             url = WebUtility.UrlDecode(result);
 
-            var firstSegment = url.Split(separators, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
+            var firstSegment = url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
                                string.Empty;
             if (string.IsNullOrEmpty(firstSegment))
                 return false;

--- a/src/Web/Grand.Web.Common/Filters/LanguageAttribute.cs
+++ b/src/Web/Grand.Web.Common/Filters/LanguageAttribute.cs
@@ -49,6 +49,7 @@ public class LanguageAttribute : TypeFilterAttribute
         private readonly IWorkContext _workContext;
         private readonly ILanguageService _languageService;
         private readonly AppConfig _config;
+        private static readonly char[] separators = new[] { '/' };
 
         #endregion
 
@@ -105,7 +106,7 @@ public class LanguageAttribute : TypeFilterAttribute
             _ = new PathString(url).StartsWithSegments(pathBase, out var result);
             url = WebUtility.UrlDecode(result);
 
-            var firstSegment = url.Split(['/'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
+            var firstSegment = url.Split(separators, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
                                string.Empty;
             if (string.IsNullOrEmpty(firstSegment))
                 return false;

--- a/src/Web/Grand.Web.Common/Startup/HostFilteringStartup.cs
+++ b/src/Web/Grand.Web.Common/Startup/HostFilteringStartup.cs
@@ -26,7 +26,7 @@ public class HostFilteringStartup : IStartupApplication
 
         //configuration[
         var hosts = securityConfig.AllowedHosts?
-            .Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         if (hosts?.Length > 0) services.Configure<HostFilteringOptions>(options => options.AllowedHosts = hosts);
     }
 
@@ -51,6 +51,4 @@ public class HostFilteringStartup : IStartupApplication
     public int Priority => -40;
 
     public bool BeforeConfigure => true;
-
-    private static readonly char[] separators = new[] { ';' };
 }

--- a/src/Web/Grand.Web.Common/Startup/HostFilteringStartup.cs
+++ b/src/Web/Grand.Web.Common/Startup/HostFilteringStartup.cs
@@ -26,7 +26,7 @@ public class HostFilteringStartup : IStartupApplication
 
         //configuration[
         var hosts = securityConfig.AllowedHosts?
-            .Split([';'], StringSplitOptions.RemoveEmptyEntries);
+            .Split(separators, StringSplitOptions.RemoveEmptyEntries);
         if (hosts?.Length > 0) services.Configure<HostFilteringOptions>(options => options.AllowedHosts = hosts);
     }
 
@@ -51,4 +51,6 @@ public class HostFilteringStartup : IStartupApplication
     public int Priority => -40;
 
     public bool BeforeConfigure => true;
+
+    private static readonly char[] separators = new[] { ';' };
 }

--- a/src/Web/Grand.Web.Common/WorkContext.cs
+++ b/src/Web/Grand.Web.Common/WorkContext.cs
@@ -98,7 +98,7 @@ public class WorkContext : IWorkContext, IWorkContextSetter
         if (string.IsNullOrEmpty(path))
             return await Task.FromResult<Language>(null);
 
-        var firstSegment = path.Split(separators, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
+        var firstSegment = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
                            string.Empty;
         if (string.IsNullOrEmpty(firstSegment))
             return await Task.FromResult<Language>(null);
@@ -447,8 +447,6 @@ public class WorkContext : IWorkContext, IWorkContextSetter
     ///     Gets the current domain host
     /// </summary>
     public virtual DomainHost CurrentHost => _storeHelper.DomainHost;
-
-    private static readonly char[] separators = new[] { '/' };
 
     #endregion
 }

--- a/src/Web/Grand.Web.Common/WorkContext.cs
+++ b/src/Web/Grand.Web.Common/WorkContext.cs
@@ -98,7 +98,7 @@ public class WorkContext : IWorkContext, IWorkContextSetter
         if (string.IsNullOrEmpty(path))
             return await Task.FromResult<Language>(null);
 
-        var firstSegment = path.Split(['/'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
+        var firstSegment = path.Split(separators, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
                            string.Empty;
         if (string.IsNullOrEmpty(firstSegment))
             return await Task.FromResult<Language>(null);
@@ -447,6 +447,8 @@ public class WorkContext : IWorkContext, IWorkContextSetter
     ///     Gets the current domain host
     /// </summary>
     public virtual DomainHost CurrentHost => _storeHelper.DomainHost;
+
+    private static readonly char[] separators = new[] { '/' };
 
     #endregion
 }

--- a/src/Web/Grand.Web.Vendor/Controllers/OrderController.cs
+++ b/src/Web/Grand.Web.Vendor/Controllers/OrderController.cs
@@ -188,7 +188,7 @@ public class OrderController : BaseVendorController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             orders.AddRange(await _orderService.GetOrdersByIds(ids));

--- a/src/Web/Grand.Web.Vendor/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web.Vendor/Controllers/ProductController.cs
@@ -314,7 +314,7 @@ public class ProductController : BaseVendorController
         if (!string.IsNullOrWhiteSpace(productIds))
         {
             var rangeArray = productIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x.Trim())
                 .ToList();
 
@@ -1439,7 +1439,7 @@ public class ProductController : BaseVendorController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             products.AddRange(await _productService.GetProductsByIds(ids, true));

--- a/src/Web/Grand.Web.Vendor/Controllers/ShipmentController.cs
+++ b/src/Web/Grand.Web.Vendor/Controllers/ShipmentController.cs
@@ -409,7 +409,7 @@ public class ShipmentController : BaseVendorController
         if (selectedIds != null)
         {
             var ids = selectedIds
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => x)
                 .ToArray();
             shipments.AddRange(await _shipmentService.GetShipmentsByIds(ids));

--- a/src/Web/Grand.Web.Vendor/Services/ProductViewModelService.cs
+++ b/src/Web/Grand.Web.Vendor/Services/ProductViewModelService.cs
@@ -1568,7 +1568,7 @@ public class ProductViewModelService : IProductViewModelService
                         if (!string.IsNullOrEmpty(cblAttributes))
                         {
                             var anyValueSelected = false;
-                            foreach (var item in cblAttributes.Split([','],
+                            foreach (var item in cblAttributes.Split(new[] { ',' },
                                          StringSplitOptions.RemoveEmptyEntries))
                                 if (!string.IsNullOrEmpty(item))
                                 {
@@ -1929,7 +1929,7 @@ public class ProductViewModelService : IProductViewModelService
                         var cblAttributes = model.SelectedAttributes.FirstOrDefault(x => x.Key == attribute.Id)
                             ?.Value;
                         if (!string.IsNullOrEmpty(cblAttributes))
-                            foreach (var item in cblAttributes.Split([','],
+                            foreach (var item in cblAttributes.Split(new[] { ',' },
                                          StringSplitOptions.RemoveEmptyEntries))
                                 if (!string.IsNullOrEmpty(item))
                                     customAttributes = ProductExtensions.AddProductAttribute(

--- a/src/Web/Grand.Web/Commands/Handler/Contact/ContactUsCommandHandler.cs
+++ b/src/Web/Grand.Web/Commands/Handler/Contact/ContactUsCommandHandler.cs
@@ -80,7 +80,7 @@ public class ContactUsCommandHandler : IRequestHandler<ContactUsCommand, Contact
 
             if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
                 attributeModel.AllowedFileExtensions = attribute.ValidationFileAllowedExtensions
-                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                     .ToList();
 
             if (attribute.ShouldHaveValues())

--- a/src/Web/Grand.Web/Controllers/CommonController.cs
+++ b/src/Web/Grand.Web/Controllers/CommonController.cs
@@ -70,7 +70,7 @@ public class CommonController : BasePublicController
         _ = new PathString(url).StartsWithSegments(pathBase, out var result);
         url = WebUtility.UrlDecode(result);
 
-        var firstSegment = url.Split(['/'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
+        var firstSegment = url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ??
                            string.Empty;
         if (string.IsNullOrEmpty(firstSegment))
             return false;

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -149,7 +149,7 @@ public class ContactController : BasePublicController
         if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
         {
             var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.ToLowerInvariant()
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .ToList();
             if (!allowedFileExtensions.Contains(fileExtension.ToLowerInvariant()))
                 return Json(new {

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -413,7 +413,7 @@ public class ProductController : BasePublicController
         if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
         {
             var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.ToLowerInvariant()
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .ToList();
             if (!allowedFileExtensions.Contains(fileExtension.ToLowerInvariant()))
                 return Json(new {

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -202,7 +202,7 @@ public class ShoppingCartController : BasePublicController
         if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
         {
             var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.ToLowerInvariant()
-                .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .ToList();
             if (!allowedFileExtensions.Contains(fileExtension.ToLowerInvariant()))
                 return Json(new {

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetCompareProductsHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetCompareProductsHandler.cs
@@ -76,7 +76,7 @@ public class GetCompareProductsHandler : IRequestHandler<GetCompareProducts, Com
             return [];
 
         //get array of string product identifiers from cookie
-        var productIds = productIdsCookie.Split(['|'], StringSplitOptions.RemoveEmptyEntries);
+        var productIds = productIdsCookie.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
 
         //return list of int product identifiers
         return productIds.Select(productId => productId).Distinct().Take(10).ToList();

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetViewSortSizeOptionsHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetViewSortSizeOptionsHandler.cs
@@ -106,7 +106,7 @@ public class GetViewSortSizeOptionsHandler : IRequestHandler<GetViewSortSizeOpti
         if (request.AllowCustomersToSelectPageSize && request.PageSizeOptions != null)
         {
             var pageSizes =
-                request.PageSizeOptions.Split([',', ' '], StringSplitOptions.RemoveEmptyEntries);
+                request.PageSizeOptions.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (pageSizes.Any())
             {

--- a/src/Web/Grand.Web/Features/Handlers/Products/GetProductDetailsPageHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Products/GetProductDetailsPageHandler.cs
@@ -869,7 +869,7 @@ public class GetProductDetailsPageHandler : IRequestHandler<GetProductDetailsPag
             };
             if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
                 attributeModel.AllowedFileExtensions = attribute.ValidationFileAllowedExtensions
-                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                     .ToList();
 
             var urlselectedValues = !string.IsNullOrEmpty(productAttribute.SeName)

--- a/src/Web/Grand.Web/Features/Handlers/ShoppingCart/GetShoppingCartHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/ShoppingCart/GetShoppingCartHandler.cs
@@ -222,7 +222,7 @@ public class GetShoppingCartHandler : IRequestHandler<GetShoppingCart, ShoppingC
             };
             if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
                 attributeModel.AllowedFileExtensions = attribute.ValidationFileAllowedExtensions
-                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                     .ToList();
 
             if (attribute.ShouldHaveValues())

--- a/src/Web/Grand.Web/Models/Catalog/CatalogPagingFilteringModel.cs
+++ b/src/Web/Grand.Web/Models/Catalog/CatalogPagingFilteringModel.cs
@@ -68,7 +68,7 @@ public class CatalogPagingFilteringModel : BasePageableModel
             //comma separated list of parameters to exclude
             const string excludedQueryStringParams = "pagenumber";
             var excludedQueryStringParamsSplitted =
-                excludedQueryStringParams.Split([','], StringSplitOptions.RemoveEmptyEntries);
+                excludedQueryStringParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             foreach (var exclude in excludedQueryStringParamsSplitted)
                 url = CommonExtensions.ModifyQueryString(url, exclude, null);
             return url;


### PR DESCRIPTION
Resolves #issueNumber  
Type: bugfix

## Issue
When trying to build the project locally, it ran into multiple build issues surrounding ambiguity with the split function.

## Solution
Replace each array in the split function with a `new [] { <list of chars>}` construct.

## Breaking changes
none

## Testing
Test that the plugins build
Test that the project builds
Run the project
