### PR TITLE
Lock system-wide settings in store panel & add "All stores" scope in admin

### DIFF
--- a/src/Web/Grand.Web.Admin/Components/StoreScope.cs
+++ b/src/Web/Grand.Web.Admin/Components/StoreScope.cs
@@ -1,6 +1,5 @@
-﻿using Grand.Business.Core.Interfaces.Common.Directory;
+﻿using Grand.Business.Core.Interfaces.Common.Localization;
 using Grand.Business.Core.Interfaces.Common.Stores;
-using Grand.Infrastructure;
 using Grand.Web.AdminShared.Models.Settings;
 using Grand.Web.Common.Components;
 using Grand.Web.Common.Helpers;
@@ -15,9 +14,8 @@ public class StoreScopeViewComponent : BaseAdminViewComponent
     #region Fields
 
     private readonly IStoreService _storeService;
-    private readonly IContextAccessor _contextAccessor;
-    private readonly IGroupService _groupService;
     private readonly IAdminStoreService _adminStoreService;
+    private readonly ITranslationService _translationService;
 
     #endregion
 
@@ -26,13 +24,11 @@ public class StoreScopeViewComponent : BaseAdminViewComponent
     public StoreScopeViewComponent(
         IStoreService storeService,
         IAdminStoreService adminStoreService,
-        IGroupService groupService,
-        IContextAccessor contextAccessor)
+        ITranslationService translationService)
     {
         _adminStoreService = adminStoreService;
         _storeService = storeService;
-        _contextAccessor = contextAccessor;
-        _groupService = groupService;
+        _translationService = translationService;
     }
 
     #endregion
@@ -45,10 +41,14 @@ public class StoreScopeViewComponent : BaseAdminViewComponent
         if (allStores.Count < 2)
             return Content("");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            allStores = allStores.Where(x => x.Id == _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId).ToList();
-
         var model = new StoreScopeModel();
