### PR TITLE
Remove MaxMind.GeoIP2 package and fix import (update product by sku)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageVersion Include="MaxMind.GeoIP2" Version="5.2.0" />
     <PackageVersion Include="ExcelMapper" Version="5.2.598" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />

--- a/src/Business/Grand.Business.Catalog/Grand.Business.Catalog.csproj
+++ b/src/Business/Grand.Business.Catalog/Grand.Business.Catalog.csproj
@@ -5,8 +5,5 @@
     <ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj" />
     <ProjectReference Include="..\Grand.Business.Core\Grand.Business.Core.csproj" />
-  </ItemGroup>
-	<ItemGroup>
-    <PackageReference Include="MaxMind.GeoIP2" />
-	</ItemGroup>
+  </ItemGroup>	
 </Project>

--- a/src/Business/Grand.Business.Catalog/Services/ExportImport/Mapper/ProductProfile.cs
+++ b/src/Business/Grand.Business.Catalog/Services/ExportImport/Mapper/ProductProfile.cs
@@ -10,6 +10,7 @@ public class ProductProfile : Profile, IAutoMapperProfile
     public ProductProfile()
     {
         CreateMap<ProductDto, Product>()
+            .ForMember(x => x.Id, opts => opts.Condition(src => !string.IsNullOrEmpty(src.Id)))
             .ForMember(x => x.UpdatedOnUtc, opt => opt.MapFrom(o => DateTime.UtcNow))
             .ForMember(x => x.ProductTypeId, opt => opt.Condition(z => z.ProductTypeId.HasValue))
             .ForMember(x => x.VisibleIndividually, opt => opt.Condition(z => z.VisibleIndividually.HasValue))


### PR DESCRIPTION
- Removed `MaxMind.GeoIP2` package version from `Directory.Packages.props` and its reference from `Grand.Business.Catalog.csproj`.
- Added new mapping conditions in `ProductProfile.cs` to improve property mapping control for `ProductDto` to `Product`.