### PR TITLE
Fix code scanning alert no. 311: Uncontrolled data used in path expression

### DIFF
--- a/src/Web/Grand.Web.Admin/Controllers/SettingController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/SettingController.cs
@@ -780,6 +780,11 @@ public class SettingController(
     private string GetSafeFilePath(IConfiguration configuration, IWebHostEnvironment webHostEnvironment, string filename)
     {
         var directoryParam = configuration[CommonPath.DirectoryParam] ?? "";
+
+        // Validate directoryParam to ensure it does not contain ".." or path separators
+        if (directoryParam.Contains("..") || directoryParam.Contains("/") || directoryParam.Contains("\\"))
+            throw new ArgumentException("Invalid directory parameter - contains illegal characters.");
+
         var safeDirectoryName = Path.GetFileName(directoryParam);
         var combinedPath = Path.Combine(webHostEnvironment.WebRootPath, safeDirectoryName, filename);
         var fullPath = Path.GetFullPath(combinedPath, webHostEnvironment.WebRootPath);


### PR DESCRIPTION
Fixes [https://github.com/grandnode/grandnode2/security/code-scanning/311](https://github.com/grandnode/grandnode2/security/code-scanning/311)

To fix the problem, we need to ensure that the `directoryParam` does not contain any path traversal characters or sequences. We can achieve this by validating the `directoryParam` to ensure it does not contain any ".." sequences or path separators. Additionally, we should ensure that the `safeDirectoryName` is a valid directory name.

1. Validate the `directoryParam` to ensure it does not contain ".." or any path separators.
2. Ensure that the `safeDirectoryName` is a valid directory name.
3. Update the `GetSafeFilePath` method to include these validations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