+
+        //global scope (all stores)
+        model.Stores.Add(new StoreModel {
+            Id = "",
+            Name = _translationService.GetResource("Admin.Settings.StoreScope.AllStores")
+        });
+
         foreach (var s in allStores)
             model.Stores.Add(new StoreModel {
                 Id = s.Id,

--- a/src/Web/Grand.Web.Admin/Controllers/BaseAdminController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/BaseAdminController.cs
@@ -1,5 +1,4 @@
-﻿using Grand.Business.Core.Interfaces.Common.Directory;
-using Grand.Business.Core.Interfaces.Common.Stores;
+﻿using Grand.Business.Core.Interfaces.Common.Stores;
 using Grand.Domain.Common;
 using Grand.Domain.Customers;
 using Grand.Infrastructure;
@@ -24,23 +23,21 @@ public abstract class BaseAdminController : BaseController
     {
         var storeService = HttpContext.RequestServices.GetRequiredService<IStoreService>();
         var workContext = HttpContext.RequestServices.GetRequiredService<IContextAccessor>().WorkContext;
-        var groupService = HttpContext.RequestServices.GetRequiredService<IGroupService>();
 
         var stores = await storeService.GetAllStores();
         if (stores.Count < 2)
             return stores.FirstOrDefault()?.Id;
 
-        if (await groupService.IsStoreManager(workContext.CurrentCustomer)) return workContext.CurrentCustomer.StaffStoreId;
-
         var storeId =
             workContext.CurrentCustomer.GetUserFieldFromEntity<string>(SystemCustomerFieldNames
                 .AdminAreaStoreScopeConfiguration);
+        //empty scope means "all stores" - settings are loaded from/saved to the global scope
         if (string.IsNullOrEmpty(storeId))
         {
-            return stores.First()?.Id;
+            return "";
         }
 
         var store = await storeService.GetStoreById(storeId);
-        return store != null ? store.Id : stores.First()?.Id;
+        return store != null ? store.Id : "";
     }
 }

--- a/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/Customer.TabCustomerSecurity.cshtml
+++ b/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/Customer.TabCustomerSecurity.cshtml
@@ -42,24 +42,6 @@
         </div>
         <div class="form-group">
             <div class="col-8 col-md-4 col-sm-4 text-right">
-                <admin-label asp-for="CustomerSettings.DefaultPasswordFormat" class="control-label"/>
-            </div>
-            <div class="col-4 col-md-8 col-sm-8">
-                <admin-select asp-for="CustomerSettings.DefaultPasswordFormat" asp-items="EnumTranslationService.ToSelectList((PasswordFormat)Model.CustomerSettings.DefaultPasswordFormat)"/>
-                <span asp-validation-for="CustomerSettings.DefaultPasswordFormat"></span>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="col-8 col-md-4 col-sm-4 text-right">
-                <admin-label asp-for="CustomerSettings.HashedPasswordFormat" class="control-label"/>
-            </div>
-            <div class="col-4 col-md-8 col-sm-8">
-                <admin-select asp-for="CustomerSettings.HashedPasswordFormat" asp-items="EnumTranslationService.ToSelectList(Model.CustomerSettings.HashedPasswordFormat)"/>
-                <span asp-validation-for="CustomerSettings.HashedPasswordFormat"></span>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="col-8 col-md-4 col-sm-4 text-right">
                 <admin-label asp-for="CustomerSettings.PasswordRegularExpression" class="control-label"/>
             </div>
             <div class="col-4 col-md-8 col-sm-8">

--- a/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/Sales.TabLoyaltyPoints.cshtml
+++ b/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/Sales.TabLoyaltyPoints.cshtml
@@ -103,18 +103,6 @@
                 <span asp-validation-for="LoyaltyPointsSettings.DisplayHowMuchWillBeEarned"></span>
             </div>
         </div>
-        <div class="form-group">
-            <div class="col-8 col-md-4 col-sm-4 text-right">
-                <admin-label asp-for="LoyaltyPointsSettings.PointsAccumulatedForAllStores" class="control-label"/>
-            </div>
-            <div class="col-4 col-md-8 col-sm-8">
-                <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
-                    <admin-input asp-for="LoyaltyPointsSettings.PointsAccumulatedForAllStores"/>
-                    <div class="control__indicator"></div>
-                </label>
-                <span asp-validation-for="LoyaltyPointsSettings.PointsAccumulatedForAllStores"></span>
-            </div>
-        </div>
     </div>
 </div>
 <vc:admin-widget widget-zone="loyalty_points_settings_bottom" additional-data="null"/>

--- a/src/Web/Grand.Web.Store/Controllers/SettingController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/SettingController.cs
@@ -285,7 +285,13 @@ public class SettingController(
         if (ModelState.IsValid)
         {
             var loyaltyPointsSettings = await settingService.LoadSetting<LoyaltyPointsSettings>(storeScope);
+
+            // Cross-store accumulation is managed by the administrator - store owners cannot change it
+            var pointsAccumulatedForAllStores = loyaltyPointsSettings.PointsAccumulatedForAllStores;
+
             loyaltyPointsSettings = model.LoyaltyPointsSettings.ToEntity(loyaltyPointsSettings);
+            loyaltyPointsSettings.PointsAccumulatedForAllStores = pointsAccumulatedForAllStores;
+
             await settingService.SaveSetting(loyaltyPointsSettings, storeScope);
 
             var shoppingCartSettings = await settingService.LoadSetting<ShoppingCartSettings>(storeScope);
@@ -625,7 +631,14 @@ public class SettingController(
         var customerSettings = await settingService.LoadSetting<CustomerSettings>(storeScope);
         var addressSettings = await settingService.LoadSetting<AddressSettings>(storeScope);
 
+        // Password storage formats are managed by the administrator - store owners cannot change them
+        var defaultPasswordFormat = customerSettings.DefaultPasswordFormat;
+        var hashedPasswordFormat = customerSettings.HashedPasswordFormat;
+
         customerSettings = model.CustomerSettings.ToEntity(customerSettings);
+        customerSettings.DefaultPasswordFormat = defaultPasswordFormat;
+        customerSettings.HashedPasswordFormat = hashedPasswordFormat;
+
         await settingService.SaveSetting(customerSettings, storeScope);
 
         addressSettings = model.AddressSettings.ToEntity(addressSettings);


### PR DESCRIPTION
## Summary

Follow-up to the store-owner panel security review: some setting fields have cross-store / system impact and must stay under administrator control, plus the admin panel gets a proper way to manage the global settings record.

### Store panel (Grand.Web.Store)

Store owners can no longer change:
- `CustomerSettings.DefaultPasswordFormat` and `HashedPasswordFormat` - password storage is a system-wide concern; a per-store downgrade would affect shared customer accounts,
- `LoyaltyPointsSettings.PointsAccumulatedForAllStores` - a store owner enabling cross-store accumulation (combined with inflated earning rates in his own store) could mint points redeemable in other stores.

The inputs are removed from the store views and the values are preserved server-side on save (snapshot from the store-scoped load before `ToEntity`, restored after), following the same pattern already used for the media file-manager fields.

### Admin panel (Grand.Web.Admin)

- The store scope selector now includes an **"All stores"** option (uses the existing `Admin.Settings.StoreScope.AllStores` resource). Selecting it loads/saves the **global** settings record, which stores without their own record inherit automatically - so the administrator no longer has to re-apply settings for every newly created store.
- `BaseAdminController.GetActiveStore()` returns the global scope (`""`) when no store is selected or the selected store no longer exists, instead of silently falling back to the first store. This aligns it with `AdminStoreService.GetActiveStore()` and with what the selector displays.
- Removed dead `IsStoreManager` branches in `StoreScopeViewComponent` and `BaseAdminController` - store managers have no access to the admin panel.

### Behavior note

On multi-store installations where the administrator never picked a store scope, settings pages previously edited the first store; they now edit the global scope until a store is selected.

## Test plan

- [x] `Grand.Web.Store` and `Grand.Web.Admin` build clean (0 warnings / 0 errors)
- [x] Tests touching `GetActiveStore` (PaymentController, AdminStoreService) pass
- [x] Manual: multi-store admin - select "All stores", save Customer/Sales settings, verify a store without its own record inherits them
- [x] Manual: store owner panel - verify password format / points accumulation fields are gone and saving a tab keeps admin-managed values intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)