### PR TITLE
Hash customer passwords with PBKDF2 and upgrade legacy hashes transparently

### DIFF
--- a/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
+++ b/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
@@ -182,9 +182,10 @@ public class EncryptionService : IEncryptionService
                 PepperedPassword(enteredPassword), salt, iterations, HashAlgorithmName.SHA256, expected.Length);
             return CryptographicOperations.FixedTimeEquals(actual, expected);
         }
-        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        catch (FormatException)
         {
-            //corrupted/malformed stored hash - fail closed instead of throwing on the auth path
+            //salt/hash are not valid Base64 (corrupted stored value) - fail closed on the auth path.
+            //Other arguments cannot throw here: iterations/output length are guarded above and the rest are constant.
             return false;
         }
     }

--- a/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
+++ b/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
@@ -1,11 +1,27 @@
 ﻿using Grand.Business.Core.Interfaces.Common.Security;
 using Grand.Domain.Customers;
+using Grand.Infrastructure.Configuration;
 using System.Security.Cryptography;
 
 namespace Grand.Business.Common.Services.Security;
 
 public class EncryptionService : IEncryptionService
 {
+    private const string Pbkdf2Prefix = "PBKDF2";
+    private const int Pbkdf2SaltSize = 16;
+    private const int Pbkdf2HashSize = 32;
+    private const int DefaultIterations = 210_000;
+
+    private readonly SecurityConfig _securityConfig;
+
+    public EncryptionService(SecurityConfig securityConfig = null)
+    {
+        _securityConfig = securityConfig ?? new SecurityConfig();
+    }
+
+    private int Iterations =>
+        _securityConfig.PasswordHashIterations > 0 ? _securityConfig.PasswordHashIterations : DefaultIterations;
+
     /// <summary>
     ///     Create salt key
     /// </summary>
@@ -91,6 +107,93 @@ public class EncryptionService : IEncryptionService
 
         var buffer = Convert.FromBase64String(cipherText);
         return DecryptTextFromMemory(buffer, tDes.Key, tDes.IV);
+    }
+
+    /// <summary>
+    ///     Creates a strong, self-describing PBKDF2 (HMAC-SHA256) password hash.
+    ///     Format: PBKDF2$1$&lt;iterations&gt;$&lt;saltBase64&gt;$&lt;hashBase64&gt;
+    /// </summary>
+    public virtual string HashPassword(string password)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+
+        var salt = RandomNumberGenerator.GetBytes(Pbkdf2SaltSize);
+        var iterations = Iterations;
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            PepperedPassword(password), salt, iterations, HashAlgorithmName.SHA256, Pbkdf2HashSize);
+
+        return string.Join('$',
+            Pbkdf2Prefix, "1", iterations.ToString(), Convert.ToBase64String(salt), Convert.ToBase64String(hash));
+    }
+
+    public virtual bool VerifyPassword(string enteredPassword, PasswordFormat passwordFormat, string storedPassword,
+        string storedSalt, HashedPasswordFormat legacyHashedFormat)
+    {
+        if (enteredPassword == null || storedPassword == null)
+            return false;
+
+        switch (passwordFormat)
+        {
+            case PasswordFormat.Clear:
+                return FixedTimeEquals(enteredPassword, storedPassword);
+            case PasswordFormat.Encrypted:
+                return FixedTimeEquals(EncryptText(enteredPassword, storedSalt), storedPassword);
+            case PasswordFormat.Hashed:
+                return IsPbkdf2Hash(storedPassword)
+                    ? VerifyPbkdf2(enteredPassword, storedPassword)
+                    : FixedTimeEquals(CreatePasswordHash(enteredPassword, storedSalt, legacyHashedFormat),
+                        storedPassword);
+            default:
+                return false;
+        }
+    }
+
+    public virtual bool PasswordHashNeedsUpgrade(PasswordFormat passwordFormat, string storedPassword)
+    {
+        //only a current-strength PBKDF2 hash is considered up to date; everything else is upgraded on next login
+        return !(passwordFormat == PasswordFormat.Hashed && IsPbkdf2Hash(storedPassword));
+    }
+
+    private static bool IsPbkdf2Hash(string storedPassword)
+    {
+        return storedPassword != null && storedPassword.StartsWith(Pbkdf2Prefix + "$", StringComparison.Ordinal);
+    }
+
+    private bool VerifyPbkdf2(string enteredPassword, string storedPassword)
+    {
+        //PBKDF2$1$<iterations>$<saltBase64>$<hashBase64>
+        var parts = storedPassword.Split('$');
+        if (parts.Length != 5 || !int.TryParse(parts[2], out var iterations))
+            return false;
+
+        byte[] salt;
+        byte[] expected;
+        try
+        {
+            salt = Convert.FromBase64String(parts[3]);
+            expected = Convert.FromBase64String(parts[4]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var actual = Rfc2898DeriveBytes.Pbkdf2(
+            PepperedPassword(enteredPassword), salt, iterations, HashAlgorithmName.SHA256, expected.Length);
+        return CryptographicOperations.FixedTimeEquals(actual, expected);
+    }
+
+    private byte[] PepperedPassword(string password)
+    {
+        var pepper = _securityConfig.PasswordHashKey;
+        //a NUL separator prevents ambiguity between password and pepper boundaries
+        return Encoding.UTF8.GetBytes(string.IsNullOrEmpty(pepper) ? password : password + "\0" + pepper);
+    }
+
+    private static bool FixedTimeEquals(string a, string b)
+    {
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(a), Encoding.UTF8.GetBytes(b));
     }
 
     #region Utilities

--- a/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
+++ b/src/Business/Grand.Business.Common/Services/Security/EncryptionService.cs
@@ -150,8 +150,13 @@ public class EncryptionService : IEncryptionService
 
     public virtual bool PasswordHashNeedsUpgrade(PasswordFormat passwordFormat, string storedPassword)
     {
-        //only a current-strength PBKDF2 hash is considered up to date; everything else is upgraded on next login
-        return !(passwordFormat == PasswordFormat.Hashed && IsPbkdf2Hash(storedPassword));
+        //up to date only if it is a PBKDF2 hash whose embedded cost meets the currently configured iteration count;
+        //everything else (Clear/Encrypted, legacy SHA, or a weaker/unparseable PBKDF2 hash) is upgraded on next login
+        if (passwordFormat != PasswordFormat.Hashed || !IsPbkdf2Hash(storedPassword))
+            return true;
+
+        var parts = storedPassword.Split('$');
+        return parts.Length != 5 || !int.TryParse(parts[2], out var iterations) || iterations < Iterations;
     }
 
     private static bool IsPbkdf2Hash(string storedPassword)
@@ -163,24 +168,25 @@ public class EncryptionService : IEncryptionService
     {
         //PBKDF2$1$<iterations>$<saltBase64>$<hashBase64>
         var parts = storedPassword.Split('$');
-        if (parts.Length != 5 || !int.TryParse(parts[2], out var iterations))
+        if (parts.Length != 5 || !int.TryParse(parts[2], out var iterations) || iterations <= 0)
             return false;
 
-        byte[] salt;
-        byte[] expected;
         try
         {
-            salt = Convert.FromBase64String(parts[3]);
-            expected = Convert.FromBase64String(parts[4]);
+            var salt = Convert.FromBase64String(parts[3]);
+            var expected = Convert.FromBase64String(parts[4]);
+            if (expected.Length == 0)
+                return false;
+
+            var actual = Rfc2898DeriveBytes.Pbkdf2(
+                PepperedPassword(enteredPassword), salt, iterations, HashAlgorithmName.SHA256, expected.Length);
+            return CryptographicOperations.FixedTimeEquals(actual, expected);
         }
-        catch (FormatException)
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
         {
+            //corrupted/malformed stored hash - fail closed instead of throwing on the auth path
             return false;
         }
-
-        var actual = Rfc2898DeriveBytes.Pbkdf2(
-            PepperedPassword(enteredPassword), salt, iterations, HashAlgorithmName.SHA256, expected.Length);
-        return CryptographicOperations.FixedTimeEquals(actual, expected);
     }
 
     private byte[] PepperedPassword(string password)

--- a/src/Business/Grand.Business.Core/Interfaces/Common/Security/IEncryptionService.cs
+++ b/src/Business/Grand.Business.Core/Interfaces/Common/Security/IEncryptionService.cs
@@ -22,6 +22,35 @@ public interface IEncryptionService
         HashedPasswordFormat passwordFormat = HashedPasswordFormat.SHA1);
 
     /// <summary>
