### PR TITLE
Add store-scoped online customers panel to Grand.Web.Store

### DIFF
--- a/src/Web/Grand.Web.Store/Areas/Store/Views/OnlineCustomer/List.cshtml
+++ b/src/Web/Grand.Web.Store/Areas/Store/Views/OnlineCustomer/List.cshtml
@@ -1,0 +1,80 @@
+@inject AdminAreaSettings adminAreaSettings
+@{
+    //page title
+    ViewBag.Title = Loc["Admin.Dashboards.OnlineCustomers"];
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="x_panel light form-fit">
+            <div class="x_title">
+                <div class="caption level-caption">
+                    <i class="fa fa-users"></i>
+                    @Loc["Admin.Dashboards.OnlineCustomers"]
+                </div>
+            </div>
+            <div class="x_content form">
+                <div id="onlinecustomers-grid"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+    $(document).ready(function () {
+        $("#onlinecustomers-grid").kendoGrid({
+            dataSource: {
+                transport: {
+                    read: {
+                        url: "@Html.Raw(Url.Action("List", "OnlineCustomer", new { area = Constants.AreaStore }))",
+                        type: "POST",
+                        dataType: "json",
+                        data: addAntiForgeryToken
+                    }
+                },
+                schema: {
+                    data: "Data",
+                    total: "Total",
+                    errors: "Errors"
+                },
+                error: function(e) {
+                    display_kendoui_grid_error(e);
+                    // Cancel the changes
+                    this.cancelChanges();
+                },
+                pageSize: @(adminAreaSettings.DefaultGridPageSize),
+                serverPaging: true,
+                serverFiltering: true,
+                serverSorting: true
+            },
+            pageable: {
+                refresh: true,
+                pageSizes: [@(adminAreaSettings.GridPageSizes)]
+            },
+            editable: {
+                confirmation: false,
+                mode: "inline"
+            },
+            scrollable: true,
+            columns: [{
+                field: "Id",
+                title: "@Loc["Admin.Dashboards.OnlineCustomers.Fields.CustomerInfo"]",
+                template: '<a class="k-link" href="@Url.Action("Edit", "Customer", new { area = Constants.AreaStore })/#=Id#">#:kendo.htmlEncode(CustomerInfo)#</a>',
+                width: 220,
+            }, {
+                field: "LastIpAddress",
+                title: "@Loc["Admin.Dashboards.OnlineCustomers.Fields.IPAddress"]",
+                width: 100,
+            }, {
+                field: "LastActivityDate",
+                title: "@Loc["Admin.Dashboards.OnlineCustomers.Fields.LastActivityDate"]",
+                width: 200,
+                type: "date",
+                format: "{0:G}"
+            }, {
+                field: "LastVisitedPage",
+                title: "@Loc["Admin.Dashboards.OnlineCustomers.Fields.LastVisitedPage"]",
+                width: 400,
+            }]
+        });
+    });
+</script>

--- a/src/Web/Grand.Web.Store/Controllers/OnlineCustomerController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/OnlineCustomerController.cs
@@ -8,6 +8,7 @@ using Grand.Web.AdminShared.Models.Customers;
 using Grand.Web.Common.DataSource;
 using Grand.Web.Common.Security.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 
 namespace Grand.Web.Store.Controllers;
 
@@ -59,18 +60,13 @@ public class OnlineCustomerController : BaseStoreController
             DateTime.UtcNow.AddMinutes(-_customerSettings.OnlineCustomerMinutes),
             null, _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId, null, command.Page - 1,
             command.PageSize);
