### PR TITLE
Update NuGet package versions in Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,19 +10,19 @@
     <PackageVersion Include="Scryber.Core" Version="6.0.4-beta" />
     <PackageVersion Include="Scryber.Core.OpenType" Version="6.1.0-beta" />
     <PackageVersion Include="MailKit" Version="4.8.0" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.57" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.407.1" />
+    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.59" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.410.1" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
-    <PackageVersion Include="LiteDB" Version="5.0.17" />
-    <PackageVersion Include="MongoDB.Bson" Version="3.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
-    <PackageVersion Include="DotLiquid" Version="2.2.717" />
+    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
+    <PackageVersion Include="LiteDB" Version="5.0.21" />
+    <PackageVersion Include="MongoDB.Bson" Version="3.1.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
+    <PackageVersion Include="DotLiquid" Version="2.3.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
-    <PackageVersion Include="MassTransit" Version="8.3.2" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.2" />
+    <PackageVersion Include="MassTransit" Version="8.3.3" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.3" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
@@ -30,18 +30,18 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
     <PackageVersion Include="AutoMapper" Version="13.0.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="Scrutor" Version="5.0.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.22" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.1.1" />
     <PackageVersion Include="MongoDB.AspNetCore.OData" Version="1.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
     <PackageVersion Include="Braintree" Version="5.28.0" />
@@ -50,8 +50,8 @@
     <PackageVersion Include="elFinder.Net.AspNetCore" Version="1.5.0" />
     <PackageVersion Include="elFinder.Net.Core" Version="1.5.0" />
     <PackageVersion Include="elFinder.Net.Drivers.FileSystem" Version="1.5.0" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.4.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.13.1" />
     <PackageVersion Include="Flurl.Http" Version="4.0.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="2.7.2" />
@@ -61,8 +61,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
   </ItemGroup>

--- a/src/Business/Grand.Business.Storage/Services/PictureService.cs
+++ b/src/Business/Grand.Business.Storage/Services/PictureService.cs
@@ -853,7 +853,7 @@ public class PictureService : IPictureService
 
         try
         {
-            using var resized = image.Resize(new SKImageInfo((int)width, (int)height), SKFilterQuality.High);
+            using var resized = image.Resize(new SKImageInfo((int)width, (int)height), SKSamplingOptions.Default);
             using var resImage = SKImage.FromBitmap(resized);
             var skData = resImage.Encode(format, _mediaSettings.ImageQuality);
             return skData?.ToArray();


### PR DESCRIPTION
Updated various NuGet packages to their latest versions:
- AWSSDK.Core: 3.7.400.57 -> 3.7.400.59
- AWSSDK.S3: 3.7.407.1 -> 3.7.410.1
- SkiaSharp: 2.88.9 -> 3.116.1
- SkiaSharp.NativeAssets.Linux.NoDependencies: 2.88.9 -> 3.116.1
- LiteDB: 5.0.17 -> 5.0.21
- MongoDB.Bson: 3.0.0 -> 3.1.0
- MongoDB.Driver: 3.0.0 -> 3.1.0
- DotLiquid: 2.2.717 -> 2.3.0
- MassTransit: 8.3.2 -> 8.3.3
- MassTransit.RabbitMQ: 8.3.2 -> 8.3.3
- Microsoft.CodeAnalysis.CSharp: 4.11.0 -> 4.12.0
- Microsoft.CodeAnalysis.CSharp.Scripting: 4.11.0 -> 4.12.0
- StackExchange.Redis: 2.8.16 -> 2.8.22
- Swashbuckle.AspNetCore: 7.0.0 -> 7.1.0
- Swashbuckle.AspNetCore.Annotations: 7.0.0 -> 7.1.0
- Azure.Extensions.AspNetCore.DataProtection.Blobs: 1.3.4 -> 1.4.0
- Azure.Extensions.AspNetCore.DataProtection.Keys: 1.2.4 -> 1.3.0
- MSTest.TestAdapter: 3.6.3 -> 3.6.4
- MSTest.TestFramework: 3.6.3 -> 3.6.4