+    ///     Creates a strong, self-describing password hash for the current default algorithm (PBKDF2/HMAC-SHA256).
+    ///     The salt and parameters are embedded in the returned value, so a separate salt field is not needed and
+    ///     verification never depends on a global setting. Store the result in <c>Customer.Password</c> with
+    ///     <see cref="PasswordFormat.Hashed" />.
+    /// </summary>
+    /// <param name="password">Plain-text password</param>
+    /// <returns>Self-describing hash string</returns>
+    string HashPassword(string password);
+
+    /// <summary>
+    ///     Verifies an entered password against a stored credential in a format-aware, constant-time way.
+    ///     Handles Clear, Encrypted, the modern PBKDF2 hash and legacy SHA-x hashes transparently.
+    /// </summary>
+    /// <param name="enteredPassword">Plain-text password supplied by the user</param>
+    /// <param name="passwordFormat">Stored password format (<c>Customer.PasswordFormatId</c>)</param>
+    /// <param name="storedPassword">Stored password/hash (<c>Customer.Password</c>)</param>
+    /// <param name="storedSalt">Stored salt (<c>Customer.PasswordSalt</c>); ignored for PBKDF2</param>
+    /// <param name="legacyHashedFormat">Hash algorithm used by legacy SHA hashes (global setting)</param>
+    /// <returns>True when the password matches</returns>
+    bool VerifyPassword(string enteredPassword, PasswordFormat passwordFormat, string storedPassword,
+        string storedSalt, HashedPasswordFormat legacyHashedFormat);
+
+    /// <summary>
+    ///     Indicates whether a stored credential uses a weak/legacy format (Clear, Encrypted or a non-PBKDF2 hash)
+    ///     and should be transparently re-hashed to the modern format after the next successful authentication.
+    /// </summary>
+    bool PasswordHashNeedsUpgrade(PasswordFormat passwordFormat, string storedPassword);
+
+    /// <summary>
     ///     Encrypt text
     /// </summary>
     /// <param name="plainText">Text to encrypt</param>

