### PR TITLE
Improvements/repository

### DIFF
--- a/src/Core/Grand.Data/LiteDb/LiteDBContext.cs
+++ b/src/Core/Grand.Data/LiteDb/LiteDBContext.cs
@@ -6,7 +6,7 @@ namespace Grand.Data.LiteDb;
 
 public class LiteDBContext : IDatabaseContext
 {
-    protected LiteDatabase _database;
+    private readonly LiteDatabase _database;
 
     public LiteDBContext(LiteDatabase database)
     {

--- a/src/Core/Grand.Data/LiteDb/LiteDBStoreFilesContext.cs
+++ b/src/Core/Grand.Data/LiteDb/LiteDBStoreFilesContext.cs
@@ -5,7 +5,7 @@ namespace Grand.Data.LiteDb;
 
 public class LiteDBStoreFilesContext : IStoreFilesContext
 {
-    protected LiteDatabase _database;
+    private readonly LiteDatabase _database;
 
     public LiteDBStoreFilesContext(LiteDatabase database)
     {
@@ -16,7 +16,7 @@ public class LiteDBStoreFilesContext : IStoreFilesContext
     {
         var fs = _database.FileStorage;
         var file = fs.FindById(id);
-
+    
         if (file == null)
             throw new ArgumentNullException(nameof(file));
 

--- a/src/Core/Grand.Data/Mongo/MongoDBContext.cs
+++ b/src/Core/Grand.Data/Mongo/MongoDBContext.cs
@@ -6,7 +6,7 @@ namespace Grand.Data.Mongo;
 
 public class MongoDBContext : IDatabaseContext
 {
-    protected IMongoDatabase _database;
+    private readonly IMongoDatabase _database;
 
     public MongoDBContext(IMongoDatabase mongodatabase)
     {

--- a/src/Core/Grand.Data/Mongo/MongoRepository.cs
+++ b/src/Core/Grand.Data/Mongo/MongoRepository.cs
@@ -34,29 +34,24 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     ///     Ctor
     /// </summary>
     public MongoRepository(IAuditInfoProvider auditInfoProvider)
+    public MongoRepository(IAuditInfoProvider auditInfoProvider) : this(
+        DataSettingsManager.Instance.LoadSettings().ConnectionString, auditInfoProvider)
     {
-        _auditInfoProvider = auditInfoProvider;
-        var connection = DataSettingsManager.Instance.LoadSettings();
-
-        if (!string.IsNullOrEmpty(connection.ConnectionString))
-        {
-            var client = new MongoClient(connection.ConnectionString);
-            var databaseName = new MongoUrl(connection.ConnectionString).DatabaseName;
-            _database = client.GetDatabase(databaseName);
-            _collection = _database.GetCollection<T>(typeof(T).Name);
-        }
     }
 
     public MongoRepository(string connectionString, IAuditInfoProvider auditInfoProvider)
     {
         _auditInfoProvider = auditInfoProvider;
-        var client = new MongoClient(connectionString);
-        var databaseName = new MongoUrl(connectionString).DatabaseName;
-        _database = client.GetDatabase(databaseName);
-        _collection = _database.GetCollection<T>(typeof(T).Name);
+
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            var client = new MongoClient(connectionString);
+            var databaseName = new MongoUrl(connectionString).DatabaseName;
+            Database = client.GetDatabase(databaseName);
+            Collection = Database.GetCollection<T>(typeof(T).Name);
+        }
     }
-
-
+    
     public MongoRepository(IMongoDatabase database, IAuditInfoProvider auditInfoProvider)
     {
         _database = database;

--- a/src/Core/Grand.Data/Mongo/MongoRepository.cs
+++ b/src/Core/Grand.Data/Mongo/MongoRepository.cs
@@ -241,7 +241,7 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
         var filter = Builders<T>.Filter.Eq(x => x.Id, id)
                      & Builders<T>.Filter.ElemMatch(field, Builders<U>.Filter.Eq(elemFieldMatch, elemMatch));
 
-        var me = field.Body as MemberExpression;
+        var me = (MemberExpression)field.Body;
         var minfo = me.Member;
         var update = Builders<T>.Update.Set($"{minfo.Name}.$", value);
         var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
@@ -267,7 +267,7 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
             : Builders<T>.Filter.Eq(x => x.Id, id)
               & Builders<T>.Filter.ElemMatch(field, elemFieldMatch);
 
-        var me = field.Body as MemberExpression;
+        var me = (MemberExpression)field.Body;
         var minfo = me.Member;
         var update = Builders<T>.Update.Set($"{minfo.Name}.$", value);
 
@@ -291,7 +291,7 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     /// <returns></returns>
     public virtual async Task UpdateToSet<U>(Expression<Func<T, IEnumerable<U>>> field, U elemFieldMatch, U value)
     {
-        var me = field.Body as MemberExpression;
+        var me = (MemberExpression)field.Body;
         var minfo = me.Member;
 
         var filter = new BsonDocument {

--- a/src/Core/Grand.Data/Mongo/MongoStoreFilesContext.cs
+++ b/src/Core/Grand.Data/Mongo/MongoStoreFilesContext.cs
@@ -6,14 +6,14 @@ namespace Grand.Data.Mongo;
 
 public class MongoStoreFilesContext : IStoreFilesContext
 {
-    protected IMongoDatabase _database;
+    private readonly IMongoDatabase _database;
 
     public MongoStoreFilesContext()
     {
         var connectionString = DataSettingsManager.Instance.LoadSettings().ConnectionString;
 
-        var mongourl = new MongoUrl(connectionString);
-        var databaseName = mongourl.DatabaseName;
+        var mongoUrl = new MongoUrl(connectionString);
+        var databaseName = mongoUrl.DatabaseName;
         _database = new MongoClient(connectionString).GetDatabase(databaseName);
     }
 

--- a/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryMock.cs
+++ b/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryMock.cs
@@ -8,8 +8,8 @@ public class LiteDBRepositoryMock<T> : LiteDBRepository<T>, IRepository<T> where
 {
     public LiteDBRepositoryMock() : base(Guid.NewGuid().ToString(), new AuditInfoProvider())
     {
-        _database = new LiteDatabase(new MemoryStream());
-        _database.DropCollection(typeof(T).Name);
-        _collection = _database.GetCollection<T>(typeof(T).Name);
+        Database = new LiteDatabase(new MemoryStream());
+        Database.DropCollection(typeof(T).Name);
+        Collection = Database.GetCollection<T>(typeof(T).Name);
     }
 }

--- a/src/Tests/Grand.Data.Tests/MongoDb/MongoDBRepositoryTest.cs
+++ b/src/Tests/Grand.Data.Tests/MongoDb/MongoDBRepositoryTest.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace Grand.Data.Tests.MongoDb;
 
-public class MongoDBRepositoryTest<T> : MongoRepository<T>, IRepository<T> where T : BaseEntity
+public class MongoDBRepositoryTest<T> : MongoRepository<T> where T : BaseEntity
 {
     public MongoDBRepositoryTest() : base(
         DriverTestConfiguration.Client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName),
@@ -22,8 +22,8 @@ public class MongoDBRepositoryTest<T> : MongoRepository<T>, IRepository<T> where
         var client = DriverTestConfiguration.Client;
 
 
-        _database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
-        _database.DropCollection(typeof(T).Name);
-        _collection = _database.GetCollection<T>(typeof(T).Name);
+        Database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+        Database.DropCollection(typeof(T).Name);
+        Collection = Database.GetCollection<T>(typeof(T).Name);
     }
 }


### PR DESCRIPTION
Resolves #issueNumber  
Type: **refactor**

## Issue
1. Possible non-indecative runtime exception (see [comment](https://github.com/grandnode/grandnode2/pull/576/files#r1967560629)).
2. Code repetition in `MongoRepository` c'tor.
3.  Sensitive repository properties/fields can be less accessed.

## Solution
1. Replace the `as` operator with classic casting.
2. Reuse constructor.
3. Use appropriate access modifiers.

## Breaking changes

## Testing
Need to pass the default pipeline.
