### PR TITLE
Potential fix for code scanning alert no. 316: URL redirection from remote source

### DIFF
--- a/src/Web/Grand.Web/Controllers/CommonController.cs
+++ b/src/Web/Grand.Web/Controllers/CommonController.cs
@@ -266,10 +266,11 @@ public class CommonController : BasePublicController
             }
 
         //prevent open redirection attack
-        if (!Url.IsLocalUrl(returnUrl))
-            returnUrl = Url.RouteUrl("HomePage");
+        var redirectUrl = Url.RouteUrl("HomePage");
+        if (Url.IsLocalUrl(returnUrl))
+            redirectUrl = returnUrl;
 
-        return Redirect(returnUrl);
+        return Redirect(redirectUrl);
 
         void SetStoreCookie(Domain.Stores.Store store)
         {


### PR DESCRIPTION
Potential fix for [https://github.com/grandnode/grandnode2/security/code-scanning/316](https://github.com/grandnode/grandnode2/security/code-scanning/316)

In general, the safest fix is to never pass the raw user input directly to `Redirect`. Instead, validate the input and construct a new, trusted redirect URL based on the result of that validation. A common pattern is to introduce a separate local variable (e.g., `redirectUrl`) that is initialized with a safe default and only ever assigned validated values (such as a local URL or a known-good route), leaving the original user input unchanged.

For this specific case in `SetStore` (lines 248–273), the logic is already doing a local URL check, but it reuses the `returnUrl` variable for both the untrusted input and the trusted redirect target. To make the code clearer and more robust, we should:
- Introduce a new variable, e.g. `redirectUrl`, set initially to `Url.RouteUrl("HomePage")`.
- If `Url.IsLocalUrl(returnUrl)` is true, assign `redirectUrl = returnUrl`; otherwise leave it as the safe default.
- Call `return Redirect(redirectUrl);` instead of `Redirect(returnUrl)`.

This change occurs only within `SetStore` in `src/Web/Grand.Web/Controllers/CommonController.cs`, around lines 268–272. No new imports or helpers are needed; we reuse the existing `Url` helper and routing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
