### PR TITLE
Fix missing CSRF protection across storefront controllers

### DIFF
--- a/src/Plugins/Theme.Modern/Views/Modern/Shared/_Layout.cshtml
+++ b/src/Plugins/Theme.Modern/Views/Modern/Shared/_Layout.cshtml
@@ -19,6 +19,7 @@
     @await RenderSectionAsync("head", false)
 </head>
 <body>
+@Html.AntiForgeryToken()
 <resources asp-type="ScriptHeader"/>
 @await Component.InvokeAsync("Widget", new { widgetZone = "body_start_html_tag_after" })
 

--- a/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
+++ b/src/Web/Grand.Web.Common/Controllers/BasePublicController.cs
@@ -8,6 +8,7 @@ namespace Grand.Web.Common.Controllers;
 [ClosedStore]
 [Language]
 [Affiliate]
+[AutoValidateAntiforgeryToken]
 [SharedKernel.Attributes.ApiController]
 public abstract class BasePublicController : BaseController
 {

--- a/src/Web/Grand.Web/Controllers/AccountController.cs
+++ b/src/Web/Grand.Web/Controllers/AccountController.cs
@@ -195,7 +195,6 @@ public class AccountController : BasePublicController
     //available even when navigation is not allowed
     [PublicStore(true)]
     [ClosedStore(true)]
-    [AutoValidateAntiforgeryToken]
     [IgnoreApi]
     public virtual async Task<IActionResult> Login(LoginModel model, string returnUrl)
     {
@@ -367,7 +366,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [PublicStore(true)]
     public virtual async Task<ActionResult<PasswordRecoveryModel>> PasswordRecovery(PasswordRecoveryModel model)
     {
@@ -400,7 +398,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     //available even when navigation is not allowed
     [PublicStore(true)]
     public virtual async Task<IActionResult> PasswordRecoveryConfirm(PasswordRecoveryConfirmModel model)
@@ -447,7 +444,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     //available even when navigation is not allowed
     [PublicStore(true)]
     public virtual async Task<IActionResult> Register(RegisterModel model, string returnUrl)
@@ -570,7 +566,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     //available even when navigation is not allowed
     [PublicStore(true)]
     public virtual async Task<IActionResult> CheckUsernameAvailability(string username)
@@ -647,7 +642,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<ActionResult<CustomerInfoModel>> Info(CustomerInfoModel model)
     {
@@ -683,7 +677,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> RemoveExternalAssociation(string id,
         [FromServices] IExternalAuthenticationService openAuthenticationService)
@@ -733,7 +726,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> AddressDelete(string addressId)
     {
@@ -776,7 +768,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<ActionResult<AddressModel>> AddressAdd(CustomerAddressEditModel model,
         [FromServices] AddressSettings addressSettings)
@@ -841,7 +832,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<ActionResult<CustomerAddressEditModel>> AddressEdit(CustomerAddressEditModel model,
         [FromServices] AddressSettings addressSettings)
@@ -929,7 +919,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> ChangePassword(ChangePasswordModel model)
     {
@@ -965,7 +954,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> DeleteAccount(DeleteAccountModel model)
     {
@@ -1152,7 +1140,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> SubAccountAdd(SubAccountCreateModel model)
     {
@@ -1184,7 +1171,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> SubAccountEdit(SubAccountEditModel model)
     {
@@ -1203,7 +1189,6 @@ public class AccountController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> SubAccountDelete(string id)
     {

--- a/src/Web/Grand.Web/Controllers/BlogController.cs
+++ b/src/Web/Grand.Web/Controllers/BlogController.cs
@@ -130,7 +130,6 @@ public class BlogController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<ActionResult<AddBlogCommentModel>> BlogPost(AddBlogCommentModel model,
         [FromServices] IAclService aclService)

--- a/src/Web/Grand.Web/Controllers/CatalogController.cs
+++ b/src/Web/Grand.Web/Controllers/CatalogController.cs
@@ -318,7 +318,6 @@ public class CatalogController : BasePublicController
     #region Vendor reviews
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> VendorReviews(VendorReviewsModel model)
     {

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -59,7 +59,6 @@ public class ContactController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [ClosedStore(true)]
     [DenySystemAccount]
     public virtual async Task<ActionResult<ContactUsModel>> Index(

--- a/src/Web/Grand.Web/Controllers/KnowledgebaseController.cs
+++ b/src/Web/Grand.Web/Controllers/KnowledgebaseController.cs
@@ -264,7 +264,6 @@ public class KnowledgebaseController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> ArticleCommentAdd(KnowledgebaseArticleModel model,
         [FromServices] ICustomerService customerService)

--- a/src/Web/Grand.Web/Controllers/MerchandiseReturnController.cs
+++ b/src/Web/Grand.Web/Controllers/MerchandiseReturnController.cs
@@ -138,7 +138,6 @@ public class MerchandiseReturnController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     public virtual async Task<IActionResult> MerchandiseReturn(MerchandiseReturnModel model)
     {
         var order = await _orderService.GetOrderById(model.OrderId);

--- a/src/Web/Grand.Web/Controllers/NewsController.cs
+++ b/src/Web/Grand.Web/Controllers/NewsController.cs
@@ -91,7 +91,6 @@ public class NewsController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> NewsCommentAdd(AddNewsCommentModel model)
     {

--- a/src/Web/Grand.Web/Controllers/OrderController.cs
+++ b/src/Web/Grand.Web/Controllers/OrderController.cs
@@ -135,7 +135,6 @@ public class OrderController : BasePublicController
 
     //My account / Order details page / Add order note        
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     public virtual async Task<ActionResult<AddOrderNoteModel>> AddOrderNote(AddOrderNoteModel model)
     {
         if (!_orderSettings.AllowCustomerToAddOrderNote)
@@ -174,7 +173,6 @@ public class OrderController : BasePublicController
 
     //My account / Order details page / Complete payment
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     public virtual async Task<IActionResult> RePostPayment(string orderId)
     {
         var order = await _orderService.GetOrderById(orderId);

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -136,7 +136,6 @@ public class ProductController : BasePublicController
     #region Email a friend
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> ProductEmailAFriend(ProductEmailAFriendModel model)
     {
@@ -180,7 +179,6 @@ public class ProductController : BasePublicController
     #region Ask question
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> AskQuestionOnProduct(ProductAskQuestionSimpleModel model)
     {
@@ -549,7 +547,6 @@ public class ProductController : BasePublicController
     #region Product reviews
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> ProductReviews(
         ProductReviewsModel model)

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -301,7 +301,6 @@ public class ShoppingCartController : BasePublicController
     }
 
 
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     [HttpPost]
     public virtual async Task<IActionResult> UpdateQuantity(UpdateQuantityModel model)
@@ -497,7 +496,6 @@ public class ShoppingCartController : BasePublicController
         return RedirectToRoute("LoginCheckoutAsGuest", new { returnUrl = Url.RouteUrl("ShoppingCart") });
     }
 
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     [HttpPost]
     public virtual async Task<IActionResult> ApplyDiscountCoupon(DiscountCouponModel model)
@@ -541,7 +539,6 @@ public class ShoppingCartController : BasePublicController
         });
     }
 
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     [HttpPost]
     public virtual async Task<IActionResult> ApplyGiftVoucher(GiftVoucherCouponModel model)
@@ -586,7 +583,6 @@ public class ShoppingCartController : BasePublicController
         });
     }
 
-    [AutoValidateAntiforgeryToken]
     [HttpPost]
     public virtual async Task<IActionResult> GetEstimateShipping(EstimateShippingModel model)
     {

--- a/src/Web/Grand.Web/Controllers/VendorController.cs
+++ b/src/Web/Grand.Web/Controllers/VendorController.cs
@@ -128,7 +128,6 @@ public class VendorController : BasePublicController
 
     [HttpPost]
     [ActionName("ApplyVendor")]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     [CustomerGroupAuthorize(SystemCustomerGroupNames.Registered)]
     public virtual async Task<IActionResult> ApplyVendorSubmit(ApplyVendorModel model, [FromServices] ISeNameService seNameService)
@@ -195,7 +194,6 @@ public class VendorController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> ContactVendor(ContactVendorModel model)
     {

--- a/src/Web/Grand.Web/Controllers/WishlistController.cs
+++ b/src/Web/Grand.Web/Controllers/WishlistController.cs
@@ -111,7 +111,6 @@ public class WishlistController : BasePublicController
         return View(model);
     }
 
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     [HttpPost]
     public virtual async Task<IActionResult> UpdateQuantity(UpdateQuantityModel model)
@@ -208,7 +207,6 @@ public class WishlistController : BasePublicController
     }
 
     [HttpPost]
-    [AutoValidateAntiforgeryToken]
     [DenySystemAccount]
     public virtual async Task<IActionResult> EmailWishlist(WishlistEmailAFriendModel model,
         [FromServices] IMessageProviderService messageProviderService,

--- a/src/Web/Grand.Web/Views/Shared/_Layout.cshtml
+++ b/src/Web/Grand.Web/Views/Shared/_Layout.cshtml
@@ -19,6 +19,7 @@
     @await RenderSectionAsync("head", false)
 </head>
 <body>
+@Html.AntiForgeryToken()
 
 <resources asp-type="TemplateHeader"/>
 <resources asp-type="ScriptHeader"/>

--- a/src/Web/Grand.Web/Views/Shared/_LayoutPopup.cshtml
+++ b/src/Web/Grand.Web/Views/Shared/_LayoutPopup.cshtml
@@ -15,6 +15,7 @@
     <resources asp-type="HeadScript"/>
 </head>
 <body class="popup-window text-center px-3">
+@Html.AntiForgeryToken()
 <resources asp-type="ScriptHeader"/>
 <vc:widget widget-zone="body_start_html_tag_after" additional-data="null"></vc:widget>
 @RenderBody()

--- a/src/Web/Grand.Web/wwwroot/theme/script/public.common.js
+++ b/src/Web/Grand.Web/wwwroot/theme/script/public.common.js
@@ -12,6 +12,28 @@ function addAntiForgeryToken(data) {
     return data;
 };
 
+//attach the CSRF token as a header to every AJAX request (axios and jQuery),
+//so requests are covered regardless of body type (json/form/FormData)
+(function () {
+    var tokenInput = document.querySelector('input[name=__RequestVerificationToken]');
+    if (!tokenInput) {
+        return;
+    }
+    var token = tokenInput.value;
+
+    if (typeof axios !== 'undefined') {
+        axios.defaults.headers.common['X-CSRF-TOKEN'] = token;
+    }
+
+    if (typeof $ !== 'undefined' && typeof $.ajaxSetup === 'function') {
+        $.ajaxSetup({
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-CSRF-TOKEN', token);
+            }
+        });
+    }
+})();
+
 // runs an array of async functions in sequential order
 function seq(arr, callback, index) {
     // first call, without an index

--- a/src/Web/Grand.Web/wwwroot/theme/script/public.common.js
+++ b/src/Web/Grand.Web/wwwroot/theme/script/public.common.js
@@ -15,11 +15,11 @@ function addAntiForgeryToken(data) {
 //attach the CSRF token as a header to every AJAX request (axios and jQuery),
 //so requests are covered regardless of body type (json/form/FormData)
 (function () {
-    var tokenInput = document.querySelector('input[name=__RequestVerificationToken]');
+    const tokenInput = document.querySelector('input[name=__RequestVerificationToken]');
     if (!tokenInput) {
         return;
     }
-    var token = tokenInput.value;
+    const token = tokenInput.value;
 
     if (typeof axios !== 'undefined') {
         axios.defaults.headers.common['X-CSRF-TOKEN'] = token;


### PR DESCRIPTION
## Summary
- Apply `[AutoValidateAntiforgeryToken]` globally on `BasePublicController` (storefront), matching the convention already used by `BaseAdminController` / `BaseVendorController` / `BaseStoreController`. Previously only ~35 of ~70 POST actions in `Grand.Web` had the attribute applied manually, which is what the security report flagged as "Missing cross-site request forgery token validation" across many controllers.
- Remove the now-redundant per-action `[AutoValidateAntiforgeryToken]` attributes (35 occurrences across 12 controllers) since the base controller covers them.
- Render `@Html.AntiForgeryToken()` once in `_Layout.cshtml` / `_LayoutPopup.cshtml` (same pattern as `_AdminLayout.cshtml`), and attach that token as an `X-CSRF-TOKEN` header by default to all axios/jQuery AJAX requests in `public.common.js`. This was necessary because several existing AJAX call sites (add to cart, wishlist add/update, reservation date fill, push notification registration) posted without any CSRF token at all — enabling global validation without this fix would have broken those flows.

## Test plan
- [x] `dotnet build src/Web/Grand.Web/Grand.Web.csproj` succeeds with 0 errors
- [ ] Manually verify in a browser: add to cart, wishlist add/update, login/register/password recovery forms, and product reservation date picker all still work without 400 errors