### PR TITLE
fixed: https://github.com/grandnode/grandnode2/issues/572

### DIFF
--- a/src/Web/Grand.Web/Views/Wishlist/Components/EmailWishlist/Default.cshtml
+++ b/src/Web/Grand.Web/Views/Wishlist/Components/EmailWishlist/Default.cshtml
@@ -118,8 +118,7 @@
                                                 data: bodyFormData,
                                                 method: 'post',
                                                 headers: {
-                                                    'Accept': 'application/json',
-                                                    'Content-Type': 'application/json'
+                                                    'Accept': 'application/json'                                                    
                                                 }
                                             }).then(function (response) {
                                                 emailwishlist.Message.Result = response.data.Result;


### PR DESCRIPTION
Resolves issues/572 
Type: **feature|bugfix|**

## Issue
Description of the issue this PR is solving:=> Email your wishlist to a friend is not working.
Why it's happening:=> JavaScript POST/Header/Content-Type is 'application/json'
How to reproduce it:=> 
Login as a 'buyer'. 
Add item to Wishlist'. 
Go to 'Wishlist'. 
Click the 'Email a Friend'. 
Fill in the 'Blanks'. 
Press the Submit button. 

## Solution
Remove the ''Content-Type': 'application/json' in the POST Header

The fix: root\grandnode2\src\Web\Grand.Web\Views\Wishlist\Components\EmailWishlist\Default.cshtml
Remove: line 122: ==> 'Content-Type': 'application/json'

## Breaking changes
If you have a breaking changes, list them here, otherwise list none.

## Testing

Login as a 'buyer'. 
Add item to Wishlist'. 
Go to 'Wishlist'. 
Click the 'Email a Friend'. 
Fill in the 'Blanks'. 
Press the Submit button. 