### PR TITLE
Improvements/implicit usings

### DIFF
--- a/src/Build/Grand.Common.props
+++ b/src/Build/Grand.Common.props
@@ -1,42 +1,44 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
     <PropertyGroup>
         <Product>grandnode</Product>
         <PackageProjectUrl>https://grandnode.com/</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/grandnode/grandnode2</RepositoryUrl>
         <PackageLicenseUrl>https://github.com/grandnode/grandnode2/blob/main/LICENSE</PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/grandnode/grandnode2</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
         <DebugSymbols>false</DebugSymbols>
         <DebugType>none</DebugType>
         <Optimize>true</Optimize>
     </PropertyGroup>
+
     <ItemGroup>
-        <Using Include="System.Text" />
+        <Using Include="System.Text"/>
     </ItemGroup>
+
     <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation"
             Condition="'$(SourceRevisionId)'=='' And Exists('$(MSBuildProjectDirectory)\.git')">
         <Exec Command="git describe --long --always --exclude=* --abbrev=8" ConsoleToMSBuild="True"
               IgnoreExitCode="True">
-            <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput" />
+            <Output PropertyName="SourceRevisionId" TaskParameter="ConsoleOutput"/>
         </Exec>
     </Target>
     <Target Name="SetRepositoryBranch" BeforeTargets="InitializeSourceControlInformation"
             Condition="'$(GitBranch)'=='' And Exists('$(MSBuildProjectDirectory)\.git')">
         <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="True" IgnoreExitCode="True">
-            <Output PropertyName="branch" TaskParameter="ConsoleOutput" />
+            <Output PropertyName="branch" TaskParameter="ConsoleOutput"/>
         </Exec>
         <ItemGroup>
-            <AssemblyMetadata Include="GitBranch" Value="$(branch)" />
+            <AssemblyMetadata Include="GitBranch" Value="$(branch)"/>
         </ItemGroup>
     </Target>
     <ItemGroup Condition="'$(GitBranch)'!=''">
-        <AssemblyMetadata Include="GitBranch" Value="$(GitBranch)" />
+        <AssemblyMetadata Include="GitBranch" Value="$(GitBranch)"/>
     </ItemGroup>
     <Target Name="SetVersion" BeforeTargets="PrepareForBuild">
         <PropertyGroup>

--- a/src/Build/Grand.Common.props
+++ b/src/Build/Grand.Common.props
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
     <PropertyGroup>
         <Product>grandnode</Product>
@@ -16,13 +17,7 @@
         <Optimize>true</Optimize>
     </PropertyGroup>
     <ItemGroup>
-        <Using Include="System" />
-        <Using Include="System.Collections.Generic" />
-        <Using Include="System.IO" />
         <Using Include="System.Text" />
-        <Using Include="System.Linq" />
-        <Using Include="System.Threading" />
-        <Using Include="System.Threading.Tasks" />
     </ItemGroup>
     <Target Name="SetSourceRevisionId" BeforeTargets="InitializeSourceControlInformation"
             Condition="'$(SourceRevisionId)'=='' And Exists('$(MSBuildProjectDirectory)\.git')">

--- a/src/Web/Grand.Web.Admin/Program.cs
+++ b/src/Web/Grand.Web.Admin/Program.cs
@@ -1,7 +1,4 @@
-﻿using Grand.Infrastructure;
-using Grand.Web.Common.Extensions;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Hosting;
+﻿using Grand.Web.Common.Extensions;
 using StartupBase = Grand.Infrastructure.StartupBase;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Web/Grand.Web.Admin/Program.cs
+++ b/src/Web/Grand.Web.Admin/Program.cs
@@ -2,6 +2,7 @@
 using Grand.Web.Common.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
+using StartupBase = Grand.Infrastructure.StartupBase;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Web/Grand.Web.Vendor/Program.cs
+++ b/src/Web/Grand.Web.Vendor/Program.cs
@@ -1,7 +1,4 @@
-using Grand.Infrastructure;
 using Grand.Web.Common.Extensions;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Hosting;
 using StartupBase = Grand.Infrastructure.StartupBase;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Web/Grand.Web.Vendor/Program.cs
+++ b/src/Web/Grand.Web.Vendor/Program.cs
@@ -2,6 +2,7 @@ using Grand.Infrastructure;
 using Grand.Web.Common.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Hosting;
+using StartupBase = Grand.Infrastructure.StartupBase;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Web/Grand.Web/Program.cs
+++ b/src/Web/Grand.Web/Program.cs
@@ -1,7 +1,5 @@
 using Grand.Web.Common.Extensions;
 using Grand.Web.Common.Startup;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Hosting;
 using StartupBase = Grand.Infrastructure.StartupBase;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
Resolves #issueNumber  
Type: **improvements**

## Issue
`Grand.Common.props` should be as clean as possible. It manualy adds common namespaces as global, while .NET 6 provided a cleaner, built in way to do so.
## Solution
Add `UseGlobalUsings` which behaves differently across different SDKs. e.g for Web environment:

**Grand.Web.GlobalUsings.g.cs**
```C#
// <auto-generated/>
global using global::Microsoft.AspNetCore.Builder;
global using global::Microsoft.AspNetCore.Hosting;
global using global::Microsoft.AspNetCore.Http;
global using global::Microsoft.AspNetCore.Routing;
global using global::Microsoft.Extensions.Configuration;
global using global::Microsoft.Extensions.DependencyInjection;
global using global::Microsoft.Extensions.Hosting;
global using global::Microsoft.Extensions.Logging;
global using global::System;
global using global::System.Collections.Generic;
global using global::System.IO;
global using global::System.Linq;
global using global::System.Net.Http;
global using global::System.Net.Http.Json;
global using global::System.Text;
global using global::System.Threading;
global using global::System.Threading.Tasks;

```

## Breaking changes

## Testing
