### PR TITLE
Refactor/controller response types

### DIFF
--- a/src/Modules/Grand.Module.Api/Controllers/BrandController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/BrandController.cs
@@ -7,7 +7,6 @@ using Grand.Domain.Catalog;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Microsoft.AspNetCore.Http;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Routing;
@@ -29,7 +28,7 @@ public class BrandController : BaseApiController
     [EndpointName("GetBrands")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<BrandDto>))]
     public async Task<IActionResult> Get()
     {
@@ -41,8 +40,8 @@ public class BrandController : BaseApiController
     [EndpointDescription("Get entity from Brand by key")]
     [EndpointName("GetBrandById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BrandDto))]
     public async Task<IActionResult> GetById([FromRoute] string key)
     {
@@ -57,9 +56,9 @@ public class BrandController : BaseApiController
     [EndpointDescription("Add new entity to Brand")]
     [EndpointName("InsertBrand")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BrandDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] BrandDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Brands)) return Forbid();
@@ -71,9 +70,9 @@ public class BrandController : BaseApiController
     [EndpointDescription("Update entity in Brand")]
     [EndpointName("UpdateBrand")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BrandDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] BrandDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Brands)) return Forbid();
@@ -85,10 +84,10 @@ public class BrandController : BaseApiController
     [EndpointDescription("Partially update entity in Brand")]
     [EndpointName("PartiallyUpdateBrand")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
 
     ///sample
     ///{
@@ -115,9 +114,9 @@ public class BrandController : BaseApiController
     [EndpointDescription("Delete entity in Brand")]
     [EndpointName("DeleteBrand")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Brands)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/BrandLayoutController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/BrandLayoutController.cs
@@ -5,7 +5,6 @@ using Grand.Domain.Permissions;
 using Grand.Domain.Catalog;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -26,9 +25,9 @@ public class BrandLayoutController : BaseApiController
     [EndpointDescription("Get entity from BrandLayout by key")]
     [EndpointName("GetBrandLayoutById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LayoutDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Maintenance)) return Forbid();
@@ -43,7 +42,7 @@ public class BrandLayoutController : BaseApiController
     [EndpointName("GetBrandLayouts")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LayoutDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/CategoryController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CategoryController.cs
@@ -7,7 +7,6 @@ using Grand.Domain.Catalog;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -30,9 +29,9 @@ public class CategoryController : BaseApiController
     [EndpointDescription("Get entity from Category by key")]
     [EndpointName("GetCategoryById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CategoryDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Categories)) return Forbid();
@@ -47,7 +46,7 @@ public class CategoryController : BaseApiController
     [EndpointName("GetCategories")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CategoryDto>))]
     public async Task<IActionResult> Get()
     {
@@ -59,9 +58,9 @@ public class CategoryController : BaseApiController
     [EndpointDescription("Add new entity to Category")]
     [EndpointName("InsertCategory")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CategoryDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] CategoryDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Categories)) return Forbid();
@@ -73,9 +72,9 @@ public class CategoryController : BaseApiController
     [EndpointDescription("Update entity in Category")]
     [EndpointName("UpdateCategory")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CategoryDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] CategoryDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Categories)) return Forbid();
@@ -87,10 +86,10 @@ public class CategoryController : BaseApiController
     [EndpointDescription("Update entity in Category (delta)")]
     [EndpointName("UpdateCategoryPatch")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<CategoryDto> model)
     {
         if (string.IsNullOrEmpty(key))
@@ -110,9 +109,9 @@ public class CategoryController : BaseApiController
     [EndpointDescription("Delete entity from Category")]
     [EndpointName("DeleteCategory")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Categories)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/CategoryLayoutController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CategoryLayoutController.cs
@@ -5,7 +5,6 @@ using Grand.Domain.Permissions;
 using Grand.Domain.Catalog;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -28,9 +27,9 @@ public class CategoryLayoutController : BaseApiController
     [EndpointDescription("Get entity from CategoryLayout by key")]
     [EndpointName("GetCategoryLayoutById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LayoutDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Maintenance)) return Forbid();
@@ -45,7 +44,7 @@ public class CategoryLayoutController : BaseApiController
     [EndpointName("GetCategoryLayout")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LayoutDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/CollectionController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CollectionController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -28,9 +27,9 @@ public class CollectionController : BaseApiController
     [EndpointDescription("Get entity from Collection by key")]
     [EndpointName("GetCollectionById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CollectionDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Collections)) return Forbid();
@@ -45,7 +44,7 @@ public class CollectionController : BaseApiController
     [EndpointName("GetCollections")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CollectionDto>))]
     public async Task<IActionResult> Get()
     {
@@ -57,9 +56,9 @@ public class CollectionController : BaseApiController
     [EndpointDescription("Add new entity to Collection")]
     [EndpointName("InsertCollection")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CollectionDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] CollectionDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Collections)) return Forbid();
@@ -71,9 +70,9 @@ public class CollectionController : BaseApiController
     [EndpointDescription("Update entity in Collection")]
     [EndpointName("UpdateCollection")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CollectionDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] CollectionDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Collections)) return Forbid();
@@ -85,10 +84,10 @@ public class CollectionController : BaseApiController
     [EndpointDescription("Partially update entity in Collection")]
     [EndpointName("PartiallyUpdateCollection")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<CollectionDto> model)
     {
         if (string.IsNullOrEmpty(key))
@@ -108,9 +107,9 @@ public class CollectionController : BaseApiController
     [EndpointDescription("Delete entity in Collection")]
     [EndpointName("DeleteCollection")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Collections)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/CollectionLayoutController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CollectionLayoutController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class CollectionLayoutController : BaseApiController
     [EndpointDescription("Get entity from CollectionLayout by key")]
     [EndpointName("GetCollectionLayoutById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LayoutDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Maintenance)) return Forbid();
@@ -43,7 +42,7 @@ public class CollectionLayoutController : BaseApiController
     [EndpointName("GetCollectionLayouts")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LayoutDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/CountryController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CountryController.cs
@@ -5,7 +5,6 @@ using Grand.Domain.Permissions;
 using Grand.Domain.Directory;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -26,9 +25,9 @@ public class CountryController : BaseApiController
     [EndpointDescription("Get entity from Country by key")]
     [EndpointName("GetCountryById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CountryDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Countries)) return Forbid();
@@ -44,7 +43,7 @@ public class CountryController : BaseApiController
     [EndpointName("GetCountries")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CountryDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/CurrencyController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CurrencyController.cs
@@ -5,7 +5,6 @@ using Grand.Domain.Permissions;
 using Grand.Domain.Directory;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 using Grand.Module.Api.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -26,9 +25,9 @@ public class CurrencyController : BaseApiController
     [EndpointDescription("Get entity from Currency by key")]
     [EndpointName("GetCurrencyById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CurrencyDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Currencies)) return Forbid();
@@ -43,7 +42,7 @@ public class CurrencyController : BaseApiController
     [EndpointName("GetCurrencies")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CurrencyDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/CustomerController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CustomerController.cs
@@ -10,7 +10,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -37,9 +36,9 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Get entity from Customer by email")]
     [EndpointName("GetCustomerByEmail")]
     [HttpGet]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string email)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -53,9 +52,9 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Add new entity to Customer")]
     [EndpointName("InsertCustomer")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] CustomerDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -67,9 +66,9 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Update entity in Customer")]
     [EndpointName("UpdateCustomer")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] CustomerDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -81,9 +80,9 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Delete entity from Customer")]
     [EndpointName("DeleteCustomer")]
     [HttpDelete("{email}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string email)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -100,10 +99,10 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Invoke action AddAddress")]
     [EndpointName("AddAddress")]
     [HttpPost("{email}/AddAddress")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AddressDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> AddAddress([FromRoute] string email, [FromBody] AddressDto address)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -119,10 +118,10 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Invoke action UpdateAddress")]
     [EndpointName("UpdateAddress")]
     [HttpPost("{email}/UpdateAddress")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AddressDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateAddress([FromRoute] string email, [FromBody] AddressDto address)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -140,9 +139,9 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Invoke action DeleteAddress")]
     [EndpointName("DeleteAddress")]
     [HttpPost("{email}/DeleteAddress")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteAddress([FromRoute] string email, [FromBody] DeleteAddressDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -165,10 +164,10 @@ public class CustomerController : BaseApiController
     [EndpointDescription("Invoke action SetPassword")]
     [EndpointName("SetPassword")]
     [HttpPost("{email}/SetPassword")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> SetPassword([FromRoute] string email, [FromBody] PasswordDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/CustomerGroupController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/CustomerGroupController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -28,9 +27,9 @@ public class CustomerGroupController : BaseApiController
     [EndpointDescription("Get entity from CustomerGroup by key")]
     [EndpointName("GetCustomerGroupById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerGroupDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -45,7 +44,7 @@ public class CustomerGroupController : BaseApiController
     [EndpointName("GetCustomerGroups")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CustomerGroupDto>))]
     public async Task<IActionResult> Get()
     {
@@ -57,9 +56,9 @@ public class CustomerGroupController : BaseApiController
     [EndpointDescription("Add new entity to CustomerGroup")]
     [EndpointName("InsertCustomerGroup")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerGroupDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] CustomerGroupDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -71,9 +70,9 @@ public class CustomerGroupController : BaseApiController
     [EndpointDescription("Update entity in CustomerGroup")]
     [EndpointName("UpdateCustomerGroup")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerGroupDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] CustomerGroupDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();
@@ -90,10 +89,10 @@ public class CustomerGroupController : BaseApiController
     [EndpointDescription("Partially update entity in CustomerGroup")]
     [EndpointName("PartiallyUpdateCustomerGroup")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<CustomerGroupDto> model)
     {
         if (string.IsNullOrEmpty(key))
@@ -118,9 +117,9 @@ public class CustomerGroupController : BaseApiController
     [EndpointDescription("Delete entity in CustomerGroup")]
     [EndpointName("DeleteCustomerGroup")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Customers)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/DeliveryDateController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/DeliveryDateController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class DeliveryDateController : BaseApiController
     [EndpointDescription("Get entity from Delivery Date by key")]
     [EndpointName("GetDeliveryDateById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeliveryDateDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ShippingSettings)) return Forbid();
@@ -43,7 +42,7 @@ public class DeliveryDateController : BaseApiController
     [EndpointName("GetDeliveryDates")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DeliveryDateDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/LanguageController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/LanguageController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class LanguageController : BaseApiController
     [EndpointDescription("Get entity from Languages by key")]
     [EndpointName("GetLanguageById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LanguageDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Languages)) return Forbid();
@@ -43,7 +42,7 @@ public class LanguageController : BaseApiController
     [EndpointName("GetLanguages")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LanguageDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/PickupPointController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/PickupPointController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class PickupPointController : BaseApiController
     [EndpointDescription("Get entity from PickupPoint by key")]
     [EndpointName("GetPickupPointById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PickupPointDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ShippingSettings)) return Forbid();
@@ -43,7 +42,7 @@ public class PickupPointController : BaseApiController
     [EndpointName("GetPickupPoints")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PickupPointDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/PictureController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/PictureController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class PictureController : BaseApiController
     [EndpointDescription("Get entities from Picture by key")]
     [EndpointName("GetPictureById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PictureDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Pictures)) return Forbid();
@@ -42,9 +41,9 @@ public class PictureController : BaseApiController
     [EndpointDescription("Add new entity in Picture")]
     [EndpointName("InsertPicture")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] PictureDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Pictures)) return Forbid();
@@ -56,9 +55,9 @@ public class PictureController : BaseApiController
     [EndpointDescription("Update entity in Picture")]
     [EndpointName("UpdatePicture")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] PictureDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Pictures)) return Forbid();
@@ -70,9 +69,9 @@ public class PictureController : BaseApiController
     [EndpointDescription("Delete entity in Picture")]
     [EndpointName("DeletePicture")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Pictures)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/ProductAttributeController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/ProductAttributeController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -30,9 +29,9 @@ public class ProductAttributeController : BaseApiController
     [EndpointDescription("Get entity from ProductAttribute by key")]
     [EndpointName("GetProductAttributeById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ProductAttributes)) return Forbid();
@@ -47,7 +46,7 @@ public class ProductAttributeController : BaseApiController
     [EndpointName("GetProductAttributes")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ProductAttributeDto>))]
     public async Task<IActionResult> Get()
     {
@@ -59,9 +58,9 @@ public class ProductAttributeController : BaseApiController
     [EndpointDescription("Add new entity to ProductAttribute")]
     [EndpointName("InsertProductAttribute")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] ProductAttributeDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ProductAttributes)) return Forbid();
@@ -73,9 +72,9 @@ public class ProductAttributeController : BaseApiController
     [EndpointDescription("Update entity in ProductAttribute")]
     [EndpointName("UpdateProductAttribute")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] ProductAttributeDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ProductAttributes)) return Forbid();
@@ -87,10 +86,10 @@ public class ProductAttributeController : BaseApiController
     [EndpointDescription("Partially update entity in ProductAttribute")]
     [EndpointName("PartiallyUpdateProductAttribute")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<ProductAttributeDto> model)
     {
         if (string.IsNullOrEmpty(key))
@@ -110,9 +109,9 @@ public class ProductAttributeController : BaseApiController
     [EndpointDescription("Delete entity from ProductAttribute")]
     [EndpointName("DeleteProductAttribute")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ProductAttributes)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/ProductController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/ProductController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -30,9 +29,9 @@ public class ProductController : BaseApiController
     [EndpointDescription("Get entity from Product by key")]
     [EndpointName("GetProductById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -47,7 +46,7 @@ public class ProductController : BaseApiController
     [EndpointName("GetProducts")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ProductDto>))]
     public async Task<IActionResult> Get()
     {
@@ -59,9 +58,9 @@ public class ProductController : BaseApiController
     [EndpointDescription("Add new entity to Product")]
     [EndpointName("InsertProduct")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] ProductDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -73,9 +72,9 @@ public class ProductController : BaseApiController
     [EndpointDescription("Update entity in Product")]
     [EndpointName("UpdateProduct")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProductDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] ProductDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -87,10 +86,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Partially update entity in Product")]
     [EndpointName("PartiallyUpdateProduct")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<ProductDto> model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -110,9 +109,9 @@ public class ProductController : BaseApiController
     [EndpointDescription("Delete entity in Product")]
     [EndpointName("DeleteProduct")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -130,10 +129,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateStock")]
     [EndpointName("UpdateStock")]
     [HttpPost("{key}/UpdateStock")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateStock([FromRoute] string key, [FromBody] ProductUpdateStock model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -153,10 +152,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductCategory")]
     [EndpointName("CreateProductCategory")]
     [HttpPost("{key}/CreateProductCategory")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductCategory([FromRoute] string key, [FromBody] ProductCategoryDto productCategory)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -182,10 +181,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductCategory")]
     [EndpointName("UpdateProductCategory")]
     [HttpPost("{key}/UpdateProductCategory")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductCategory([FromRoute] string key, [FromBody] ProductCategoryDto productCategory)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -211,10 +210,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductCategory")]
     [EndpointName("DeleteProductCategory")]
     [HttpPost("{key}/DeleteProductCategory")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductCategory([FromRoute] string key, [FromBody] ProductCategoryDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -249,10 +248,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductCollection")]
     [EndpointName("CreateProductCollection")]
     [HttpPost("{key}/CreateProductCollection")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductCollection([FromRoute] string key, [FromBody] ProductCollectionDto productCollection)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -277,10 +276,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductCollection")]
     [EndpointName("UpdateProductCollection")]
     [HttpPost("{key}/UpdateProductCollection")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductCollection([FromRoute] string key, [FromBody] ProductCollectionDto productCollection)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -306,10 +305,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductCollection")]
     [EndpointName("DeleteProductCollection")]
     [HttpPost("{key}/DeleteProductCollection")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductCollection([FromRoute] string key, [FromBody] ProductCollectionDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -344,10 +343,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductPicture")]
     [EndpointName("CreateProductPicture")]
     [HttpPost("{key}/CreateProductPicture")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductPicture([FromRoute] string key, [FromBody] ProductPictureDto productPicture)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -372,10 +371,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductPicture")]
     [EndpointName("UpdateProductPicture")]
     [HttpPost("{key}/UpdateProductPicture")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductPicture([FromRoute] string key, [FromBody] ProductPictureDto productPicture)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -400,10 +399,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductPicture")]
     [EndpointName("DeleteProductPicture")]
     [HttpPost("{key}/DeleteProductPicture")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductPicture([FromRoute] string key, [FromBody] ProductPictureDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -438,10 +437,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductSpecification")]
     [EndpointName("CreateProductSpecification")]
     [HttpPost("{key}/CreateProductSpecification")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductSpecification([FromRoute] string key, [FromBody] ProductSpecificationAttributeDto productSpecification)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -467,10 +466,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductSpecification")]
     [EndpointName("UpdateProductSpecification")]
     [HttpPost("{key}/UpdateProductSpecification")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductSpecification([FromRoute] string key, [FromBody] ProductSpecificationAttributeDto productSpecification)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -496,10 +495,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductSpecification")]
     [EndpointName("DeleteProductSpecification")]
     [HttpPost("{key}/DeleteProductSpecification")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductSpecification([FromRoute] string key, [FromBody] ProductSpecificationAttributeDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -535,10 +534,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductTierPrice")]
     [EndpointName("CreateProductTierPrice")]
     [HttpPost("{key}/CreateProductTierPrice")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductTierPrice([FromRoute] string key, [FromBody] ProductTierPriceDto productTierPrice)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -563,10 +562,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductTierPrice")]
     [EndpointName("UpdateProductTierPrice")]
     [HttpPost("{key}/UpdateProductTierPrice")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductTierPrice([FromRoute] string key, [FromBody] ProductTierPriceDto productTierPrice)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -591,10 +590,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductTierPrice")]
     [EndpointName("DeleteProductTierPrice")]
     [HttpPost("{key}/DeleteProductTierPrice")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductTierPrice([FromRoute] string key, [FromBody] ProductTierPriceDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -629,10 +628,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action CreateProductAttributeMapping")]
     [EndpointName("CreateProductAttributeMapping")]
     [HttpPost("{key}/CreateProductAttributeMapping")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> CreateProductAttributeMapping([FromRoute] string key, [FromBody] ProductAttributeMappingDto productAttributeMapping)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -658,10 +657,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action UpdateProductAttributeMapping")]
     [EndpointName("UpdateProductAttributeMapping")]
     [HttpPost("{key}/UpdateProductAttributeMapping")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateProductAttributeMapping([FromRoute] string key, [FromBody] ProductAttributeMappingDto productAttributeMapping)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();
@@ -687,10 +686,10 @@ public class ProductController : BaseApiController
     [EndpointDescription("Invoke action DeleteProductAttributeMapping")]
     [EndpointName("DeleteProductAttributeMapping")]
     [HttpPost("{key}/DeleteProductAttributeMapping")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteProductAttributeMapping([FromRoute] string key, [FromBody] ProductAttributeMappingDeleteDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Products)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/ProductLayoutController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/ProductLayoutController.cs
@@ -9,7 +9,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -29,9 +28,9 @@ public class ProductLayoutController : BaseApiController
     [EndpointDescription("Get entity from ProductLayout by key")]
     [EndpointName("GetProductLayoutById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LayoutDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Maintenance)) return Forbid();
@@ -46,7 +45,7 @@ public class ProductLayoutController : BaseApiController
     [EndpointName("GetProductTemplates")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LayoutDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/ShippingMethodController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/ShippingMethodController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class ShippingMethodController : BaseApiController
     [EndpointDescription("Get entity from ShippingMethod by key")]
     [EndpointName("GetShippingMethodById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ShippingMethodDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ShippingSettings)) return Forbid();
@@ -43,7 +42,7 @@ public class ShippingMethodController : BaseApiController
     [EndpointName("GetShippingMethods")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ShippingMethodDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/SpecificationAttributeController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/SpecificationAttributeController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -28,9 +27,9 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointDescription("Get entity from SpecificationAttribute by key")]
     [EndpointName("GetSpecificationAttributeById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SpecificationAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.SpecificationAttributes)) return Forbid();
@@ -45,7 +44,7 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointName("GetSpecificationAttributes")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SpecificationAttributeDto>))]
     public async Task<IActionResult> Get()
     {
@@ -57,9 +56,9 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointDescription("Add new entity to SpecificationAttribute")]
     [EndpointName("InsertSpecificationAttribute")]
     [HttpPost]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SpecificationAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Post([FromBody] SpecificationAttributeDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.SpecificationAttributes)) return Forbid();
@@ -71,9 +70,9 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointDescription("Update entity in SpecificationAttribute")]
     [EndpointName("UpdateSpecificationAttribute")]
     [HttpPut]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SpecificationAttributeDto))]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Put([FromBody] SpecificationAttributeDto model)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.SpecificationAttributes)) return Forbid();
@@ -85,10 +84,10 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointDescription("Partially update entity in SpecificationAttribute")]
     [EndpointName("PartiallyUpdateSpecificationAttribute")]
     [HttpPatch("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Patch([FromRoute] string key, [FromBody] JsonPatchDocument<SpecificationAttributeDto> model)
     {
         if (string.IsNullOrEmpty(key))
@@ -108,9 +107,9 @@ public class SpecificationAttributeController : BaseApiController
     [EndpointDescription("Delete entity in SpecificationAttribute")]
     [EndpointName("DeleteSpecificationAttribute")]
     [HttpDelete("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
-    [ProducesResponseType((int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Delete([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.SpecificationAttributes)) return Forbid();

--- a/src/Modules/Grand.Module.Api/Controllers/StoreController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/StoreController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class StoreController : BaseApiController
     [EndpointDescription("Get entity from Store by key")]
     [EndpointName("GetStoreById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(StoreDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Stores)) return Forbid();
@@ -43,7 +42,7 @@ public class StoreController : BaseApiController
     [EndpointName("GetStores")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<StoreDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/VendorController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/VendorController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class VendorController : BaseApiController
     [EndpointDescription("Get entity from Vendor by key")]
     [EndpointName("GetVendorById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(VendorDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.Vendors)) return Forbid();
@@ -43,7 +42,7 @@ public class VendorController : BaseApiController
     [EndpointName("GetVendors")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<VendorDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Modules/Grand.Module.Api/Controllers/WarehouseController.cs
+++ b/src/Modules/Grand.Module.Api/Controllers/WarehouseController.cs
@@ -8,7 +8,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using System.Net;
 
 namespace Grand.Module.Api.Controllers;
 
@@ -26,9 +25,9 @@ public class WarehouseController : BaseApiController
     [EndpointDescription("Get entity from Warehouse by key")]
     [EndpointName("GetWarehouseById")]
     [HttpGet("{key}")]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WarehouseDto))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromRoute] string key)
     {
         if (!await _permissionService.Authorize(PermissionSystemName.ShippingSettings)) return Forbid();
@@ -43,7 +42,7 @@ public class WarehouseController : BaseApiController
     [EndpointName("GetWarehouses")]
     [HttpGet]
     [EnableQuery]
-    [ProducesResponseType((int)HttpStatusCode.Forbidden)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WarehouseDto>))]
     public async Task<IActionResult> Get()
     {

--- a/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
+++ b/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
@@ -25,7 +25,7 @@ public abstract class BasePublicController : BaseController
     }
 
     [IgnoreApi]
-    public new IActionResult View(object model)
+    public new ActionResult View(object model)
     {
         if (IsJsonResponseView())
             return Ok(model);

--- a/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
+++ b/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
@@ -11,12 +11,6 @@ namespace Grand.Web.Common.Controllers;
 [SharedKernel.Attributes.ApiController]
 public abstract class BasePublicController : BaseController
 {
-    protected IActionResult InvokeHttp404()
-    {
-        Response.StatusCode = 404;
-        return new EmptyResult();
-    }
-
     private bool IsJsonResponseView()
     {
         if (Request.Method.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
@@ -40,7 +34,7 @@ public abstract class BasePublicController : BaseController
     }
 
     [IgnoreApi]
-    public new IActionResult View(string viewName, object model)
+    public new ActionResult View(string viewName, object model)
     {
         if (IsJsonResponseView())
             return Json(model);

--- a/src/Web/Grand.Web.Common/Infrastructure/ApplicationBuilderExtensions.cs
+++ b/src/Web/Grand.Web.Common/Infrastructure/ApplicationBuilderExtensions.cs
@@ -162,15 +162,6 @@ public static class ApplicationBuilderExtensions
     }
 
     /// <summary>
-    ///     Configure MVC endpoint
-    /// </summary>
-    /// <param name="application">Builder for configuring an application's request pipeline</param>
-    public static void UseGrandDetection(this WebApplication application)
-    {
-        application.UseDetection();
-    }
-
-    /// <summary>
     ///     Configure static file serving
     /// </summary>
     /// <param name="application">Builder for configuring an application's request pipeline</param>

--- a/src/Web/Grand.Web.Common/Startup/GrandCommonStartup.cs
+++ b/src/Web/Grand.Web.Common/Startup/GrandCommonStartup.cs
@@ -104,7 +104,7 @@ public class GrandCommonStartup : IStartupApplication
             application.UsePoweredBy();
 
         //add responsive middleware (for detection)
-        application.UseGrandDetection();
+        application.UseDetection();
 
         //use routing
         application.UseRouting();

--- a/src/Web/Grand.Web/Controllers/AccountController.cs
+++ b/src/Web/Grand.Web/Controllers/AccountController.cs
@@ -359,8 +359,7 @@ public class AccountController : BasePublicController
     [HttpPost]
     [AutoValidateAntiforgeryToken]
     [PublicStore(true)]
-    [ProducesResponseType(typeof(PasswordRecoveryModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> PasswordRecovery(PasswordRecoveryModel model)
+    public virtual async Task<ActionResult<PasswordRecoveryModel>> PasswordRecovery(PasswordRecoveryModel model)
     {
         if (!ModelState.IsValid) return View(model);
 
@@ -379,8 +378,7 @@ public class AccountController : BasePublicController
 
     [HttpGet]
     [PublicStore(true)]
-    [ProducesResponseType(typeof(PasswordRecoveryConfirmModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> PasswordRecoveryConfirm(string token, string email)
+    public virtual async Task<ActionResult<PasswordRecoveryConfirmModel>> PasswordRecoveryConfirm(string token, string email)
     {
         var customer = await _customerService.GetCustomerByEmail(email);
         if (customer == null)
@@ -419,8 +417,7 @@ public class AccountController : BasePublicController
     //available even when navigation is not allowed
     [PublicStore(true)]
     [HttpGet]
-    [ProducesResponseType(typeof(RegisterModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Register()
+    public virtual async Task<ActionResult<RegisterModel>> Register()
     {
         //check whether registration is allowed
         if (_customerSettings.UserRegistrationType == UserRegistrationType.Disabled)
@@ -628,8 +625,7 @@ public class AccountController : BasePublicController
 
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerInfoModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Info()
+    public virtual async Task<ActionResult<CustomerInfoModel>> Info()
     {
         var model = await _mediator.Send(new GetInfo {
             Customer = _contextAccessor.WorkContext.CurrentCustomer,
@@ -643,8 +639,7 @@ public class AccountController : BasePublicController
     [HttpPost]
     [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerInfoModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Info(CustomerInfoModel model)
+    public virtual async Task<ActionResult<CustomerInfoModel>> Info(CustomerInfoModel model)
     {
         if (ModelState.IsValid)
         {
@@ -717,8 +712,7 @@ public class AccountController : BasePublicController
 
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerAddressListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Addresses()
+    public virtual async Task<ActionResult<CustomerAddressListModel>> Addresses()
     {
         var model = await _mediator.Send(new GetAddressList {
             Customer = _contextAccessor.WorkContext.CurrentCustomer,
@@ -751,8 +745,7 @@ public class AccountController : BasePublicController
 
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerAddressEditModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> AddressAdd()
+    public virtual async Task<ActionResult<CustomerAddressEditModel>> AddressAdd()
     {
         var countries =
             await _countryService.GetAllCountries(_contextAccessor.WorkContext.WorkingLanguage.Id, _contextAccessor.StoreContext.CurrentStore.Id);
@@ -775,8 +768,7 @@ public class AccountController : BasePublicController
     [HttpPost]
     [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(AddressModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> AddressAdd(CustomerAddressEditModel model,
+    public virtual async Task<ActionResult<AddressModel>> AddressAdd(CustomerAddressEditModel model,
         [FromServices] AddressSettings addressSettings)
     {
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
@@ -813,8 +805,7 @@ public class AccountController : BasePublicController
 
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerAddressEditModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> AddressEdit(string addressId)
+    public virtual async Task<ActionResult<CustomerAddressEditModel>> AddressEdit(string addressId)
     {
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
         //find address (ensure that it belongs to the current customer)
@@ -842,9 +833,7 @@ public class AccountController : BasePublicController
     [HttpPost]
     [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerAddressEditModel), StatusCodes.Status200OK)]
-
-    public virtual async Task<IActionResult> AddressEdit(CustomerAddressEditModel model,
+    public virtual async Task<ActionResult<CustomerAddressEditModel>> AddressEdit(CustomerAddressEditModel model,
         [FromServices] AddressSettings addressSettings)
     {
         var customer = _contextAccessor.WorkContext.CurrentCustomer;

--- a/src/Web/Grand.Web/Controllers/ActionCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ActionCartController.cs
@@ -116,7 +116,7 @@ public class ActionCartController : BasePublicController
             _contextAccessor.StoreContext.CurrentStore.DefaultWarehouseId;
     }
 
-    private IActionResult ReturnFailMessage(Product product, ShoppingCartType shoppingCartTypeId)
+    private JsonResult ReturnFailMessage(Product product, ShoppingCartType shoppingCartTypeId)
     {
         switch (product.ProductTypeId)
         {
@@ -165,9 +165,8 @@ public class ActionCartController : BasePublicController
 
     #region Public methods
 
-    [ProducesResponseType(typeof(ProductCatalogCart), StatusCodes.Status200OK)]
     [HttpPost]
-    public virtual async Task<IActionResult> AddProductCatalog(ProductCatalogCart model)
+    public virtual async Task<ActionResult<ProductCatalogCart>> AddProductCatalog(ProductCatalogCart model)
     {
         var product = await _productService.GetProductById(model.ProductId);
         if (product == null)
@@ -319,9 +318,8 @@ public class ActionCartController : BasePublicController
         }
     }
 
-    [ProducesResponseType(typeof(ProductDetailsCart), StatusCodes.Status200OK)]
     [HttpPost]
-    public virtual async Task<IActionResult> AddProductDetails(ProductDetailsCart model)
+    public virtual async Task<ActionResult<ProductDetailsCart>> AddProductDetails(ProductDetailsCart model)
     {
         var product = await _productService.GetProductById(model.ProductId);
         if (product == null)
@@ -520,9 +518,8 @@ public class ActionCartController : BasePublicController
         #endregion
     }
 
-    [ProducesResponseType(typeof(ProductDetailsCart), StatusCodes.Status200OK)]
     [HttpPost]
-    public virtual async Task<IActionResult> UpdateItemCart(ProductDetailsCart model)
+    public virtual async Task<ActionResult<ProductDetailsCart>> UpdateItemCart(ProductDetailsCart model)
     {
         var cart = _contextAccessor.WorkContext.CurrentCustomer.ShoppingCartItems.FirstOrDefault(sci =>
             sci.Id == model.ShoppingCartItemId);
@@ -709,9 +706,8 @@ public class ActionCartController : BasePublicController
         });
     }
 
-    [ProducesResponseType(typeof(AddBidModel), StatusCodes.Status200OK)]
     [HttpPost]
-    public virtual async Task<IActionResult> AddBid(AddBidModel model,
+    public virtual async Task<ActionResult<AddBidModel>> AddBid(AddBidModel model,
         [FromServices] IAuctionService auctionService)
     {
         var customer = _contextAccessor.WorkContext.CurrentCustomer;

--- a/src/Web/Grand.Web/Controllers/ActionCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ActionCartController.cs
@@ -68,7 +68,7 @@ public class ActionCartController : BasePublicController
 
     #region Private methods
 
-    private IActionResult RedirectToProduct(Product product, ShoppingCartType cartType, int quantity)
+    private JsonResult RedirectToProduct(Product product, ShoppingCartType cartType, int quantity)
     {
         //we can't add grouped products 
         if (product.ProductTypeId == ProductType.GroupedProduct)

--- a/src/Web/Grand.Web/Controllers/BlogController.cs
+++ b/src/Web/Grand.Web/Controllers/BlogController.cs
@@ -125,7 +125,7 @@ public class BlogController : BasePublicController
 
         //Store acl
         if (!aclService.Authorize(blogPost, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         var model = await _mediator.Send(new GetBlogPost { BlogPost = blogPost });
 

--- a/src/Web/Grand.Web/Controllers/BlogController.cs
+++ b/src/Web/Grand.Web/Controllers/BlogController.cs
@@ -54,8 +54,7 @@ public class BlogController : BasePublicController
     #region Methods
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> List(BlogPagingFilteringModel command)
+    public virtual async Task<ActionResult<BlogPostListModel>> List(BlogPagingFilteringModel command)
     {
         if (!_blogSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -65,8 +64,7 @@ public class BlogController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogByTag(BlogPagingFilteringModel command)
+    public virtual async Task<ActionResult<BlogPostListModel>> BlogByTag(BlogPagingFilteringModel command)
     {
         if (!_blogSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -76,8 +74,7 @@ public class BlogController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogByMonth(BlogPagingFilteringModel command)
+    public virtual async Task<ActionResult<BlogPostListModel>> BlogByMonth(BlogPagingFilteringModel command)
     {
         if (!_blogSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -87,8 +84,7 @@ public class BlogController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogByCategory(BlogPagingFilteringModel command)
+    public virtual async Task<ActionResult<BlogPostListModel>> BlogByCategory(BlogPagingFilteringModel command)
     {
         if (!_blogSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -98,8 +94,7 @@ public class BlogController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogByKeyword(BlogPagingFilteringModel command)
+    public virtual async Task<ActionResult<BlogPostListModel>> BlogByKeyword(BlogPagingFilteringModel command)
     {
         if (!_blogSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -109,8 +104,7 @@ public class BlogController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(BlogPostModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogPost(string blogPostId,
+    public virtual async Task<ActionResult<BlogPostModel>> BlogPost(string blogPostId,
         [FromServices] IAclService aclService,
         [FromServices] IPermissionService permissionService)
     {
@@ -140,8 +134,7 @@ public class BlogController : BasePublicController
     [HttpPost]
     [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
-    [ProducesResponseType(typeof(AddBlogCommentModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> BlogPost(AddBlogCommentModel model,
+    public virtual async Task<ActionResult<AddBlogCommentModel>> BlogPost(AddBlogCommentModel model,
         [FromServices] IAclService aclService)
     {
         var blogPost = await _blogService.GetBlogPostById(model.Id);

--- a/src/Web/Grand.Web/Controllers/CatalogController.cs
+++ b/src/Web/Grand.Web/Controllers/CatalogController.cs
@@ -91,9 +91,8 @@ public class CatalogController : BasePublicController
 
     #region Categories
 
-    [ProducesResponseType(typeof(CategoryModel), StatusCodes.Status200OK)]
     [HttpGet]
-    public virtual async Task<IActionResult> Category(string categoryId, CatalogPagingFilteringModel command)
+    public virtual async Task<ActionResult<CategoryModel>> Category(string categoryId, CatalogPagingFilteringModel command)
     {
         var category = await _categoryService.GetCategoryById(categoryId);
         if (category == null)

--- a/src/Web/Grand.Web/Controllers/CatalogController.cs
+++ b/src/Web/Grand.Web/Controllers/CatalogController.cs
@@ -97,22 +97,22 @@ public class CatalogController : BasePublicController
     {
         var category = await _categoryService.GetCategoryById(categoryId);
         if (category == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
 
         //Check whether the current user has a "Manage catalog" permission
         //It allows him to preview a category before publishing
         if (!category.Published && !await _permissionService.Authorize(StandardPermission.ManageCategories, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //ACL (access control list)
         if (!_aclService.Authorize(category, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //Store access
         if (!_aclService.Authorize(category, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&
@@ -157,22 +157,22 @@ public class CatalogController : BasePublicController
     {
         var brand = await _brandService.GetBrandById(brandId);
         if (brand == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
 
         //Check whether the current user has a "Manage catalog" permission
         //It allows him to preview a collection before publishing
         if (!brand.Published && !await _permissionService.Authorize(StandardPermission.ManageBrands, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //ACL (access control list)
         if (!_aclService.Authorize(brand, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //Store access
         if (!_aclService.Authorize(brand, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&
@@ -216,7 +216,7 @@ public class CatalogController : BasePublicController
     {
         var collection = await _collectionService.GetCollectionById(collectionId);
         if (collection == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
 
@@ -224,15 +224,15 @@ public class CatalogController : BasePublicController
         //It allows him to preview a collection before publishing
         if (!collection.Published &&
             !await _permissionService.Authorize(StandardPermission.ManageCollections, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //ACL (access control list)
         if (!_aclService.Authorize(collection, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //Store access
         if (!_aclService.Authorize(collection, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&
@@ -277,11 +277,11 @@ public class CatalogController : BasePublicController
     {
         var vendor = await _vendorService.GetVendorById(vendorId);
         if (vendor == null || vendor.Deleted || !vendor.Active)
-            return InvokeHttp404();
+            return NotFound();
 
         //Vendor is active?
         if (!vendor.Active)
-            return InvokeHttp404();
+            return NotFound();
 
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
 
@@ -415,7 +415,7 @@ public class CatalogController : BasePublicController
     {
         var productTag = await productTagService.GetProductTagById(productTagId);
         if (productTag == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var model = await _mediator.Send(new GetProductsByTag {
             Command = command,
@@ -433,7 +433,7 @@ public class CatalogController : BasePublicController
     {
         var productTag = await productTagService.GetProductTagBySeName(seName);
         if (productTag == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var model = await _mediator.Send(new GetProductsByTag {
             Command = command,

--- a/src/Web/Grand.Web/Controllers/CommonController.cs
+++ b/src/Web/Grand.Web/Controllers/CommonController.cs
@@ -452,7 +452,7 @@ public class CommonController : BasePublicController
     public virtual IActionResult GenericUrl()
     {
         //not found
-        return InvokeHttp404();
+        return NotFound();
     }
 
     [ClosedStore(true)]

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -14,7 +14,6 @@ using Grand.Web.Common.Filters;
 using Grand.Web.Events;
 using Grand.Web.Models.Contact;
 using MediatR;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Grand.Web.Controllers;
@@ -39,8 +38,7 @@ public class ContactController : BasePublicController
     //available even when a store is closed
     [ClosedStore(true)]
     [HttpGet]
-    [ProducesResponseType(typeof(ContactUsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Index(
+    public virtual async Task<ActionResult<ContactUsModel>> Index(
         [FromServices] StoreInformationSettings storeInformationSettings,
         [FromServices] IPageService pageService)
     {
@@ -60,11 +58,10 @@ public class ContactController : BasePublicController
     }
 
     [HttpPost]
-    [ProducesResponseType(typeof(ContactUsModel), StatusCodes.Status200OK)]
     [AutoValidateAntiforgeryToken]
     [ClosedStore(true)]
     [DenySystemAccount]
-    public virtual async Task<IActionResult> Index(
+    public virtual async Task<ActionResult<ContactUsModel>> Index(
         [FromServices] StoreInformationSettings storeInformationSettings,
         [FromServices] IPageService pageService,
         ContactUsModel model)

--- a/src/Web/Grand.Web/Controllers/CourseController.cs
+++ b/src/Web/Grand.Web/Controllers/CourseController.cs
@@ -82,10 +82,10 @@ public class CourseController : BasePublicController
 
         var course = await _courseService.GetById(courseId);
         if (course == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (!await CheckPermission(course, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&
@@ -109,14 +109,14 @@ public class CourseController : BasePublicController
 
         var lesson = await _courseLessonService.GetById(id);
         if (lesson == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var course = await _courseService.GetById(lesson.CourseId);
         if (course == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (!await CheckPermission(course, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&
@@ -141,14 +141,14 @@ public class CourseController : BasePublicController
 
         var lesson = await _courseLessonService.GetById(id);
         if (lesson == null || string.IsNullOrEmpty(lesson.AttachmentId))
-            return InvokeHttp404();
+            return NotFound();
 
         var course = await _courseService.GetById(lesson.CourseId);
         if (course == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (!await CheckPermission(course, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         var download = await _downloadService.GetDownloadById(lesson.AttachmentId);
         if (download == null)
@@ -177,14 +177,14 @@ public class CourseController : BasePublicController
 
         var lesson = await _courseLessonService.GetById(id);
         if (lesson == null || string.IsNullOrEmpty(lesson.VideoFile))
-            return InvokeHttp404();
+            return NotFound();
 
         var course = await _courseService.GetById(lesson.CourseId);
         if (course == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (!await CheckPermission(course, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         var download = await _downloadService.GetDownloadById(lesson.VideoFile);
         if (download == null)

--- a/src/Web/Grand.Web/Controllers/DownloadController.cs
+++ b/src/Web/Grand.Web/Controllers/DownloadController.cs
@@ -53,7 +53,7 @@ public class DownloadController : BasePublicController
     {
         var product = await _productService.GetProductById(productId);
         if (product == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (!product.HasSampleDownload)
             return Content("Product doesn't have a sample download.");
@@ -81,7 +81,7 @@ public class DownloadController : BasePublicController
     {
         var orderItem = await _orderService.GetOrderItemByGuid(orderItemId);
         if (orderItem == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var order = await _orderService.GetOrderByOrderItemId(orderItem.Id);
         var product = await _productService.GetProductById(orderItem.ProductId);
@@ -186,7 +186,7 @@ public class DownloadController : BasePublicController
     {
         var orderItem = await _orderService.GetOrderItemByGuid(orderItemId);
         if (orderItem == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var order = await _orderService.GetOrderByOrderItemId(orderItem.Id);
         var product = await _productService.GetProductById(orderItem.ProductId);
@@ -250,11 +250,11 @@ public class DownloadController : BasePublicController
     {
         var orderNote = await _orderService.GetOrderNote(orderNoteId);
         if (orderNote == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var order = await _orderService.GetOrderById(orderNote.OrderId);
         if (order == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (_contextAccessor.WorkContext.CurrentCustomer == null || (order.CustomerId != _contextAccessor.WorkContext.CurrentCustomer.Id &&
                                                      order.OwnerId != _contextAccessor.WorkContext.CurrentCustomer.Id))
@@ -286,15 +286,15 @@ public class DownloadController : BasePublicController
     {
         var shipmentNote = await shipmentService.GetShipmentNote(shipmentNoteId);
         if (shipmentNote == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var shipment = await shipmentService.GetShipmentById(shipmentNote.ShipmentId);
         if (shipment == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var order = await _orderService.GetOrderById(shipment.OrderId);
         if (order == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (_contextAccessor.WorkContext.CurrentCustomer == null || (order.CustomerId != _contextAccessor.WorkContext.CurrentCustomer.Id &&
                                                      order.OwnerId != _contextAccessor.WorkContext.CurrentCustomer.Id))
@@ -329,7 +329,7 @@ public class DownloadController : BasePublicController
 
         var customerNote = await customerNoteService.GetCustomerNote(customerNoteId);
         if (customerNote == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (_contextAccessor.WorkContext.CurrentCustomer == null || customerNote.CustomerId != _contextAccessor.WorkContext.CurrentCustomer.Id)
             return Challenge();
@@ -359,12 +359,12 @@ public class DownloadController : BasePublicController
     {
         var merchandiseReturnNote = await _merchandiseReturnService.GetMerchandiseReturnNote(merchandiseReturnNoteId);
         if (merchandiseReturnNote == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var merchandiseReturn =
             await _merchandiseReturnService.GetMerchandiseReturnById(merchandiseReturnNote.MerchandiseReturnId);
         if (merchandiseReturn == null)
-            return InvokeHttp404();
+            return NotFound();
 
         if (_contextAccessor.WorkContext.CurrentCustomer == null || merchandiseReturn.CustomerId != _contextAccessor.WorkContext.CurrentCustomer.Id)
             return Challenge();
@@ -398,7 +398,7 @@ public class DownloadController : BasePublicController
 
         var document = await documentService.GetById(documentId);
         if (document is not { Published: true })
-            return InvokeHttp404();
+            return NotFound();
 
         if (_contextAccessor.WorkContext.CurrentCustomer == null || document.CustomerId != _contextAccessor.WorkContext.CurrentCustomer.Id)
             return Challenge();

--- a/src/Web/Grand.Web/Controllers/KnowledgebaseController.cs
+++ b/src/Web/Grand.Web/Controllers/KnowledgebaseController.cs
@@ -186,11 +186,11 @@ public class KnowledgebaseController : BasePublicController
 
         //ACL (access control list)
         if (!_aclService.Authorize(article, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //Store acl
         if (!_aclService.Authorize(article, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         //display "edit" (manage) link
         if (await _permissionService.Authorize(StandardPermission.ManageAccessAdminPanel, customer) &&

--- a/src/Web/Grand.Web/Controllers/NewsController.cs
+++ b/src/Web/Grand.Web/Controllers/NewsController.cs
@@ -59,8 +59,7 @@ public class NewsController : BasePublicController
     #region Methods
 
     [HttpGet]
-    [ProducesResponseType(typeof(NewsItemListModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> List(NewsPagingFilteringModel command)
+    public virtual async Task<ActionResult<NewsItemListModel>> List(NewsPagingFilteringModel command)
     {
         if (!_newsSettings.Enabled)
             return RedirectToRoute("HomePage");
@@ -70,8 +69,7 @@ public class NewsController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(NewsItemModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> NewsItem(string newsItemId)
+    public virtual async Task<ActionResult<NewsItemModel>> NewsItem(string newsItemId)
     {
         if (!_newsSettings.Enabled)
             return RedirectToRoute("HomePage");

--- a/src/Web/Grand.Web/Controllers/OrderController.cs
+++ b/src/Web/Grand.Web/Controllers/OrderController.cs
@@ -71,8 +71,7 @@ public class OrderController : BasePublicController
     //My account / Orders
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(OrderPagingModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> CustomerOrders(OrderPagingModel command)
+    public virtual async Task<ActionResult<OrderPagingModel>> CustomerOrders(OrderPagingModel command)
     {
         var model = await _mediator.Send(new GetCustomerOrderList {
             Customer = _contextAccessor.WorkContext.CurrentCustomer,
@@ -85,8 +84,7 @@ public class OrderController : BasePublicController
 
     //My account / Order details page
     [HttpGet]
-    [ProducesResponseType(typeof(OrderDetailsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Details(string orderId)
+    public virtual async Task<ActionResult<OrderDetailsModel>> Details(string orderId)
     {
         var order = await _orderService.GetOrderById(orderId);
         if (!await order.Access(_contextAccessor.WorkContext.CurrentCustomer, _groupService))
@@ -139,8 +137,7 @@ public class OrderController : BasePublicController
     //My account / Order details page / Add order note        
     [HttpPost]
     [AutoValidateAntiforgeryToken]
-    [ProducesResponseType(typeof(AddOrderNoteModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> AddOrderNote(AddOrderNoteModel model)
+    public virtual async Task<ActionResult<AddOrderNoteModel>> AddOrderNote(AddOrderNoteModel model)
     {
         if (!_orderSettings.AllowCustomerToAddOrderNote)
             return RedirectToRoute("HomePage");
@@ -199,8 +196,7 @@ public class OrderController : BasePublicController
 
     //My account / Order details page / Shipment details page
     [HttpGet]
-    [ProducesResponseType(typeof(ShipmentDetailsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> ShipmentDetails(string shipmentId,
+    public virtual async Task<ActionResult<ShipmentDetailsModel>> ShipmentDetails(string shipmentId,
         [FromServices] IShipmentService shipmentService)
     {
         var shipment = await shipmentService.GetShipmentById(shipmentId);
@@ -224,8 +220,7 @@ public class OrderController : BasePublicController
     //My account / Loyalty points
     [HttpGet]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
-    [ProducesResponseType(typeof(CustomerLoyaltyPointsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> CustomerLoyaltyPoints(
+    public virtual async Task<ActionResult<CustomerLoyaltyPointsModel>> CustomerLoyaltyPoints(
         [FromServices] LoyaltyPointsSettings loyaltyPointsSettings)
     {
         if (!loyaltyPointsSettings.Enabled)

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -270,8 +270,7 @@ public class ProductController : BasePublicController
     #region Product details page
 
     [HttpGet]
-    [ProducesResponseType(typeof(ProductDetailsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> ProductDetails(string productId)
+    public virtual async Task<ActionResult<ProductDetailsModel>> ProductDetails(string productId)
     {
         var product = await _productService.GetProductById(productId);
         if (product == null)
@@ -337,8 +336,7 @@ public class ProductController : BasePublicController
     //handle product attribute selection event. this way we return new price, overridden gtin/sku/mpn
     //currently we use this method on the product details pages
     [HttpPost]
-    [ProducesResponseType(typeof(ProductDetailsModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> ProductDetails_AttributeChange(ProductModel model)
+    public virtual async Task<ActionResult<ProductDetailsModel>> ProductDetails_AttributeChange(ProductModel model)
     {
         var product = await _productService.GetProductById(model.ProductId);
         if (product == null)

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -275,7 +275,7 @@ public class ProductController : BasePublicController
     {
         var product = await _productService.GetProductById(productId);
         if (product == null)
-            return InvokeHttp404();
+            return NotFound();
 
         var customer = _contextAccessor.WorkContext.CurrentCustomer;
 
@@ -284,19 +284,19 @@ public class ProductController : BasePublicController
             //Check whether the current user has a "Manage catalog" permission
             //It allows him to preview a product before publishing
             if (!product.Published && !await _permissionService.Authorize(StandardPermission.ManageProducts, customer))
-                return InvokeHttp404();
+                return NotFound();
 
         //ACL (access control list)
         if (!_aclService.Authorize(product, customer))
-            return InvokeHttp404();
+            return NotFound();
 
         //Store access
         if (!_aclService.Authorize(product, _contextAccessor.StoreContext.CurrentStore.Id))
-            return InvokeHttp404();
+            return NotFound();
 
         //availability dates
         if (!product.IsAvailable() && product.ProductTypeId != ProductType.Auction)
-            return InvokeHttp404();
+            return NotFound();
 
         //visible individually?
         if (!product.VisibleIndividually)

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -98,8 +98,7 @@ public class ShoppingCartController : BasePublicController
     #region Shopping cart
 
     [HttpGet]
-    [ProducesResponseType(typeof(MiniShoppingCartModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SidebarShoppingCart()
+    public async Task<ActionResult<MiniShoppingCartModel>> SidebarShoppingCart()
     {
         if (!_shoppingCartSettings.MiniShoppingCartEnabled)
             return Content("");
@@ -253,8 +252,7 @@ public class ShoppingCartController : BasePublicController
     }
 
     [HttpGet]
-    //[ProducesResponseType(typeof(ShoppingCartModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Cart(bool checkoutAttributes)
+    public virtual async Task<ActionResult<ShoppingCartModel>> Cart(bool checkoutAttributes)
     {
         if (!await _permissionService.Authorize(StandardPermission.EnableShoppingCart))
             return RedirectToRoute("HomePage");
@@ -274,8 +272,7 @@ public class ShoppingCartController : BasePublicController
 
     [HttpGet]
     [DenySystemAccount]
-    [ProducesResponseType(typeof(ShoppingCartModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CartSummary()
+    public async Task<ActionResult<ShoppingCartModel>> CartSummary()
     {
         var cart = await _shoppingCartService.GetShoppingCart(_contextAccessor.StoreContext.CurrentStore.Id,
             ShoppingCartType.ShoppingCart, ShoppingCartType.Auctions);
@@ -295,8 +292,7 @@ public class ShoppingCartController : BasePublicController
 
     [HttpGet]
     [DenySystemAccount]
-    [ProducesResponseType(typeof(OrderTotalsModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> CartTotal()
+    public async Task<ActionResult<OrderTotalsModel>> CartTotal()
     {
         var cart = await _shoppingCartService.GetShoppingCart(_contextAccessor.StoreContext.CurrentStore.Id,
             ShoppingCartType.ShoppingCart, ShoppingCartType.Auctions);

--- a/src/Web/Grand.Web/Controllers/WishlistController.cs
+++ b/src/Web/Grand.Web/Controllers/WishlistController.cs
@@ -60,8 +60,7 @@ public class WishlistController : BasePublicController
     #region Wishlist
 
     [HttpGet]
-    [ProducesResponseType(typeof(MiniWishlistModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SidebarWishlist()
+    public async Task<ActionResult<MiniWishlistModel>> SidebarWishlist()
     {
         if (!await _permissionService.Authorize(StandardPermission.EnableWishlist))
             return Content("");
@@ -84,8 +83,7 @@ public class WishlistController : BasePublicController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(WishlistModel), StatusCodes.Status200OK)]
-    public virtual async Task<IActionResult> Index(Guid? customerGuid)
+    public virtual async Task<ActionResult<WishlistModel>> Index(Guid? customerGuid)
     {
         if (!await _permissionService.Authorize(StandardPermission.EnableWishlist))
             return RedirectToRoute("HomePage");


### PR DESCRIPTION
Resolves #issueNumber  
Type: **refactor**

## Issue
1. `ProducesResponseTypeAttribute` + `IActionResult` can achieve the same behavior with `ActionResult<T>`.
2. `InvokeHttp404` seems to be redundant.
3. `System.Net.Http.HttpStatusCode` should be avoided in ASP context.
4. `UseGrandDetection` does not provide any extra logic.

## Solution
1. Replace with `ActionResult<T>`. It supports various implicit convertions to maintain flexibilty, and can also easily get the action's return type from the return type itself without attributes.
2. Use ASP `NotFound` to achieve the same behavior.
3. Use `Microsoft.AspNetCore.Http.StatusCodes`.
4. Remove `UseGrandDetection`.
## Breaking changes

## Testing
1. I've seen the return types on scalar and openApi's json via diff checker and they seem to be almost identical (a bit more informative now).