--- a/src/Business/Grand.Business.Customers/Services/CustomerManagerService.cs
+++ b/src/Business/Grand.Business.Customers/Services/CustomerManagerService.cs
@@ -61,14 +61,9 @@ public class CustomerManagerService : ICustomerManagerService
     public virtual bool PasswordMatch(PasswordFormat passwordFormat, string oldPassword, string newPassword,
         string passwordSalt)
     {
-        var newPwd = passwordFormat switch {
-            PasswordFormat.Clear => newPassword,
-            PasswordFormat.Encrypted => _encryptionService.EncryptText(newPassword, passwordSalt),
-            PasswordFormat.Hashed => _encryptionService.CreatePasswordHash(newPassword, passwordSalt,
-                _customerSettings.HashedPasswordFormat),
-            _ => throw new Exception("PasswordFormat not supported")
-        };
-        return oldPassword.Equals(newPwd);
+        //oldPassword is the stored credential, newPassword is the plain-text candidate being checked against it
+        return _encryptionService.VerifyPassword(newPassword, passwordFormat, oldPassword, passwordSalt,
+            _customerSettings.HashedPasswordFormat);
     }
 
 
@@ -84,16 +79,14 @@ public class CustomerManagerService : ICustomerManagerService
             ? await _customerService.GetCustomerByUsername(usernameOrEmail, storeId)
             : await _customerService.GetCustomerByEmail(usernameOrEmail, storeId);
 
-        var pwd = customer.PasswordFormatId switch {
-            PasswordFormat.Clear => password,
-            PasswordFormat.Encrypted => _encryptionService.EncryptText(password, customer.PasswordSalt),
-            PasswordFormat.Hashed => _encryptionService.CreatePasswordHash(password, customer.PasswordSalt,
-                _customerSettings.HashedPasswordFormat),
-            _ => throw new Exception("PasswordFormat not supported")
-        };
-        var isValid = pwd == customer.Password;
+        var isValid = _encryptionService.VerifyPassword(password, customer.PasswordFormatId, customer.Password,
+            customer.PasswordSalt, _customerSettings.HashedPasswordFormat);
         if (!isValid)
             return CustomerLoginResults.WrongPassword;
