### PR TITLE
Add missing default permissions for Store manager role on install

### DIFF
--- a/src/Modules/Grand.Module.Installer/Extensions/PermissionExtensions.cs
+++ b/src/Modules/Grand.Module.Installer/Extensions/PermissionExtensions.cs
@@ -214,7 +214,22 @@ public static class PermissionExtensions
                     StandardPermission.ManageCheckoutAttribute,
                     StandardPermission.ManageReports,
                     StandardPermission.ManageNews,
-                    StandardPermission.ManageBlog
+                    StandardPermission.ManageBlog,
+                    StandardPermission.ManageCustomers,
+                    StandardPermission.ManageCustomerAttribute,
+                    StandardPermission.ManageAddressAttribute,
+                    StandardPermission.ManageContactAttribute,
+                    StandardPermission.ManageSettings,
+                    StandardPermission.ManagePaymentMethods,
+                    StandardPermission.ManageShippingSettings,
+                    StandardPermission.ManageTaxSettings,
+                    StandardPermission.ManageCurrencies,
+                    StandardPermission.ManageDiscounts,
+                    StandardPermission.ManageGiftVouchers,
+                    StandardPermission.ManageLanguages,
+                    StandardPermission.ManageEmailAccounts,
+                    StandardPermission.ManageMessageTemplates,
+                    StandardPermission.ManagePages
                 ]
             },
 


### PR DESCRIPTION
## Summary
- Store owner (`StoreManager` customer group) functionality in `Grand.Web.Store` grew significantly (per-store Customers, Settings, Payment methods/settings/restrictions, Customer/Address/Contact attributes, Shipping, Tax, Currencies, Discounts, Gift vouchers, Languages, Email accounts, Message templates, Pages), but the default permission set granted to that role at install time was never updated.
- As a result, a freshly installed Store manager account could not reach these newer store-owner controllers/actions, even though `ManageAccessStoreManagerPanel` (the panel gate) was already granted.
- Adds the 15 corresponding `StandardPermission` entries to the `StoreManager` block in `PermissionExtensions.DefaultPermissions()`.
- Scope is intentionally install-time only — **no migration** of existing installations, so stores that already customized Store manager permissions are left untouched.
- Deliberately excluded: `ManageDocuments` (Documents tab is intentionally hidden for store managers), `ManagePlugins` and `ManageMessageQueue` (system-level/global concerns, not per-store).

## Test plan
- [ ] Fresh install and verify a Store manager account can access Customers, Settings, Payment, Customer/Address/Contact Attributes, Shipping, Tax, Currencies, Discounts, Gift Vouchers, Languages, Email Accounts, Message Templates, Pages under `/Store`
- [ ] Verify Documents tab remains hidden and Plugins/global Message Queue remain inaccessible for Store manager
- [ ] Verify existing installations are unaffected (no permission changes for already-provisioned customer groups)