-        var items = new List<OnlineCustomerModel>();
-        foreach (var x in customers)
-        {
-            var item = new OnlineCustomerModel {
-                Id = x.Id,
-                CustomerInfo = !string.IsNullOrEmpty(x.Email) ? x.Email : _translationService.GetResource("Admin.Customers.Guest"),
-                LastIpAddress = x.LastIpAddress,
-                LastActivityDate = _dateTimeService.ConvertToUserTime(x.LastActivityDateUtc, DateTimeKind.Utc),
-                LastVisitedPage = _customerSettings.StoreLastVisitedPage ? x.LastVisitedPage : _translationService.GetResource("Admin.Dashboards.OnlineCustomers.Fields.LastVisitedPage.Disabled")
-            };
-            items.Add(item);
-        }
+        var items = customers.Select(x => new OnlineCustomerModel {
+            Id = x.Id,
+            CustomerInfo = !string.IsNullOrEmpty(x.Email) ? x.Email : _translationService.GetResource("Admin.Customers.Guest"),
+            LastIpAddress = x.LastIpAddress,
+            LastActivityDate = _dateTimeService.ConvertToUserTime(x.LastActivityDateUtc, DateTimeKind.Utc),
+            LastVisitedPage = _customerSettings.StoreLastVisitedPage ? x.LastVisitedPage : _translationService.GetResource("Admin.Dashboards.OnlineCustomers.Fields.LastVisitedPage.Disabled")
+        }).ToList();
 
         var gridModel = new DataSourceResult {
             Data = items,

--- a/src/Web/Grand.Web.Store/Controllers/OnlineCustomerController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/OnlineCustomerController.cs
@@ -1,0 +1,84 @@
+using Grand.Business.Core.Interfaces.Common.Directory;
+using Grand.Business.Core.Interfaces.Common.Localization;
+using Grand.Business.Core.Interfaces.Customers;
+using Grand.Domain.Permissions;
+using Grand.Domain.Customers;
+using Grand.Infrastructure;
+using Grand.Web.AdminShared.Models.Customers;
+using Grand.Web.Common.DataSource;
+using Grand.Web.Common.Security.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Grand.Web.Store.Controllers;
+
+/// <summary>
+///     Lets a store manager see the customers of his own store who are currently online.
+/// </summary>
+[PermissionAuthorize(PermissionSystemName.Customers)]
+public class OnlineCustomerController : BaseStoreController
+{
+    #region Constructors
+
+    public OnlineCustomerController(ICustomerService customerService,
+        IDateTimeService dateTimeService,
+        CustomerSettings customerSettings,
+        ITranslationService translationService,
+        IContextAccessor contextAccessor)
+    {
+        _customerService = customerService;
+        _dateTimeService = dateTimeService;
+        _customerSettings = customerSettings;
+        _translationService = translationService;
+        _contextAccessor = contextAccessor;
+    }
+
+    #endregion
+
+    #region Fields
+
+    private readonly ICustomerService _customerService;
+    private readonly IDateTimeService _dateTimeService;
+    private readonly CustomerSettings _customerSettings;
+    private readonly ITranslationService _translationService;
+    private readonly IContextAccessor _contextAccessor;
+
+    #endregion
+
+    #region Methods
+
+    public IActionResult List()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    [PermissionAuthorizeAction(PermissionActionName.List)]
+    public async Task<IActionResult> List(DataSourceRequest command)
+    {
+        var customers = await _customerService.GetOnlineCustomers(
+            DateTime.UtcNow.AddMinutes(-_customerSettings.OnlineCustomerMinutes),
+            null, _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId, null, command.Page - 1,
+            command.PageSize);
+        var items = new List<OnlineCustomerModel>();
+        foreach (var x in customers)
+        {
+            var item = new OnlineCustomerModel {
+                Id = x.Id,
+                CustomerInfo = !string.IsNullOrEmpty(x.Email) ? x.Email : _translationService.GetResource("Admin.Customers.Guest"),
+                LastIpAddress = x.LastIpAddress,
+                LastActivityDate = _dateTimeService.ConvertToUserTime(x.LastActivityDateUtc, DateTimeKind.Utc),
+                LastVisitedPage = _customerSettings.StoreLastVisitedPage ? x.LastVisitedPage : _translationService.GetResource("Admin.Dashboards.OnlineCustomers.Fields.LastVisitedPage.Disabled")
+            };
+            items.Add(item);
+        }
+
+        var gridModel = new DataSourceResult {
+            Data = items,
+            Total = customers.TotalCount
+        };
+
+        return Json(gridModel);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Adds `OnlineCustomerController` to Grand.Web.Store, letting a store manager see customers of their own store who are currently online.
- Mirrors `Grand.Web.Admin`'s `OnlineCustomerController`/view, but filters by the manager's `StaffStoreId` and links to the store-scoped `Customer/Edit` action.

## Test plan
- [x] `dotnet build` on `Grand.Web.Store` succeeds
- [x] Manually verify the grid loads and only shows customers of the current store