+
+        //transparently migrate weak/legacy hashes (SHA-x, Clear, Encrypted) to the modern PBKDF2 format
+        if (_encryptionService.PasswordHashNeedsUpgrade(customer.PasswordFormatId, customer.Password))
+            await UpgradePasswordHash(customer, password);
 
         //2fa required
         if (customer.GetUserFieldFromEntity<bool>(SystemCustomerFieldNames.TwoFactorEnabled) &&
@@ -134,10 +127,9 @@ public class CustomerManagerService : ICustomerManagerService
                     _encryptionService.EncryptText(request.Password, request.Customer.PasswordSalt);
                 break;
             case PasswordFormat.Hashed:
-                var saltKey = _encryptionService.CreateSaltKey(5);
-                request.Customer.PasswordSalt = saltKey;
-                request.Customer.Password = _encryptionService.CreatePasswordHash(request.Password, saltKey,
-                    _customerSettings.HashedPasswordFormat);
+                //modern self-describing PBKDF2 hash - salt and parameters are embedded in the value itself
+                request.Customer.PasswordSalt = string.Empty;
+                request.Customer.Password = _encryptionService.HashPassword(request.Password);
                 break;
         }
 
@@ -190,10 +182,9 @@ public class CustomerManagerService : ICustomerManagerService
                 break;
             case PasswordFormat.Hashed:
             {
-                var saltKey = _encryptionService.CreateSaltKey(5);
-                customer.PasswordSalt = saltKey;
-                customer.Password = _encryptionService.CreatePasswordHash(request.NewPassword, saltKey,
-                    _customerSettings.HashedPasswordFormat);
+                //modern self-describing PBKDF2 hash - salt and parameters are embedded in the value itself
+                customer.PasswordSalt = string.Empty;
+                customer.Password = _encryptionService.HashPassword(request.NewPassword);
             }
                 break;
         }
@@ -206,6 +197,19 @@ public class CustomerManagerService : ICustomerManagerService
 
         //create new login token
         await _customerService.UpdateUserField(customer, SystemCustomerFieldNames.PasswordToken, Guid.NewGuid().ToString());
+    }
+
+    /// <summary>
+    ///     Re-hashes an already-verified plain-text password to the modern PBKDF2 format and persists it.
+    ///     Called right after a successful authentication against a weak/legacy credential, so no password reset is
+    ///     required and no schema change is involved (the value simply moves to the self-describing hash format).
+    /// </summary>
+    private async Task UpgradePasswordHash(Customer customer, string plainPassword)
+    {
+        customer.Password = _encryptionService.HashPassword(plainPassword);
+        customer.PasswordSalt = string.Empty;
+        customer.PasswordFormatId = PasswordFormat.Hashed;
+        await _customerService.UpdateCustomer(customer);
     }
 
     #endregion

--- a/src/Business/Grand.Business.Customers/Services/CustomerManagerService.cs
+++ b/src/Business/Grand.Business.Customers/Services/CustomerManagerService.cs
@@ -86,8 +86,16 @@ public class CustomerManagerService : ICustomerManagerService
 
         //transparently migrate weak/legacy hashes (SHA-x, Clear, Encrypted) to the modern PBKDF2 format
         if (_encryptionService.PasswordHashNeedsUpgrade(customer.PasswordFormatId, customer.Password))
-            await UpgradePasswordHash(customer, password);
-
+        {
+            try
+            {
+                await UpgradePasswordHash(customer, password);
+            }
+            catch
+            {
+                //best-effort upgrade only; don't block login if persisting the upgraded hash fails
+            }
+        }
         //2fa required
         if (customer.GetUserFieldFromEntity<bool>(SystemCustomerFieldNames.TwoFactorEnabled) &&
             _customerSettings.TwoFactorAuthenticationEnabled)

--- a/src/Core/Grand.Infrastructure/Configuration/SecurityConfig.cs
+++ b/src/Core/Grand.Infrastructure/Configuration/SecurityConfig.cs
@@ -78,4 +78,19 @@ public class SecurityConfig
     ///     using menu configuration.
     /// </summary>
     public bool AuthorizeAdminMenu { get; set; }
