### PR TITLE
Potential fix for code scanning alert no. 1045: Missing cross-site request forgery token validation

### DIFF
--- a/src/Web/Grand.Web.AdminShared/Controllers/BaseLoginController.cs
+++ b/src/Web/Grand.Web.AdminShared/Controllers/BaseLoginController.cs
@@ -139,6 +139,7 @@ public abstract class BaseLoginController : BaseController
     }
 
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> TwoFactorAuthorization(string token,
         [FromServices] ITwoFactorAuthenticationService twoFactorAuthenticationService)
     {


### PR DESCRIPTION
Potential fix for [https://github.com/grandnode/grandnode2/security/code-scanning/1045](https://github.com/grandnode/grandnode2/security/code-scanning/1045)

To fix this, add ASP.NET Core’s anti-forgery validation attribute to the POST overload of `TwoFactorAuthorization`.

Best single fix (without changing functionality): in `src/Web/Grand.Web.AdminShared/Controllers/BaseLoginController.cs`, add `[ValidateAntiForgeryToken]` directly above the `[HttpPost]` `TwoFactorAuthorization` method (the overload taking `string token`). No new imports are needed because `Microsoft.AspNetCore.Mvc` is already present and contains `ValidateAntiForgeryTokenAttribute`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
