### PR TITLE
Fix DI resolution error in ProductEmailAFriendValidator

### DIFF
--- a/src/Web/Grand.Web/Validators/Catalog/ProductEmailAFriendValidator.cs
+++ b/src/Web/Grand.Web/Validators/Catalog/ProductEmailAFriendValidator.cs
@@ -7,7 +7,7 @@ using Grand.Domain.Common;
 using Grand.Infrastructure;
 using Grand.Infrastructure.Models;
 using Grand.Infrastructure.Validators;
-using Grand.Web.Common.Security.Captcha;
+using Grand.SharedKernel.Captcha;
 using Grand.Web.Common.Validators;
 using Grand.Web.Models.Catalog;
 
@@ -20,7 +20,7 @@ public class ProductEmailAFriendValidator : BaseGrandValidator<ProductEmailAFrie
         IEnumerable<IValidatorConsumer<ICaptchaValidModel>> validatorsCaptcha,
         CaptchaSettings captchaSettings, CatalogSettings catalogSettings,
         IContextAccessor contextAccessor, IGroupService groupService, IProductService productService,
-        IHttpContextAccessor httpcontextAccessor, GoogleReCaptchaValidator googleReCaptchaValidator,
+        IHttpContextAccessor httpcontextAccessor, IGoogleReCaptchaValidator googleReCaptchaValidator,
         ITranslationService translationService)
         : base(validators)
     {


### PR DESCRIPTION
## Summary
- `ProductEmailAFriendValidator` requested the concrete `GoogleReCaptchaValidator` class in its constructor, but the container only registers it under its interface (`serviceCollection.AddHttpClient<IGoogleReCaptchaValidator, GoogleReCaptchaValidator>()` in `StartupApplication.cs`).
- This causes `System.InvalidOperationException: Unable to resolve service for type 'Grand.Web.Common.Security.Captcha.GoogleReCaptchaValidator' while attempting to activate 'Grand.Web.Validators.Catalog.ProductEmailAFriendValidator'` whenever the "Email a friend" form is submitted with captcha enabled on that page.
- Every other validator using captcha (`LoginValidator`, `RegisterValidator`, `ContactUsValidator`, `ProductAskQuestionSimpleValidator`, `ProductReviewsValidator`, etc.) already correctly depends on `IGoogleReCaptchaValidator` — this one was the odd one out.

## Fix
Changed the constructor parameter from `GoogleReCaptchaValidator` to `IGoogleReCaptchaValidator` (and updated the `using` accordingly), matching every other captcha-validating validator in the codebase.

## Test plan
- [x] `dotnet build src/Web/Grand.Web/Grand.Web.csproj` compiles with 0 C# errors
- [x] Manually submit the "Email a friend" form on a product page with captcha enabled and confirm no 500