+
+    /// <summary>
+    ///     Server-side secret ("pepper") mixed into the PBKDF2 password hash. Optional but recommended: it must be stored
+    ///     outside the database (appsettings/secret store), so a database-only leak is not enough to verify hashes offline.
+    ///     Leave empty to hash without a pepper.
+    ///     IMPORTANT: changing this value invalidates all existing PBKDF2 hashes (affected customers must reset their
+    ///     password); legacy SHA hashes are unaffected. Set it once, before going live.
+    /// </summary>
+    public string PasswordHashKey { get; set; }
+
+    /// <summary>
+    ///     PBKDF2 (HMAC-SHA256) iteration count for newly created/upgraded password hashes. Default 210000 (OWASP 2023).
+    ///     The value is embedded in each stored hash, so raising it later does not break existing hashes.
+    /// </summary>
+    public int PasswordHashIterations { get; set; }
 }

--- a/src/Tests/Grand.Business.Common.Tests/Services/Security/EncryptionServiceTests.cs
+++ b/src/Tests/Grand.Business.Common.Tests/Services/Security/EncryptionServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Grand.Business.Common.Services.Security;
 using Grand.Domain.Customers;
+using Grand.Infrastructure.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Grand.Business.Common.Tests.Services.Security;
@@ -92,5 +93,57 @@ public class EncryptionServiceTests
         var privateKey = "secure key.";
         var toDescrypt = "gdfgdfgt45gfdfg";
         Assert.ThrowsExactly<Exception>(() => _encryptionService.DecryptText(toDescrypt, privateKey));
+    }
+
+    [TestMethod]
+    public void HashPassword_ProducesSelfDescribingSaltedHash_ThatVerifies()
+    {
+        var hash1 = _encryptionService.HashPassword("password");
+        var hash2 = _encryptionService.HashPassword("password");
+
+        //self-describing PBKDF2 format and a random salt per call
+        StringAssert.StartsWith(hash1, "PBKDF2$");
+        Assert.AreNotEqual(hash1, hash2);
+
+        Assert.IsTrue(_encryptionService.VerifyPassword("password", PasswordFormat.Hashed, hash1, string.Empty,
+            HashedPasswordFormat.SHA1));
+        Assert.IsFalse(_encryptionService.VerifyPassword("wrong", PasswordFormat.Hashed, hash1, string.Empty,
+            HashedPasswordFormat.SHA1));
+    }
+
+    [TestMethod]
+    public void VerifyPassword_VerifiesLegacyShaHash_WithoutRehashing()
+    {
+        var salt = _encryptionService.CreateSaltKey(16);
+        var legacy = _encryptionService.CreatePasswordHash("password", salt, HashedPasswordFormat.SHA512);
+
+        Assert.IsTrue(_encryptionService.VerifyPassword("password", PasswordFormat.Hashed, legacy, salt,
+            HashedPasswordFormat.SHA512));
+        Assert.IsFalse(_encryptionService.VerifyPassword("password", PasswordFormat.Hashed, legacy, salt,
+            HashedPasswordFormat.SHA256));
+    }
+
+    [TestMethod]
+    public void PasswordHashNeedsUpgrade_TrueForLegacyOrReversible_FalseForPbkdf2()
+    {
+        var pbkdf2 = _encryptionService.HashPassword("password");
+        Assert.IsFalse(_encryptionService.PasswordHashNeedsUpgrade(PasswordFormat.Hashed, pbkdf2));
+
+        Assert.IsTrue(_encryptionService.PasswordHashNeedsUpgrade(PasswordFormat.Hashed, "5FDEFB16C983"));
+        Assert.IsTrue(_encryptionService.PasswordHashNeedsUpgrade(PasswordFormat.Clear, "password"));
+        Assert.IsTrue(_encryptionService.PasswordHashNeedsUpgrade(PasswordFormat.Encrypted, "cipher"));
+    }
+
+    [TestMethod]
+    public void VerifyPassword_Pbkdf2_IsPepperSensitive()
+    {
+        var peppered = new EncryptionService(new SecurityConfig { PasswordHashKey = "server-pepper" });
+        var hash = peppered.HashPassword("password");
+
+        //same pepper verifies, missing/different pepper does not
+        Assert.IsTrue(peppered.VerifyPassword("password", PasswordFormat.Hashed, hash, string.Empty,
+            HashedPasswordFormat.SHA1));
+        Assert.IsFalse(_encryptionService.VerifyPassword("password", PasswordFormat.Hashed, hash, string.Empty,
+            HashedPasswordFormat.SHA1));
     }
 }

