### PR TITLE
Update package versions and adjust MongoDB OData

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="NPOI" Version="2.7.2" />
     <PackageVersion Include="Scryber.Core" Version="6.0.4-beta" />
     <PackageVersion Include="Scryber.Core.OpenType" Version="6.1.0-beta" />
-    <PackageVersion Include="MailKit" Version="4.8.0" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.59" />
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.410.1" />
+    <PackageVersion Include="MailKit" Version="4.9.0" />
+    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.63" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.410.5" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageVersion Include="SkiaSharp" Version="3.116.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
@@ -39,9 +39,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.1.1" />
-    <PackageVersion Include="MongoDB.AspNetCore.OData" Version="1.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.1.0" />
+    <PackageVersion Include="MongoDB.AspNetCore.OData" Version="1.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.0" />
     <PackageVersion Include="Braintree" Version="5.28.0" />

--- a/src/Modules/Grand.Module.Api/Grand.Module.Api.csproj
+++ b/src/Modules/Grand.Module.Api/Grand.Module.Api.csproj
@@ -49,7 +49,7 @@
     </ItemGroup>
     <Target Name="CopyMongoDBODataDLL" AfterTargets="Build">
         <ItemGroup>
-            <MongoDBODataFiles Include="$(NuGetPackageRoot)mongodb.aspnetcore.odata\1.0.1\lib\net5.0\MongoDB.AspNetCore.OData.dll" />
+            <MongoDBODataFiles Include="$(NuGetPackageRoot)mongodb.aspnetcore.odata\1.1.0\lib\net5.0\MongoDB.AspNetCore.OData.dll" />
         </ItemGroup>
         <Copy SourceFiles="@(MongoDBODataFiles)" DestinationFolder="$(OutDir)" />
     </Target>


### PR DESCRIPTION
Updated the `Directory.Packages.props` file to change the versions of several package dependencies:
- `MailKit` from `4.8.0` to `4.9.0`
- `AWSSDK.Core` from `3.7.400.59` to `3.7.400.63`
- `AWSSDK.S3` from `3.7.410.1` to `3.7.410.5`
- `MongoDB.AspNetCore.OData` from `1.0.1` to `1.1.0`
- `Swashbuckle.AspNetCore` from `7.1.0` to `7.2.0`
- `Swashbuckle.AspNetCore.Annotations` from `7.1.0` to `7.2.0`

Updated the `Grand.Module.Api.csproj` file to reflect the new path for `MongoDB.AspNetCore.OData.dll` version `1.1.0`.