--- a/src/Tests/Grand.Business.Common.Tests/Services/Security/EncryptionServiceTests.cs
+++ b/src/Tests/Grand.Business.Common.Tests/Services/Security/EncryptionServiceTests.cs
@@ -135,6 +135,33 @@ public class EncryptionServiceTests
     }
 
     [TestMethod]
+    public void PasswordHashNeedsUpgrade_TrueWhenEmbeddedIterationsBelowConfigured()
+    {
+        //hash created at the default cost, then verified against a service configured with a higher cost
+        var weakHash = _encryptionService.HashPassword("password");
+        var stronger = new EncryptionService(new SecurityConfig { PasswordHashIterations = 400_000 });
+
+        Assert.IsTrue(stronger.PasswordHashNeedsUpgrade(PasswordFormat.Hashed, weakHash));
+        Assert.IsFalse(stronger.PasswordHashNeedsUpgrade(PasswordFormat.Hashed, stronger.HashPassword("password")));
+    }
+
+    [TestMethod]
+    public void VerifyPassword_Pbkdf2_FailsClosedOnMalformedHash()
+    {
+        //corrupted stored hashes must not throw on the auth path - they simply do not match
+        foreach (var malformed in new[]
+                 {
+                     "PBKDF2$1$0$YQ==$YQ==", //zero iterations
+                     "PBKDF2$1$-5$YQ==$YQ==", //negative iterations
+                     "PBKDF2$1$210000$not-base64$YQ==", //invalid salt
+                     "PBKDF2$1$210000$YQ==", //too few segments
+                     "PBKDF2$1$210000$YQ==$" //empty hash
+                 })
+            Assert.IsFalse(_encryptionService.VerifyPassword("password", PasswordFormat.Hashed, malformed,
+                string.Empty, HashedPasswordFormat.SHA1), $"should fail closed for: {malformed}");
+    }
+
+    [TestMethod]
     public void VerifyPassword_Pbkdf2_IsPepperSensitive()
     {
         var peppered = new EncryptionService(new SecurityConfig { PasswordHashKey = "server-pepper" });

--- a/src/Tests/Grand.Business.Customers.Tests/Services/CustomerManagerServiceTests.cs
+++ b/src/Tests/Grand.Business.Customers.Tests/Services/CustomerManagerServiceTests.cs
@@ -28,6 +28,11 @@ public class CustomerManagerServiceTests
         _customerServiceMock = new Mock<ICustomerService>();
         _groupServiceMock = new Mock<IGroupService>();
         _encryptionServiceMock = new Mock<IEncryptionService>();
+        //emulate the real format-aware verification for the Clear-format credentials used by these tests
+        _encryptionServiceMock.Setup(e => e.VerifyPassword(It.IsAny<string>(), It.IsAny<PasswordFormat>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<HashedPasswordFormat>()))
+            .Returns((string entered, PasswordFormat _, string stored, string _, HashedPasswordFormat _) =>
+                entered == stored);
         _mediatorMock = new Mock<IMediator>();
         _customerHistoryPasswordServiceMock = new Mock<ICustomerHistoryPasswordService>();
         _customerSettings = new CustomerSettings {

--- a/src/Web/Grand.Web.AdminShared/Validators/Common/LoginValidator.cs
+++ b/src/Web/Grand.Web.AdminShared/Validators/Common/LoginValidator.cs
@@ -71,16 +71,8 @@ public class LoginValidator : BaseGrandValidator<LoginModel>
                     break;
                 case not null:
                     {
-                        var pwd = customer.PasswordFormatId switch {
-                            PasswordFormat.Clear => x.Password,
-                            PasswordFormat.Encrypted =>
-                                encryptionService.EncryptText(x.Password, customer.PasswordSalt),
-                            PasswordFormat.Hashed => encryptionService.CreatePasswordHash(x.Password,
-                                customer.PasswordSalt,
-                                customerSettings.HashedPasswordFormat),
-                            _ => throw new Exception("Password format not supported")
-                        };
-                        var isValid = pwd == customer.Password;
+                        var isValid = encryptionService.VerifyPassword(x.Password, customer.PasswordFormatId,
+                            customer.Password, customer.PasswordSalt, customerSettings.HashedPasswordFormat);
                         if (!isValid)
                         {
                             context.AddFailure(translationService.GetResource("Account.Login.WrongCredentials"));

--- a/src/Web/Grand.Web/App_Data/appsettings.json
+++ b/src/Web/Grand.Web/App_Data/appsettings.json
@@ -88,7 +88,13 @@
     "CookieSameSite": "Lax",
     "CookieSameSiteExternalAuth": "None",
     //Enabling this setting allows for verification of access to a specific controller and action in the admin panel using menu configuration.
-    "AuthorizeAdminMenu": false
+    "AuthorizeAdminMenu": false,
+    //Server-side secret ("pepper") mixed into the PBKDF2 password hash. Keep it OUT of the database (here or in a secret store).
+    //Optional but recommended. IMPORTANT: changing it invalidates existing PBKDF2 hashes (those customers must reset their password);
+    //legacy SHA hashes are not affected. Set it once, before going live. Empty = hash without a pepper.
+    "PasswordHashKey": "",
+    //PBKDF2 (HMAC-SHA256) iteration count for new/upgraded password hashes. Default 210000 (OWASP). Embedded per-hash, so it can be raised safely later.
+    "PasswordHashIterations": 210000
   },
   "Cache": {
     //Gets or sets a value indicating for default cache time in minutes"

--- a/src/Web/Grand.Web/Validators/Customer/ChangePasswordValidator.cs
+++ b/src/Web/Grand.Web/Validators/Customer/ChangePasswordValidator.cs
@@ -68,14 +68,9 @@ public class ChangePasswordValidator : BaseGrandValidator<ChangePasswordModel>
 
             if (customer is not null)
             {
-                var oldPwd = customer.PasswordFormatId switch {
-                    PasswordFormat.Encrypted => encryptionService.EncryptText(x.OldPassword,
-                        customer.PasswordSalt),
-                    PasswordFormat.Hashed => encryptionService.CreatePasswordHash(x.OldPassword,
-                        customer.PasswordSalt, customerSettings.HashedPasswordFormat),
-                    _ => x.OldPassword
-                };
-                if (oldPwd != customer.Password)
+                var oldPasswordValid = encryptionService.VerifyPassword(x.OldPassword, customer.PasswordFormatId,
+                    customer.Password, customer.PasswordSalt, customerSettings.HashedPasswordFormat);
+                if (!oldPasswordValid)
                     context.AddFailure(
                         translationService.GetResource("Account.ChangePassword.Errors.OldPasswordDoesntMatch"));
             }

--- a/src/Web/Grand.Web/Validators/Customer/DeleteAccountValidator.cs
+++ b/src/Web/Grand.Web/Validators/Customer/DeleteAccountValidator.cs
@@ -20,16 +20,9 @@ public class DeleteAccountValidator : BaseGrandValidator<DeleteAccountModel>
             .WithMessage(translationService.GetResource("Account.DeleteAccount.Fields.Password.Required"));
         RuleFor(x => x).Custom((x, context) =>
         {
-            var pwd = contextAccessor.WorkContext.CurrentCustomer.PasswordFormatId switch {
-                PasswordFormat.Clear => x.Password,
-                PasswordFormat.Encrypted => encryptionService.EncryptText(x.Password,
-                    contextAccessor.WorkContext.CurrentCustomer.PasswordSalt),
-                PasswordFormat.Hashed => encryptionService.CreatePasswordHash(x.Password,
-                    contextAccessor.WorkContext.CurrentCustomer.PasswordSalt,
-                    customerSettings.HashedPasswordFormat),
-                _ => throw new Exception("PasswordFormat not supported")
-            };
-            var isValid = pwd == contextAccessor.WorkContext.CurrentCustomer.Password;
+            var customer = contextAccessor.WorkContext.CurrentCustomer;
+            var isValid = encryptionService.VerifyPassword(x.Password, customer.PasswordFormatId, customer.Password,
+                customer.PasswordSalt, customerSettings.HashedPasswordFormat);
             if (!isValid) context.AddFailure(translationService.GetResource("Account.Login.WrongCredentials"));
         });
     }

--- a/src/Web/Grand.Web/Validators/Customer/LoginValidator.cs
+++ b/src/Web/Grand.Web/Validators/Customer/LoginValidator.cs
@@ -75,14 +75,8 @@ public class LoginValidator : BaseGrandValidator<LoginModel>
                     break;
                 case not null:
                     {
-                        var pwd = customer.PasswordFormatId switch {
-                            PasswordFormat.Clear => x.Password,
-                            PasswordFormat.Encrypted => encryptionService.EncryptText(x.Password, customer.PasswordSalt),
-                            PasswordFormat.Hashed => encryptionService.CreatePasswordHash(x.Password, customer.PasswordSalt,
-                                customerSettings.HashedPasswordFormat),
-                            _ => throw new Exception("PasswordFormat not supported")
-                        };
-                        var isValid = pwd == customer.Password;
+                        var isValid = encryptionService.VerifyPassword(x.Password, customer.PasswordFormatId,
+                            customer.Password, customer.PasswordSalt, customerSettings.HashedPasswordFormat);
                         if (!isValid)
                         {
                             context.AddFailure(translationService.GetResource("Account.Login.WrongCredentials"));


### PR DESCRIPTION
## Summary

Addresses **audit finding #1 (weak password hashing)**: customer passwords were hashed with fast, general-purpose SHA1/SHA-x (a 5-byte salt for the `Hashed` format), which is unsuitable for password storage. This switches new/changed passwords to **PBKDF2 (HMAC-SHA256, 210k iterations, 16-byte CSPRNG salt)** with an optional server-side **pepper** from configuration.

**No database schema change. No forced password reset.**

## How it works

- **Self-describing hash** stored in the existing `Customer.Password` field: `PBKDF2$1$<iterations>$<saltB64>$<hashB64>`. The algorithm and cost are known per record, so verification never depends on a global setting and different accounts can use different formats side by side. `PasswordSalt` is left empty for PBKDF2 (the salt is embedded).
- **Format-aware, constant-time verification** in `IEncryptionService.VerifyPassword(...)`: PBKDF2 is detected by prefix; anything else falls back to the legacy SHA path using the existing `CustomerSettings.HashedPasswordFormat`, so existing accounts keep working.
- **Transparent upgrade on login**: after a successful authentication against a weak/legacy credential, `CustomerManagerService.LoginCustomer` re-hashes to PBKDF2 and persists it. Storefront, admin and API web login all route through `LoginCustomer`.
- **De-duplication**: the previously copy-pasted `CreatePasswordHash(...) == Password` compare (customer manager + 4 validators) now goes through the single `VerifyPassword` entry point.

## Configuration (new, both optional)

Under `Security` in `appsettings.json`:
- `PasswordHashKey` — server-side pepper mixed into the hash. Keep it **out of source control** (env var `Security__PasswordHashKey` / secret store). Empty = no pepper. Changing it invalidates existing PBKDF2 hashes (legacy SHA unaffected), so set it once before go-live.
- `PasswordHashIterations` — default `210000` (OWASP). Embedded per hash, so it can be raised safely later.

## Tests

- `EncryptionServiceTests` — 11/11 (added: PBKDF2 round-trip, legacy SHA verify, upgrade detection, pepper sensitivity).
- `CustomerManagerServiceTests` — 5/5.

## Notes / follow-ups (not in this PR)

- Chose PBKDF2 (framework-native) over Argon2id to avoid a new NuGet dependency.
- The admin `HashedPasswordFormat` setting now only governs verification of pre-existing SHA hashes; new hashes are always PBKDF2.
- **Optional migration** to proactively upgrade dormant accounts: `Clear`/`Encrypted` passwords can be fully converted to clean PBKDF2 (plaintext is recoverable), and legacy `Hashed` could be onion-wrapped. Can follow in a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)