### PR TITLE
Rename Mongo-specific repository methods to storage-neutral names, reduce overloads

### DIFF
--- a/src/Business/Grand.Business.Catalog/Events/Handlers/CategoryDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/CategoryDeletedEventHandler.cs
@@ -32,8 +32,8 @@ public class CategoryDeletedEventHandler : INotificationHandler<EntityDeleted<Ca
             x.EntityId == notification.Entity.Id && x.EntityName == EntityTypes.Category);
 
         //delete on the product
-        await _productRepository.PullFilter(string.Empty, x => x.ProductCategories, z => z.CategoryId,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductCategories,
+            z => z.CategoryId == notification.Entity.Id);
 
         //clear cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/CollectionDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/CollectionDeletedEventHandler.cs
@@ -31,8 +31,8 @@ public class CollectionDeletedEventHandler : INotificationHandler<EntityDeleted<
             x.EntityId == notification.Entity.Id && x.EntityName == EntityTypes.Collection);
 
         //delete on the product
-        await _productRepository.PullFilter(string.Empty, x => x.ProductCollections, z => z.CollectionId,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductCollections,
+            z => z.CollectionId == notification.Entity.Id);
 
         //clear cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/DiscountDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/DiscountDeletedEventHandler.cs
@@ -39,31 +39,31 @@ public class DiscountDeletedEventHandler : INotificationHandler<EntityDeleted<Di
         {
             case DiscountType.AssignedToSkus:
                 //delete on the product
-                await _productRepository.Pull(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
 
                 await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToCategories:
                 //delete on the category
-                await _categoryRepository.Pull(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _categoryRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.CATEGORIES_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToBrands:
                 //delete on the brand
-                await _brandRepository.Pull(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _brandRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.BRANDS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToCollections:
                 //delete on the collection
-                await _collectionRepository.Pull(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _collectionRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.COLLECTIONS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToVendors:
                 //delete on the vendor
-                await _vendorRepository.Pull(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _vendorRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);
                 break;

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/DiscountDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/DiscountDeletedEventHandler.cs
@@ -39,31 +39,31 @@ public class DiscountDeletedEventHandler : INotificationHandler<EntityDeleted<Di
         {
             case DiscountType.AssignedToSkus:
                 //delete on the product
-                await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.AppliedDiscounts, y => y == discount.Id);
 
                 await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToCategories:
                 //delete on the category
-                await _categoryRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _categoryRepository.RemoveCollectionFieldItem(string.Empty, x => x.AppliedDiscounts, y => y == discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.CATEGORIES_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToBrands:
                 //delete on the brand
-                await _brandRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _brandRepository.RemoveCollectionFieldItem(string.Empty, x => x.AppliedDiscounts, y => y == discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.BRANDS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToCollections:
                 //delete on the collection
-                await _collectionRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _collectionRepository.RemoveCollectionFieldItem(string.Empty, x => x.AppliedDiscounts, y => y == discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.COLLECTIONS_PATTERN_KEY);
                 break;
             case DiscountType.AssignedToVendors:
                 //delete on the vendor
-                await _vendorRepository.RemoveCollectionFieldValue(string.Empty, x => x.AppliedDiscounts, discount.Id);
+                await _vendorRepository.RemoveCollectionFieldItem(string.Empty, x => x.AppliedDiscounts, y => y == discount.Id);
                 //clear cache
                 await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);
                 break;

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/ProductDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/ProductDeletedEventHandler.cs
@@ -39,25 +39,25 @@ public class ProductDeletedEventHandler : INotificationHandler<EntityDeleted<Pro
     public async Task Handle(EntityDeleted<Product> notification, CancellationToken cancellationToken)
     {
         //delete related product
-        await _productRepository.PullFilter(string.Empty, x => x.RelatedProducts, z => z.ProductId2,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.RelatedProducts,
+            z => z.ProductId2 == notification.Entity.Id);
 
         //delete similar product
-        await _productRepository.PullFilter(string.Empty, x => x.SimilarProducts, z => z.ProductId2,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.SimilarProducts,
+            z => z.ProductId2 == notification.Entity.Id);
 
         //delete cross sales product
-        await _productRepository.Pull(string.Empty, x => x.CrossSellProduct, notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.CrossSellProduct, notification.Entity.Id);
 
         //delete recommended product
-        await _productRepository.Pull(string.Empty, x => x.RecommendedProduct, notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.RecommendedProduct, notification.Entity.Id);
 
         //delete review
         await _productReviewRepository.DeleteManyAsync(x => x.ProductId == notification.Entity.Id);
 
         //delete from shopping cart
-        await _customerRepository.PullFilter(string.Empty, x => x.ShoppingCartItems, z => z.ProductId,
-            notification.Entity.Id);
+        await _customerRepository.RemoveCollectionFieldItem(string.Empty, x => x.ShoppingCartItems,
+            z => z.ProductId == notification.Entity.Id);
 
         //delete customer group product
         await _customerGroupProductRepository.DeleteManyAsync(x => x.ProductId == notification.Entity.Id);

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/ProductDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/ProductDeletedEventHandler.cs
@@ -47,10 +47,10 @@ public class ProductDeletedEventHandler : INotificationHandler<EntityDeleted<Pro
             z => z.ProductId2 == notification.Entity.Id);
 
         //delete cross sales product
-        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.CrossSellProduct, notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.CrossSellProduct, y => y == notification.Entity.Id);
 
         //delete recommended product
-        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.RecommendedProduct, notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.RecommendedProduct, y => y == notification.Entity.Id);
 
         //delete review
         await _productReviewRepository.DeleteManyAsync(x => x.ProductId == notification.Entity.Id);

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/UpdateProductOnCartEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/UpdateProductOnCartEventHandler.cs
@@ -27,7 +27,7 @@ public class UpdateProductOnCartEventHandler : INotificationHandler<UpdateProduc
             item.IsGiftVoucher = notification.Product.IsGiftVoucher;
             item.IsShipEnabled = notification.Product.IsShipEnabled;
             item.IsTaxExempt = notification.Product.IsTaxExempt;
-            await _customerRepository.UpdateToSet(cs.Id, x => x.ShoppingCartItems, z => z.Id, item.Id, item);
+            await _customerRepository.UpdateCollectionFieldItem(cs.Id, x => x.ShoppingCartItems, z => z.Id == item.Id, item);
         }
     }
 }

--- a/src/Business/Grand.Business.Catalog/Events/Handlers/WarehouseDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Catalog/Events/Handlers/WarehouseDeletedEventHandler.cs
@@ -17,8 +17,8 @@ public class WarehouseDeletedEventHandler : INotificationHandler<EntityDeleted<W
 
     public async Task Handle(EntityDeleted<Warehouse> notification, CancellationToken cancellationToken)
     {
-        await _productRepository.PullFilter(string.Empty, x => x.ProductWarehouseInventory, z => z.WarehouseId,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductWarehouseInventory,
+            z => z.WarehouseId == notification.Entity.Id);
 
         await _productRepository.UpdateManyAsync(x => x.WarehouseId == notification.Entity.Id,
             UpdateBuilder<Product>.Create().Set(x => x.WarehouseId, ""));

--- a/src/Business/Grand.Business.Catalog/Services/Categories/ProductCategoryService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Categories/ProductCategoryService.cs
@@ -104,7 +104,7 @@ public class ProductCategoryService : IProductCategoryService
     {
         ArgumentNullException.ThrowIfNull(productCategory);
 
-        await _productRepository.AddToSet(productId, x => x.ProductCategories, productCategory);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductCategories, productCategory);
 
         //cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTCATEGORIES_PATTERN_KEY);
@@ -123,7 +123,7 @@ public class ProductCategoryService : IProductCategoryService
     {
         ArgumentNullException.ThrowIfNull(productCategory);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductCategories, z => z.Id, productCategory.Id,
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductCategories, z => z.Id == productCategory.Id,
             productCategory);
 
         //cache
@@ -143,7 +143,7 @@ public class ProductCategoryService : IProductCategoryService
     {
         ArgumentNullException.ThrowIfNull(productCategory);
 
-        await _productRepository.PullFilter(productId, x => x.ProductCategories, z => z.Id, productCategory.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductCategories, z => z.Id == productCategory.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTCATEGORIES_PATTERN_KEY);

--- a/src/Business/Grand.Business.Catalog/Services/Collections/ProductCollectionService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Collections/ProductCollectionService.cs
@@ -97,7 +97,7 @@ public class ProductCollectionService : IProductCollectionService
     {
         ArgumentNullException.ThrowIfNull(productCollection);
 
-        await _productRepository.AddToSet(productId, x => x.ProductCollections, productCollection);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductCollections, productCollection);
 
         //cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTCOLLECTIONS_PATTERN_KEY);
@@ -116,7 +116,7 @@ public class ProductCollectionService : IProductCollectionService
     {
         ArgumentNullException.ThrowIfNull(productCollection);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductCollections, z => z.Id, productCollection.Id,
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductCollections, z => z.Id == productCollection.Id,
             productCollection);
 
         //cache
@@ -136,7 +136,7 @@ public class ProductCollectionService : IProductCollectionService
     {
         ArgumentNullException.ThrowIfNull(productCollection);
 
-        await _productRepository.PullFilter(productId, x => x.ProductCollections, z => z.Id, productCollection.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductCollections, z => z.Id == productCollection.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTCOLLECTIONS_PATTERN_KEY);

--- a/src/Business/Grand.Business.Catalog/Services/Products/InventoryManageService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/InventoryManageService.cs
@@ -61,7 +61,7 @@ public class InventoryManageService : IInventoryManageService
             if (pwi.ReservedQuantity < 0)
                 pwi.ReservedQuantity = 0;
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductWarehouseInventory, z => z.Id, pwi.Id, pwi);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
 
             product.StockQuantity = product.ProductWarehouseInventory.Sum(x => x.StockQuantity);
@@ -89,8 +89,7 @@ public class InventoryManageService : IInventoryManageService
             if (combination.ReservedQuantity < 0)
                 combination.ReservedQuantity = 0;
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
         else
@@ -107,8 +106,7 @@ public class InventoryManageService : IInventoryManageService
             combination.StockQuantity = combination.WarehouseInventory.Sum(x => x.StockQuantity);
             combination.ReservedQuantity = combination.WarehouseInventory.Sum(x => x.ReservedQuantity);
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
@@ -188,8 +186,7 @@ public class InventoryManageService : IInventoryManageService
                 if (pwi.ReservedQuantity < 0)
                     pwi.ReservedQuantity = 0;
 
-                await _productRepository.UpdateToSet(product.Id, x => x.ProductWarehouseInventory, z => z.Id, pwi.Id,
-                    pwi);
+                await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
                 await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
                 break;
             }
@@ -215,8 +212,7 @@ public class InventoryManageService : IInventoryManageService
                     product.StockQuantity = product.ProductAttributeCombinations.Sum(x => x.StockQuantity);
                     product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
-                    await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                        combination.Id, combination);
+                    await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
                     await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
 
                     await UpdateStockProduct(product);
@@ -239,8 +235,7 @@ public class InventoryManageService : IInventoryManageService
                     product.StockQuantity = product.ProductAttributeCombinations.Sum(x => x.StockQuantity);
                     product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
-                    await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                        combination.Id, combination);
+                    await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
                     await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
                     await UpdateStockProduct(product);
                 }
@@ -469,7 +464,7 @@ public class InventoryManageService : IInventoryManageService
             if (pwi.ReservedQuantity < 0)
                 pwi.ReservedQuantity = 0;
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductWarehouseInventory, z => z.Id, pwi.Id, pwi);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
@@ -507,8 +502,7 @@ public class InventoryManageService : IInventoryManageService
 
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
@@ -527,8 +521,7 @@ public class InventoryManageService : IInventoryManageService
 
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
@@ -573,7 +566,7 @@ public class InventoryManageService : IInventoryManageService
             if (pwi.ReservedQuantity < 0)
                 pwi.ReservedQuantity = 0;
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductWarehouseInventory, z => z.Id, pwi.Id, pwi);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
@@ -607,8 +600,7 @@ public class InventoryManageService : IInventoryManageService
 
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
@@ -624,8 +616,7 @@ public class InventoryManageService : IInventoryManageService
 
             combination.ReservedQuantity = combination.WarehouseInventory.Sum(x => x.ReservedQuantity);
 
-            await _productRepository.UpdateToSet(product.Id, x => x.ProductAttributeCombinations, z => z.Id,
-                combination.Id, combination);
+            await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
             await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 

--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductAttributeService.cs
@@ -140,8 +140,7 @@ public class ProductAttributeService : IProductAttributeService
         ArgumentNullException.ThrowIfNull(productAttribute);
 
         //delete from all product collections
-        await _productRepository.PullFilter(string.Empty, x => x.ProductAttributeMappings, z => z.ProductAttributeId,
-            productAttribute.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductAttributeMappings, z => z.ProductAttributeId == productAttribute.Id);
 
         //delete from productAttribute collection
         await _productAttributeRepository.DeleteAsync(productAttribute);
@@ -171,8 +170,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(productAttributeMapping);
 
-        await _productRepository.PullFilter(productId, x => x.ProductAttributeMappings, z => z.Id,
-            productAttributeMapping.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductAttributeMappings, z => z.Id == productAttributeMapping.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -191,7 +189,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(productAttributeMapping);
 
-        await _productRepository.AddToSet(productId, x => x.ProductAttributeMappings, productAttributeMapping);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductAttributeMappings, productAttributeMapping);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -211,8 +209,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(productAttributeMapping);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductAttributeMappings, z => z.Id,
-            productAttributeMapping.Id, productAttributeMapping);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductAttributeMappings, z => z.Id == productAttributeMapping.Id, productAttributeMapping);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -244,8 +241,7 @@ public class ProductAttributeService : IProductAttributeService
             if (pav != null)
             {
                 pavs.ProductAttributeValues.Remove(pav);
-                await _productRepository.UpdateToSet(productId, x => x.ProductAttributeMappings, z => z.Id,
-                    productAttributeMappingId, pavs);
+                await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductAttributeMappings, z => z.Id == productAttributeMappingId, pavs);
             }
         }
 
@@ -275,8 +271,7 @@ public class ProductAttributeService : IProductAttributeService
         ArgumentNullException.ThrowIfNull(pam);
 
         pam.ProductAttributeValues.Add(productAttributeValue);
-        await _productRepository.UpdateToSet(productId, x => x.ProductAttributeMappings, z => z.Id,
-            productAttributeMappingId, pam);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductAttributeMappings, z => z.Id == productAttributeMappingId, pam);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -315,8 +310,7 @@ public class ProductAttributeService : IProductAttributeService
             pav.PictureId = productAttributeValue.PictureId;
             pav.Locales = productAttributeValue.Locales;
 
-            await _productRepository.UpdateToSet(productId, x => x.ProductAttributeMappings, z => z.Id,
-                productAttributeMappingId, pavs);
+            await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductAttributeMappings, z => z.Id == productAttributeMappingId, pavs);
         }
 
         //cache
@@ -340,7 +334,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(combination);
 
-        await _productRepository.PullFilter(productId, x => x.ProductAttributeCombinations, z => z.Id, combination.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductAttributeCombinations, z => z.Id == combination.Id);
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
 
@@ -358,7 +352,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(combination);
 
-        await _productRepository.AddToSet(productId, x => x.ProductAttributeCombinations, combination);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductAttributeCombinations, combination);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -377,8 +371,7 @@ public class ProductAttributeService : IProductAttributeService
     {
         ArgumentNullException.ThrowIfNull(combination);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductAttributeCombinations, z => z.Id, combination.Id,
-            combination);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));

--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductService.cs
@@ -665,7 +665,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(relatedProduct);
 
-        await _productRepository.AddToSet(productId, x => x.RelatedProducts, relatedProduct);
+        await _productRepository.AddToCollectionField(productId, x => x.RelatedProducts, relatedProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -683,7 +683,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(relatedProduct);
 
-        await _productRepository.PullFilter(productId, x => x.RelatedProducts, z => z.Id, relatedProduct.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.RelatedProducts, z => z.Id == relatedProduct.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -701,8 +701,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(relatedProduct);
 
-        await _productRepository.UpdateToSet(productId, x => x.RelatedProducts, z => z.Id, relatedProduct.Id,
-            relatedProduct);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.RelatedProducts, z => z.Id == relatedProduct.Id, relatedProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -719,7 +718,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(similarProduct);
 
-        await _productRepository.AddToSet(similarProduct.ProductId1, x => x.SimilarProducts, similarProduct);
+        await _productRepository.AddToCollectionField(similarProduct.ProductId1, x => x.SimilarProducts, similarProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, similarProduct.ProductId1));
@@ -736,8 +735,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(similarProduct);
 
-        await _productRepository.UpdateToSet(similarProduct.ProductId1, x => x.SimilarProducts, z => z.Id,
-            similarProduct.Id, similarProduct);
+        await _productRepository.UpdateCollectionFieldItem(similarProduct.ProductId1, x => x.SimilarProducts, z => z.Id == similarProduct.Id, similarProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, similarProduct.ProductId1));
@@ -754,8 +752,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(similarProduct);
 
-        await _productRepository.PullFilter(similarProduct.ProductId1, x => x.SimilarProducts, z => z.Id,
-            similarProduct.Id);
+        await _productRepository.RemoveCollectionFieldItem(similarProduct.ProductId1, x => x.SimilarProducts, z => z.Id == similarProduct.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, similarProduct.ProductId1));
@@ -777,7 +774,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(bundleProduct);
 
-        await _productRepository.AddToSet(productBundleId, x => x.BundleProducts, bundleProduct);
+        await _productRepository.AddToCollectionField(productBundleId, x => x.BundleProducts, bundleProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productBundleId));
@@ -795,8 +792,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(bundleProduct);
 
-        await _productRepository.UpdateToSet(productBundleId, x => x.BundleProducts, z => z.Id, bundleProduct.Id,
-            bundleProduct);
+        await _productRepository.UpdateCollectionFieldItem(productBundleId, x => x.BundleProducts, z => z.Id == bundleProduct.Id, bundleProduct);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productBundleId));
@@ -814,7 +810,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(bundleProduct);
 
-        await _productRepository.PullFilter(productBundleId, x => x.BundleProducts, z => z.Id, bundleProduct.Id);
+        await _productRepository.RemoveCollectionFieldItem(productBundleId, x => x.BundleProducts, z => z.Id == bundleProduct.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productBundleId));
@@ -835,7 +831,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(crossSellProduct);
 
-        await _productRepository.AddToSet(crossSellProduct.ProductId1, x => x.CrossSellProduct,
+        await _productRepository.AddToCollectionField(crossSellProduct.ProductId1, x => x.CrossSellProduct,
             crossSellProduct.ProductId2);
 
         //cache
@@ -853,7 +849,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(crossSellProduct);
 
-        await _productRepository.Pull(crossSellProduct.ProductId1, x => x.CrossSellProduct,
+        await _productRepository.RemoveCollectionFieldValue(crossSellProduct.ProductId1, x => x.CrossSellProduct,
             crossSellProduct.ProductId2);
 
         //cache
@@ -929,7 +925,7 @@ public class ProductService : IProductService
         ArgumentNullException.ThrowIfNull(productId);
         ArgumentNullException.ThrowIfNull(recommendedProductId);
 
-        await _productRepository.AddToSet(productId, x => x.RecommendedProduct, recommendedProductId);
+        await _productRepository.AddToCollectionField(productId, x => x.RecommendedProduct, recommendedProductId);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -945,7 +941,7 @@ public class ProductService : IProductService
         ArgumentNullException.ThrowIfNull(productId);
         ArgumentNullException.ThrowIfNull(recommendedProductId);
 
-        await _productRepository.Pull(productId, x => x.RecommendedProduct, recommendedProductId);
+        await _productRepository.RemoveCollectionFieldValue(productId, x => x.RecommendedProduct, recommendedProductId);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -964,7 +960,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(tierPrice);
 
-        await _productRepository.AddToSet(productId, x => x.TierPrices, tierPrice);
+        await _productRepository.AddToCollectionField(productId, x => x.TierPrices, tierPrice);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -982,7 +978,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(tierPrice);
 
-        await _productRepository.UpdateToSet(productId, x => x.TierPrices, z => z.Id, tierPrice.Id, tierPrice);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.TierPrices, z => z.Id == tierPrice.Id, tierPrice);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1000,7 +996,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(tierPrice);
 
-        await _productRepository.PullFilter(productId, x => x.TierPrices, x => x.Id, tierPrice.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.TierPrices, x => x.Id == tierPrice.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1021,7 +1017,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPrice);
 
-        await _productRepository.AddToSet(productPrice.ProductId, x => x.ProductPrices, productPrice);
+        await _productRepository.AddToCollectionField(productPrice.ProductId, x => x.ProductPrices, productPrice);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productPrice.ProductId));
@@ -1038,8 +1034,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPrice);
 
-        await _productRepository.UpdateToSet(productPrice.ProductId, x => x.ProductPrices, z => z.Id, productPrice.Id,
-            productPrice);
+        await _productRepository.UpdateCollectionFieldItem(productPrice.ProductId, x => x.ProductPrices, z => z.Id == productPrice.Id, productPrice);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productPrice.ProductId));
@@ -1056,7 +1051,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPrice);
 
-        await _productRepository.PullFilter(productPrice.ProductId, x => x.ProductPrices, x => x.Id, productPrice.Id);
+        await _productRepository.RemoveCollectionFieldItem(productPrice.ProductId, x => x.ProductPrices, x => x.Id == productPrice.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productPrice.ProductId));
@@ -1078,7 +1073,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPicture);
 
-        await _productRepository.AddToSet(productId, x => x.ProductPictures, productPicture);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductPictures, productPicture);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1096,8 +1091,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPicture);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductPictures, z => z.Id, productPicture.Id,
-            productPicture);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductPictures, z => z.Id == productPicture.Id, productPicture);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1115,7 +1109,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(productPicture);
 
-        await _productRepository.PullFilter(productId, x => x.ProductPictures, x => x.Id, productPicture.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductPictures, x => x.Id == productPicture.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1138,7 +1132,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(pwi);
 
-        await _productRepository.AddToSet(productId, x => x.ProductWarehouseInventory, pwi);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductWarehouseInventory, pwi);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1157,7 +1151,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(pwi);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductWarehouseInventory, z => z.Id, pwi.Id, pwi);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1174,7 +1168,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(pwi);
 
-        await _productRepository.PullFilter(productId, x => x.ProductWarehouseInventory, x => x.Id, pwi.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductWarehouseInventory, x => x.Id == pwi.Id);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1189,7 +1183,7 @@ public class ProductService : IProductService
         ArgumentNullException.ThrowIfNullOrEmpty(discountId);
         ArgumentNullException.ThrowIfNullOrEmpty(productId);
 
-        await _productRepository.Pull(productId, x => x.AppliedDiscounts, discountId);
+        await _productRepository.RemoveCollectionFieldValue(productId, x => x.AppliedDiscounts, discountId);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1200,7 +1194,7 @@ public class ProductService : IProductService
         if (string.IsNullOrEmpty(discountId))
             throw new ArgumentNullException(nameof(discountId));
 
-        await _productRepository.AddToSet(productId, x => x.AppliedDiscounts, discountId);
+        await _productRepository.AddToCollectionField(productId, x => x.AppliedDiscounts, discountId);
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
     }

--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductService.cs
@@ -849,8 +849,7 @@ public class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(crossSellProduct);
 
-        await _productRepository.RemoveCollectionFieldValue(crossSellProduct.ProductId1, x => x.CrossSellProduct,
-            crossSellProduct.ProductId2);
+        await _productRepository.RemoveCollectionFieldItem(crossSellProduct.ProductId1, x => x.CrossSellProduct, y => y == crossSellProduct.ProductId2);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, crossSellProduct.ProductId1));
@@ -941,7 +940,7 @@ public class ProductService : IProductService
         ArgumentNullException.ThrowIfNull(productId);
         ArgumentNullException.ThrowIfNull(recommendedProductId);
 
-        await _productRepository.RemoveCollectionFieldValue(productId, x => x.RecommendedProduct, recommendedProductId);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.RecommendedProduct, y => y == recommendedProductId);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -1183,7 +1182,7 @@ public class ProductService : IProductService
         ArgumentNullException.ThrowIfNullOrEmpty(discountId);
         ArgumentNullException.ThrowIfNullOrEmpty(productId);
 
-        await _productRepository.RemoveCollectionFieldValue(productId, x => x.AppliedDiscounts, discountId);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.AppliedDiscounts, y => y == discountId);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));

--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductTagService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductTagService.cs
@@ -137,7 +137,12 @@ public class ProductTagService : IProductTagService
         await _productTagRepository.UpdateAsync(productTag);
 
         //update on products
-        await _productRepository.UpdateToSet(x => x.ProductTags, previous.Name, productTag.Name);
+        var products = _productRepository.Table.Where(x => x.ProductTags.Contains(previous.Name)).ToList();
+        foreach (var product in products)
+        {
+            var tags = product.ProductTags.Select(t => t == previous.Name ? productTag.Name : t).ToList();
+            await _productRepository.UpdateField(product.Id, x => x.ProductTags, tags);
+        }
 
         //cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTTAG_PATTERN_KEY);
@@ -155,7 +160,7 @@ public class ProductTagService : IProductTagService
         ArgumentNullException.ThrowIfNull(productTag);
 
         //update product
-        await _productRepository.Pull(string.Empty, x => x.ProductTags, productTag.Name);
+        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.ProductTags, productTag.Name);
 
         //delete tag
         await _productTagRepository.DeleteAsync(productTag);
@@ -178,7 +183,7 @@ public class ProductTagService : IProductTagService
         ArgumentNullException.ThrowIfNull(productTag);
 
         //assign to product
-        await _productRepository.AddToSet(productId, x => x.ProductTags, productTag.Name);
+        await _productRepository.AddToCollectionField(productId, x => x.ProductTags, productTag.Name);
 
         //update product tag
         await _productTagRepository.UpdateField(productTag.Id, x => x.Count, productTag.Count + 1);
@@ -200,7 +205,7 @@ public class ProductTagService : IProductTagService
     {
         ArgumentNullException.ThrowIfNull(productTag);
 
-        await _productRepository.Pull(productId, x => x.ProductTags, productTag.Name);
+        await _productRepository.RemoveCollectionFieldValue(productId, x => x.ProductTags, productTag.Name);
 
         //update product tag
         await _productTagRepository.UpdateField(productTag.Id, x => x.Count, productTag.Count - 1);

--- a/src/Business/Grand.Business.Catalog/Services/Products/ProductTagService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/ProductTagService.cs
@@ -160,7 +160,7 @@ public class ProductTagService : IProductTagService
         ArgumentNullException.ThrowIfNull(productTag);
 
         //update product
-        await _productRepository.RemoveCollectionFieldValue(string.Empty, x => x.ProductTags, productTag.Name);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductTags, y => y == productTag.Name);
 
         //delete tag
         await _productTagRepository.DeleteAsync(productTag);
@@ -205,7 +205,7 @@ public class ProductTagService : IProductTagService
     {
         ArgumentNullException.ThrowIfNull(productTag);
 
-        await _productRepository.RemoveCollectionFieldValue(productId, x => x.ProductTags, productTag.Name);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductTags, y => y == productTag.Name);
 
         //update product tag
         await _productTagRepository.UpdateField(productTag.Id, x => x.Count, productTag.Count - 1);

--- a/src/Business/Grand.Business.Catalog/Services/Products/SpecificationAttributeService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/SpecificationAttributeService.cs
@@ -145,8 +145,7 @@ public class SpecificationAttributeService : ISpecificationAttributeService
         ArgumentNullException.ThrowIfNull(specificationAttribute);
 
         //delete from all product collections
-        await _productRepository.PullFilter(string.Empty, x => x.ProductSpecificationAttributes,
-            z => z.SpecificationAttributeId, specificationAttribute.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductSpecificationAttributes, z => z.SpecificationAttributeId == specificationAttribute.Id);
 
         await _specificationAttributeRepository.DeleteAsync(specificationAttribute);
 
@@ -193,8 +192,7 @@ public class SpecificationAttributeService : ISpecificationAttributeService
         ArgumentNullException.ThrowIfNull(specificationAttributeOption);
 
         //delete from all product collections
-        await _productRepository.PullFilter(string.Empty, x => x.ProductSpecificationAttributes,
-            z => z.SpecificationAttributeOptionId, specificationAttributeOption.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.ProductSpecificationAttributes, z => z.SpecificationAttributeOptionId == specificationAttributeOption.Id);
 
         var specificationAttribute = await GetSpecificationAttributeByOptionId(specificationAttributeOption.Id);
         var sao = specificationAttribute.SpecificationAttributeOptions.FirstOrDefault(x =>
@@ -227,7 +225,7 @@ public class SpecificationAttributeService : ISpecificationAttributeService
     {
         ArgumentNullException.ThrowIfNull(productSpecificationAttribute);
 
-        await _productRepository.AddToSet(productId, x => x.ProductSpecificationAttributes,
+        await _productRepository.AddToCollectionField(productId, x => x.ProductSpecificationAttributes,
             productSpecificationAttribute);
 
         //cache
@@ -247,8 +245,7 @@ public class SpecificationAttributeService : ISpecificationAttributeService
     {
         ArgumentNullException.ThrowIfNull(productSpecificationAttribute);
 
-        await _productRepository.UpdateToSet(productId, x => x.ProductSpecificationAttributes, z => z.Id,
-            productSpecificationAttribute.Id, productSpecificationAttribute);
+        await _productRepository.UpdateCollectionFieldItem(productId, x => x.ProductSpecificationAttributes, z => z.Id == productSpecificationAttribute.Id, productSpecificationAttribute);
 
         //cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));
@@ -267,8 +264,7 @@ public class SpecificationAttributeService : ISpecificationAttributeService
     {
         ArgumentNullException.ThrowIfNull(productSpecificationAttribute);
 
-        await _productRepository.PullFilter(productId, x => x.ProductSpecificationAttributes, x => x.Id,
-            productSpecificationAttribute.Id);
+        await _productRepository.RemoveCollectionFieldItem(productId, x => x.ProductSpecificationAttributes, x => x.Id == productSpecificationAttribute.Id);
 
         //clear cache
         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, productId));

--- a/src/Business/Grand.Business.Checkout/Services/Orders/OrderTagService.cs
+++ b/src/Business/Grand.Business.Checkout/Services/Orders/OrderTagService.cs
@@ -131,7 +131,7 @@ public class OrderTagService : IOrderTagService
         ArgumentNullException.ThrowIfNull(orderTag);
 
         //update orders
-        await _orderRepository.Pull(string.Empty, x => x.OrderTags, orderTag.Id);
+        await _orderRepository.RemoveCollectionFieldValue(string.Empty, x => x.OrderTags, orderTag.Id);
 
         //delete tag
         await _orderTagRepository.DeleteAsync(orderTag);
@@ -152,7 +152,7 @@ public class OrderTagService : IOrderTagService
     public virtual async Task AttachOrderTag(string orderTagId, string orderId)
     {
         //assign to product
-        await _orderRepository.AddToSet(orderId, x => x.OrderTags, orderTagId);
+        await _orderRepository.AddToCollectionField(orderId, x => x.OrderTags, orderTagId);
 
         var orderTag = await GetOrderTagById(orderTagId);
         //update product tag
@@ -173,7 +173,7 @@ public class OrderTagService : IOrderTagService
     /// <param name="orderId">Order ident</param>
     public virtual async Task DetachOrderTag(string orderTagId, string orderId)
     {
-        await _orderRepository.Pull(orderId, x => x.OrderTags, orderTagId);
+        await _orderRepository.RemoveCollectionFieldValue(orderId, x => x.OrderTags, orderTagId);
 
         var orderTag = await GetOrderTagById(orderTagId);
         //update product tag

--- a/src/Business/Grand.Business.Checkout/Services/Orders/OrderTagService.cs
+++ b/src/Business/Grand.Business.Checkout/Services/Orders/OrderTagService.cs
@@ -131,7 +131,7 @@ public class OrderTagService : IOrderTagService
         ArgumentNullException.ThrowIfNull(orderTag);
 
         //update orders
-        await _orderRepository.RemoveCollectionFieldValue(string.Empty, x => x.OrderTags, orderTag.Id);
+        await _orderRepository.RemoveCollectionFieldItem(string.Empty, x => x.OrderTags, y => y == orderTag.Id);
 
         //delete tag
         await _orderTagRepository.DeleteAsync(orderTag);
@@ -173,7 +173,7 @@ public class OrderTagService : IOrderTagService
     /// <param name="orderId">Order ident</param>
     public virtual async Task DetachOrderTag(string orderTagId, string orderId)
     {
-        await _orderRepository.RemoveCollectionFieldValue(orderId, x => x.OrderTags, orderTagId);
+        await _orderRepository.RemoveCollectionFieldItem(orderId, x => x.OrderTags, y => y == orderTagId);
 
         var orderTag = await GetOrderTagById(orderTagId);
         //update product tag

--- a/src/Business/Grand.Business.Common/Events/GroupDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Common/Events/GroupDeletedEventHandler.cs
@@ -27,11 +27,11 @@ public class GroupDeletedEventHandler : INotificationHandler<EntityDeleted<Custo
     public async Task Handle(EntityDeleted<CustomerGroup> notification, CancellationToken cancellationToken)
     {
         //delete from customers
-        await _customerRepository.Pull(string.Empty, x => x.Groups, notification.Entity.Id);
+        await _customerRepository.RemoveCollectionFieldValue(string.Empty, x => x.Groups, notification.Entity.Id);
 
         //delete tier prices on the product
-        await _productRepository.PullFilter(string.Empty, x => x.TierPrices, z => z.CustomerGroupId,
-            notification.Entity.Id);
+        await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.TierPrices,
+            z => z.CustomerGroupId == notification.Entity.Id);
 
         //clear cache
         await _cacheBase.RemoveByPrefix(CacheKey.PRODUCTS_PATTERN_KEY);

--- a/src/Business/Grand.Business.Common/Events/GroupDeletedEventHandler.cs
+++ b/src/Business/Grand.Business.Common/Events/GroupDeletedEventHandler.cs
@@ -27,7 +27,7 @@ public class GroupDeletedEventHandler : INotificationHandler<EntityDeleted<Custo
     public async Task Handle(EntityDeleted<CustomerGroup> notification, CancellationToken cancellationToken)
     {
         //delete from customers
-        await _customerRepository.RemoveCollectionFieldValue(string.Empty, x => x.Groups, notification.Entity.Id);
+        await _customerRepository.RemoveCollectionFieldItem(string.Empty, x => x.Groups, y => y == notification.Entity.Id);
 
         //delete tier prices on the product
         await _productRepository.RemoveCollectionFieldItem(string.Empty, x => x.TierPrices,

--- a/src/Business/Grand.Business.Common/Services/Addresses/AddressAttributeService.cs
+++ b/src/Business/Grand.Business.Common/Services/Addresses/AddressAttributeService.cs
@@ -156,7 +156,7 @@ public class AddressAttributeService : IAddressAttributeService
     {
         ArgumentNullException.ThrowIfNull(addressAttributeValue);
 
-        await _addressAttributeRepository.AddToSet(addressAttributeValue.AddressAttributeId,
+        await _addressAttributeRepository.AddToCollectionField(addressAttributeValue.AddressAttributeId,
             x => x.AddressAttributeValues, addressAttributeValue);
 
         await _cacheBase.RemoveByPrefix(CacheKey.ADDRESSATTRIBUTES_PATTERN_KEY);
@@ -174,8 +174,7 @@ public class AddressAttributeService : IAddressAttributeService
     {
         ArgumentNullException.ThrowIfNull(addressAttributeValue);
 
-        await _addressAttributeRepository.UpdateToSet(addressAttributeValue.AddressAttributeId,
-            x => x.AddressAttributeValues, z => z.Id, addressAttributeValue.Id, addressAttributeValue);
+        await _addressAttributeRepository.UpdateCollectionFieldItem(addressAttributeValue.AddressAttributeId, x => x.AddressAttributeValues, z => z.Id == addressAttributeValue.Id, addressAttributeValue);
 
         await _cacheBase.RemoveByPrefix(CacheKey.ADDRESSATTRIBUTES_PATTERN_KEY);
         await _cacheBase.RemoveByPrefix(CacheKey.ADDRESSATTRIBUTEVALUES_PATTERN_KEY);
@@ -192,8 +191,7 @@ public class AddressAttributeService : IAddressAttributeService
     {
         ArgumentNullException.ThrowIfNull(addressAttributeValue);
 
-        await _addressAttributeRepository.PullFilter(addressAttributeValue.AddressAttributeId,
-            x => x.AddressAttributeValues, z => z.Id, addressAttributeValue.Id);
+        await _addressAttributeRepository.RemoveCollectionFieldItem(addressAttributeValue.AddressAttributeId, x => x.AddressAttributeValues, z => z.Id == addressAttributeValue.Id);
 
         await _cacheBase.RemoveByPrefix(CacheKey.ADDRESSATTRIBUTES_PATTERN_KEY);
         await _cacheBase.RemoveByPrefix(CacheKey.ADDRESSATTRIBUTEVALUES_PATTERN_KEY);

--- a/src/Business/Grand.Business.Customers/Services/CustomerService.cs
+++ b/src/Business/Grand.Business.Customers/Services/CustomerService.cs
@@ -438,14 +438,14 @@ public class CustomerService : ICustomerService
             if (string.IsNullOrWhiteSpace(valueStr))
             {
                 //delete
-                await _customerRepository.PullFilter(customer.Id, x => x.UserFields,y => y.Key == prop.Key && y.StoreId == storeId);
+                await _customerRepository.RemoveCollectionFieldItem(customer.Id, x => x.UserFields,y => y.Key == prop.Key && y.StoreId == storeId);
                 customer.UserFields.Remove(prop);
             }
             else
             {
                 //update
                 prop.Value = valueStr;
-                await _customerRepository.UpdateToSet(customer.Id, x => x.UserFields,y => y.Key == prop.Key && y.StoreId == storeId, prop);
+                await _customerRepository.UpdateCollectionFieldItem(customer.Id, x => x.UserFields,y => y.Key == prop.Key && y.StoreId == storeId, prop);
             }
         }
         else
@@ -457,7 +457,7 @@ public class CustomerService : ICustomerService
                     Value = valueStr,
                     StoreId = storeId
                 };
-                await _customerRepository.AddToSet(customer.Id, x => x.UserFields, prop);
+                await _customerRepository.AddToCollectionField(customer.Id, x => x.UserFields, prop);
                 customer.UserFields.Add(prop);
             }
         }
@@ -670,7 +670,7 @@ public class CustomerService : ICustomerService
         ArgumentNullException.ThrowIfNull(customerGroup);
         ArgumentNullException.ThrowIfNullOrEmpty(customerId);
 
-        await _customerRepository.Pull(customerId, x => x.Groups, customerGroup.Id);
+        await _customerRepository.RemoveCollectionFieldValue(customerId, x => x.Groups, customerGroup.Id);
     }
 
     public virtual async Task InsertCustomerGroupInCustomer(CustomerGroup customerGroup, string customerId)
@@ -678,7 +678,7 @@ public class CustomerService : ICustomerService
         ArgumentNullException.ThrowIfNull(customerGroup);
         ArgumentNullException.ThrowIfNullOrEmpty(customerId);
 
-        await _customerRepository.AddToSet(customerId, x => x.Groups, customerGroup.Id);
+        await _customerRepository.AddToCollectionField(customerId, x => x.Groups, customerGroup.Id);
     }
 
     #endregion
@@ -690,7 +690,7 @@ public class CustomerService : ICustomerService
         ArgumentNullException.ThrowIfNull(address);
         ArgumentNullException.ThrowIfNullOrEmpty(customerId);
 
-        await _customerRepository.PullFilter(customerId, x => x.Addresses, x => x.Id, address.Id);
+        await _customerRepository.RemoveCollectionFieldItem(customerId, x => x.Addresses, x => x.Id == address.Id);
 
         //event notification
         await _mediator.EntityDeleted(address);
@@ -704,7 +704,7 @@ public class CustomerService : ICustomerService
         if (address.StateProvinceId == "0")
             address.StateProvinceId = "";
 
-        await _customerRepository.AddToSet(customerId, x => x.Addresses, address);
+        await _customerRepository.AddToCollectionField(customerId, x => x.Addresses, address);
 
         //event notification
         await _mediator.EntityInserted(address);
@@ -715,7 +715,7 @@ public class CustomerService : ICustomerService
         ArgumentNullException.ThrowIfNull(address);
         ArgumentNullException.ThrowIfNullOrEmpty(customerId);
 
-        await _customerRepository.UpdateToSet(customerId, x => x.Addresses, z => z.Id, address.Id, address);
+        await _customerRepository.UpdateCollectionFieldItem(customerId, x => x.Addresses, z => z.Id == address.Id, address);
 
         //event notification
         await _mediator.EntityUpdated(address);
@@ -746,7 +746,7 @@ public class CustomerService : ICustomerService
     {
         ArgumentNullException.ThrowIfNull(shoppingCartItem);
 
-        await _customerRepository.PullFilter(customerId, x => x.ShoppingCartItems, x => x.Id, shoppingCartItem.Id);
+        await _customerRepository.RemoveCollectionFieldItem(customerId, x => x.ShoppingCartItems, x => x.Id == shoppingCartItem.Id);
 
         if (shoppingCartItem.ShoppingCartTypeId == ShoppingCartType.ShoppingCart)
             await UpdateCustomerField(customerId, x => x.LastUpdateCartDateUtc, DateTime.UtcNow);
@@ -757,7 +757,7 @@ public class CustomerService : ICustomerService
     public virtual async Task ClearShoppingCartItem(string customerId, IList<ShoppingCartItem> cart)
     {
         foreach (var item in cart)
-            await _customerRepository.PullFilter(customerId, x => x.ShoppingCartItems, x => x.Id, item.Id);
+            await _customerRepository.RemoveCollectionFieldItem(customerId, x => x.ShoppingCartItems, x => x.Id == item.Id);
 
         if (cart.Any(c => c.ShoppingCartTypeId is ShoppingCartType.ShoppingCart or ShoppingCartType.Auctions))
             await UpdateCustomerField(customerId, x => x.LastUpdateCartDateUtc, DateTime.UtcNow);
@@ -769,7 +769,7 @@ public class CustomerService : ICustomerService
     {
         ArgumentNullException.ThrowIfNull(shoppingCartItem);
 
-        await _customerRepository.AddToSet(customerId, x => x.ShoppingCartItems, shoppingCartItem);
+        await _customerRepository.AddToCollectionField(customerId, x => x.ShoppingCartItems, shoppingCartItem);
 
         if (shoppingCartItem.ShoppingCartTypeId == ShoppingCartType.ShoppingCart)
             await UpdateCustomerField(customerId, x => x.LastUpdateCartDateUtc, DateTime.UtcNow);
@@ -781,8 +781,7 @@ public class CustomerService : ICustomerService
     {
         ArgumentNullException.ThrowIfNull(shoppingCartItem);
 
-        await _customerRepository.UpdateToSet(customerId, x => x.ShoppingCartItems, z => z.Id, shoppingCartItem.Id,
-            shoppingCartItem);
+        await _customerRepository.UpdateCollectionFieldItem(customerId, x => x.ShoppingCartItems, z => z.Id == shoppingCartItem.Id, shoppingCartItem);
 
         if (shoppingCartItem.ShoppingCartTypeId == ShoppingCartType.ShoppingCart)
             await UpdateCustomerField(customerId, x => x.LastUpdateCartDateUtc, DateTime.UtcNow);

--- a/src/Business/Grand.Business.Customers/Services/CustomerService.cs
+++ b/src/Business/Grand.Business.Customers/Services/CustomerService.cs
@@ -670,7 +670,7 @@ public class CustomerService : ICustomerService
         ArgumentNullException.ThrowIfNull(customerGroup);
         ArgumentNullException.ThrowIfNullOrEmpty(customerId);
 
-        await _customerRepository.RemoveCollectionFieldValue(customerId, x => x.Groups, customerGroup.Id);
+        await _customerRepository.RemoveCollectionFieldItem(customerId, x => x.Groups, y => y == customerGroup.Id);
     }
 
     public virtual async Task InsertCustomerGroupInCustomer(CustomerGroup customerGroup, string customerId)

--- a/src/Business/Grand.Business.Customers/Services/VendorService.cs
+++ b/src/Business/Grand.Business.Customers/Services/VendorService.cs
@@ -150,7 +150,7 @@ public class VendorService : IVendorService
     {
         ArgumentNullException.ThrowIfNull(vendorNote);
 
-        await _vendorRepository.AddToSet(vendorId, x => x.VendorNotes, vendorNote);
+        await _vendorRepository.AddToCollectionField(vendorId, x => x.VendorNotes, vendorNote);
 
         //event notification
         await _mediator.EntityInserted(vendorNote);
@@ -165,7 +165,7 @@ public class VendorService : IVendorService
     {
         ArgumentNullException.ThrowIfNull(vendorNote);
 
-        await _vendorRepository.PullFilter(vendorId, x => x.VendorNotes, x => x.Id, vendorNote.Id);
+        await _vendorRepository.RemoveCollectionFieldItem(vendorId, x => x.VendorNotes, x => x.Id == vendorNote.Id);
 
         //event notification
         await _mediator.EntityDeleted(vendorNote);

--- a/src/Business/Grand.Business.Marketing/Services/Customers/CustomerTagService.cs
+++ b/src/Business/Grand.Business.Marketing/Services/Customers/CustomerTagService.cs
@@ -57,7 +57,7 @@ public class CustomerTagService : ICustomerTagService
         ArgumentNullException.ThrowIfNull(customerTag);
 
         //update customer
-        await _customerRepository.Pull(string.Empty, x => x.CustomerTags, customerTag.Id);
+        await _customerRepository.RemoveCollectionFieldValue(string.Empty, x => x.CustomerTags, customerTag.Id);
 
         //delete
         await _customerTagRepository.DeleteAsync(customerTag);
@@ -131,7 +131,7 @@ public class CustomerTagService : ICustomerTagService
     /// </summary>
     public virtual async Task InsertTagToCustomer(string customerTagId, string customerId)
     {
-        await _customerRepository.AddToSet(customerId, x => x.CustomerTags, customerTagId);
+        await _customerRepository.AddToCollectionField(customerId, x => x.CustomerTags, customerTagId);
     }
 
     /// <summary>
@@ -139,7 +139,7 @@ public class CustomerTagService : ICustomerTagService
     /// </summary>
     public virtual async Task DeleteTagFromCustomer(string customerTagId, string customerId)
     {
-        await _customerRepository.Pull(customerId, x => x.CustomerTags, customerTagId);
+        await _customerRepository.RemoveCollectionFieldValue(customerId, x => x.CustomerTags, customerTagId);
     }
 
     /// <summary>

--- a/src/Business/Grand.Business.Marketing/Services/Customers/CustomerTagService.cs
+++ b/src/Business/Grand.Business.Marketing/Services/Customers/CustomerTagService.cs
@@ -57,7 +57,7 @@ public class CustomerTagService : ICustomerTagService
         ArgumentNullException.ThrowIfNull(customerTag);
 
         //update customer
-        await _customerRepository.RemoveCollectionFieldValue(string.Empty, x => x.CustomerTags, customerTag.Id);
+        await _customerRepository.RemoveCollectionFieldItem(string.Empty, x => x.CustomerTags, y => y == customerTag.Id);
 
         //delete
         await _customerTagRepository.DeleteAsync(customerTag);
@@ -139,7 +139,7 @@ public class CustomerTagService : ICustomerTagService
     /// </summary>
     public virtual async Task DeleteTagFromCustomer(string customerTagId, string customerId)
     {
-        await _customerRepository.RemoveCollectionFieldValue(customerId, x => x.CustomerTags, customerTagId);
+        await _customerRepository.RemoveCollectionFieldItem(customerId, x => x.CustomerTags, y => y == customerTagId);
     }
 
     /// <summary>

--- a/src/Core/Grand.Data/IRepository.cs
+++ b/src/Core/Grand.Data/IRepository.cs
@@ -126,15 +126,6 @@ public interface IRepository<T> where T : BaseEntity
     Task RemoveCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, bool>> elemFieldMatch);
 
     /// <summary>
-    ///     Delete subdocument
-    /// </summary>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element);
-
-    /// <summary>
     ///     Delete entity
     /// </summary>
     /// <param name="entity">Entity</param>

--- a/src/Core/Grand.Data/IRepository.cs
+++ b/src/Core/Grand.Data/IRepository.cs
@@ -101,21 +101,7 @@ public interface IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="value"></param>
     /// <returns></returns>
-    Task AddToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value);
-
-    /// <summary>
-    ///     Update subdocument
-    /// </summary>
-    /// <typeparam name="U">Document</typeparam>
-    /// <typeparam name="Z">Subdocuments</typeparam>
-    /// <param name="id">Ident of entitie</param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="elemMatch">Subdocument ident value</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    /// <returns></returns>
-    Task UpdateToSet<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, Z>> elemFieldMatch,
-        Z elemMatch, U value);
+    Task AddToCollectionField<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value);
 
     /// <summary>
     ///     Update subdocument
@@ -123,38 +109,13 @@ public interface IRepository<T> where T : BaseEntity
     /// <typeparam name="U">Document</typeparam>
     /// <param name="id">Ident of entitie</param>
     /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
+    /// <param name="elemFieldMatch">Subdocument predicate to match</param>
     /// <param name="value">Subdocument - to update (all values)</param>
     /// <returns></returns>
-    Task UpdateToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, bool>> elemFieldMatch,
+    Task UpdateCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, bool>> elemFieldMatch,
         U value);
 
     /// <summary>
-    ///     Update subdocuments
-    /// </summary>
-    /// <typeparam name="T">Document</typeparam>
-    /// <typeparam name="U"></typeparam>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    /// <returns></returns>
-    Task UpdateToSet<U>(Expression<Func<T, IEnumerable<U>>> field, U elemFieldMatch, U value);
-
-
-    /// <summary>
-    ///     Delete subdocument
-    /// </summary>
-    /// <typeparam name="U"></typeparam>
-    /// <typeparam name="Z"></typeparam>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch"></param>
-    /// <param name="elemMatch"></param>
-    /// <returns></returns>
-    Task PullFilter<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, Z>> elemFieldMatch,
-        Z elemMatch);
-
-    /// <summary>
     ///     Delete subdocument
     /// </summary>
     /// <typeparam name="U"></typeparam>
@@ -162,7 +123,7 @@ public interface IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="elemFieldMatch"></param>
     /// <returns></returns>
-    Task PullFilter<U>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, bool>> elemFieldMatch);
+    Task RemoveCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field, Expression<Func<U, bool>> elemFieldMatch);
 
     /// <summary>
     ///     Delete subdocument
@@ -171,7 +132,7 @@ public interface IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="element"></param>
     /// <returns></returns>
-    Task Pull(string id, Expression<Func<T, IEnumerable<string>>> field, string element);
+    Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element);
 
     /// <summary>
     ///     Delete entity

--- a/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
+++ b/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
@@ -241,7 +241,7 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="value"></param>
     /// <returns></returns>
-    public virtual Task AddToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value)
+    public virtual Task AddToCollectionField<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value)
     {
         var collection = Database.GetCollection(Collection.Name);
         var entity = collection.FindById(new BsonValue(id));
@@ -265,49 +265,11 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
     ///     Update subdocument
     /// </summary>
     /// <typeparam name="U">Document</typeparam>
-    /// <typeparam name="Z">Subdocuments</typeparam>
     /// <param name="id">Ident of entitie</param>
     /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="elemMatch">Subdocument ident value</param>
+    /// <param name="elemFieldMatch">Subdocument predicate to match</param>
     /// <param name="value">Subdocument - to update (all values)</param>
-    public virtual Task UpdateToSet<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, Z>> elemFieldMatch, Z elemMatch, U value)
-    {
-        var collection = Database.GetCollection(Collection.Name);
-        var entity = collection.FindById(new BsonValue(id));
-        var fieldName = ((MemberExpression)field.Body).Member.Name;
-
-        var member = ((MemberExpression)elemFieldMatch.Body).Member;
-        var dBFieldName = member.GetCustomAttribute<DBFieldNameAttribute>();
-        var elementfieldName = dBFieldName?.Name ?? member.Name;
-
-        if (entity[fieldName].IsArray)
-        {
-            var bsonValue = BsonMapper.Global.Serialize(value);
-            var list = entity[fieldName].AsArray.ToList();
-            var document = list.FirstOrDefault(x => x[elementfieldName] == new BsonValue(elemMatch));
-            if (document == null) return Task.CompletedTask;
-
-            foreach (var key in bsonValue.AsDocument.Keys) document[key] = bsonValue[key];
-            entity[fieldName] = new BsonArray(list);
-            entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-            entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
-            collection.Update(entity);
-        }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    ///     Update subdocument
-    /// </summary>
-    /// <typeparam name="U">Document</typeparam>
-    /// <param name="id">Ident of entitie</param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    public virtual Task UpdateToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
+    public virtual Task UpdateCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
         Expression<Func<U, bool>> elemFieldMatch, U value)
     {
         var collection = Database.GetCollection(Collection.Name);
@@ -342,116 +304,40 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
     }
 
     /// <summary>
-    ///     Update subdocuments
-    /// </summary>
-    /// <typeparam name="T">Document</typeparam>
-    /// <typeparam name="U"></typeparam>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    /// <returns></returns>
-    public virtual Task UpdateToSet<U>(Expression<Func<T, IEnumerable<U>>> field, U elemFieldMatch, U value)
-    {
-        var collection = Database.GetCollection(Collection.Name);
-        var fieldName = ((MemberExpression)field.Body).Member.Name;
-        var records = collection.Find(Query.EQ($"{fieldName}[*] ANY", elemFieldMatch.ToString())).ToList();
-        foreach (var entity in records)
-            if (entity[fieldName].IsArray)
-            {
-                var bsonValue = BsonMapper.Global.Serialize(value);
-                var oldbsonValue = BsonMapper.Global.Serialize(elemFieldMatch);
-                var list = entity[fieldName].AsArray.ToList();
-                if (list.Any())
-                {
-                    list.Add(bsonValue);
-                    list.Remove(oldbsonValue);
-                    entity[fieldName] = new BsonArray(list);
-                    entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-                    entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
-                    collection.Update(entity);
-                }
-            }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
     ///     Delete subdocument
     /// </summary>
     /// <typeparam name="U"></typeparam>
-    /// <typeparam name="Z"></typeparam>
     /// <param name="id"></param>
     /// <param name="field"></param>
     /// <param name="elemFieldMatch"></param>
-    /// <param name="elemMatch"></param>
     /// <returns></returns>
-    public virtual Task PullFilter<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, Z>> elemFieldMatch, Z elemMatch)
+    public virtual Task RemoveCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
+        Expression<Func<U, bool>> elemFieldMatch)
     {
         var collection = Database.GetCollection(Collection.Name);
         var fieldName = ((MemberExpression)field.Body).Member.Name;
-
-        var member = ((MemberExpression)elemFieldMatch.Body).Member;
-        var dBFieldName = member.GetCustomAttribute<DBFieldNameAttribute>();
-        var elementfieldName = dBFieldName?.Name ?? member.Name;
+        var predicate = elemFieldMatch.Compile();
 
         if (string.IsNullOrEmpty(id))
         {
-            //update many
             var entities = collection.FindAll();
             foreach (var entity in entities) UpdateEntity(entity);
         }
         else
         {
-            //update one
             var entity = collection.FindById(new BsonValue(id));
             UpdateEntity(entity);
         }
 
         void UpdateEntity(BsonDocument entity)
         {
-            if (entity != null && entity[fieldName].IsArray)
-            {
-                var bsonValue = BsonMapper.Global.Serialize(elemMatch);
-                var list = entity[fieldName].AsArray.ToList();
-                var documents = list.Where(x => x[elementfieldName] == new BsonValue(elemMatch)).ToList();
-                if (documents.Any())
-                {
-                    foreach (var document in documents) list.Remove(document);
-                    entity[fieldName] = new BsonArray(list);
-                    entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-                    entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
-                    collection.Update(entity);
-                }
-            }
-        }
+            if (entity == null || !entity[fieldName].IsArray) return;
 
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    ///     Delete subdocument
-    /// </summary>
-    /// <typeparam name="U"></typeparam>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch"></param>
-    /// <returns></returns>
-    public virtual Task PullFilter<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, bool>> elemFieldMatch)
-    {
-        var collection = Database.GetCollection(Collection.Name);
-        var entity = collection.FindById(new BsonValue(id));
-        var fieldName = ((MemberExpression)field.Body).Member.Name;
-        if (entity == null) return Task.CompletedTask;
-
-        if (entity[fieldName].IsArray)
-        {
             var list = BsonMapper.Global.Deserialize<IList<U>>(entity[fieldName]).ToList();
-            var position = list.FirstOrDefault(elemFieldMatch.Compile());
-            if (position == null) return Task.CompletedTask;
+            var matches = list.Where(predicate).ToList();
+            if (matches.Count == 0) return;
 
-            list.Remove(position);
+            foreach (var match in matches) list.Remove(match);
 
             var updatelist = BsonMapper.Global.Serialize<IList<U>>(list);
             entity[fieldName] = updatelist;
@@ -470,7 +356,7 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="element"></param>
     /// <returns></returns>
-    public virtual Task Pull(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
+    public virtual Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
     {
         var collection = Database.GetCollection(Collection.Name);
         var fieldName = ((MemberExpression)field.Body).Member.Name;

--- a/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
+++ b/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
@@ -13,6 +13,9 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
 {
     #region Fields
 
+    private const string UpdatedOnUtcField = "UpdatedOnUtc";
+    private const string UpdatedByField = "UpdatedBy";
+
     private readonly IAuditInfoProvider _auditInfoProvider;
 
     /// <summary>
@@ -152,8 +155,8 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
         var entity = Database.GetCollection(typeof(T).Name).FindById(new BsonValue(id));
         var bsonValue = BsonMapper.Global.Serialize(value);
         entity[GetName(expression)] = bsonValue;
-        entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-        entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
+        entity[UpdatedOnUtcField] = _auditInfoProvider.GetCurrentDateTime();
+        entity[UpdatedByField] = _auditInfoProvider.GetCurrentUser();
         Database.GetCollection(typeof(T).Name).Update(entity);
 
         return Task.CompletedTask;
@@ -214,7 +217,7 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
         return Task.CompletedTask;
     }
 
-    private Task Update(T entity, UpdateBuilder<T> updateBuilder)
+    private void Update(T entity, UpdateBuilder<T> updateBuilder)
     {
         foreach (var item in updateBuilder.ExpressionFields)
         {
@@ -230,7 +233,6 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
         entity!.UpdatedBy = _auditInfoProvider.GetCurrentUser();
 
         Collection.Update(entity);
-        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -253,8 +255,8 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
             var list = entity[fieldName].AsArray.ToList();
             list.Add(bsonValue);
             entity[fieldName] = new BsonArray(list);
-            entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-            entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
+            entity[UpdatedOnUtcField] = _auditInfoProvider.GetCurrentDateTime();
+            entity[UpdatedByField] = _auditInfoProvider.GetCurrentUser();
             collection.Update(entity);
         }
 
@@ -294,8 +296,8 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
 
             var updateList = BsonMapper.Global.Serialize<IList<U>>(list);
             entity[fieldName] = updateList;
-            entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-            entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
+            entity[UpdatedOnUtcField] = _auditInfoProvider.GetCurrentDateTime();
+            entity[UpdatedByField] = _auditInfoProvider.GetCurrentUser();
 
             collection.Update(entity);
         }
@@ -341,8 +343,8 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
 
             var updatelist = BsonMapper.Global.Serialize<IList<U>>(list);
             entity[fieldName] = updatelist;
-            entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-            entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
+            entity[UpdatedOnUtcField] = _auditInfoProvider.GetCurrentDateTime();
+            entity[UpdatedByField] = _auditInfoProvider.GetCurrentUser();
             collection.Update(entity);
         }
 

--- a/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
+++ b/src/Core/Grand.Data/LiteDb/LiteDBRepository.cs
@@ -350,48 +350,6 @@ public class LiteDBRepository<T> : IRepository<T> where T : BaseEntity
     }
 
     /// <summary>
-    ///     Delete subdocument
-    /// </summary>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    public virtual Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
-    {
-        var collection = Database.GetCollection(Collection.Name);
-        var fieldName = ((MemberExpression)field.Body).Member.Name;
-        if (string.IsNullOrEmpty(id))
-        {
-            var entities = collection.Find(Query.EQ($"{fieldName}[*] ANY", element)).ToList();
-            foreach (var entity in entities) UpdateEntity(entity);
-        }
-        else
-        {
-            //update one
-            var entity = collection.FindById(new BsonValue(id));
-            UpdateEntity(entity);
-        }
-
-        void UpdateEntity(BsonDocument entity)
-        {
-            if (entity != null && entity[fieldName].IsArray)
-            {
-                var list = entity[fieldName].AsArray.ToList();
-                if (list.Any())
-                {
-                    list.Remove(new BsonValue(element));
-                    entity[fieldName] = new BsonArray(list);
-                    entity["UpdatedOnUtc"] = _auditInfoProvider.GetCurrentDateTime();
-                    entity["UpdatedBy"] = _auditInfoProvider.GetCurrentUser();
-                    collection.Update(entity);
-                }
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
     ///     Delete entity
     /// </summary>
     /// <param name="entity">Entity</param>

--- a/src/Core/Grand.Data/Mongo/MongoRepository.cs
+++ b/src/Core/Grand.Data/Mongo/MongoRepository.cs
@@ -1,5 +1,4 @@
 using Grand.Domain;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using System.Linq.Expressions;
 
@@ -48,7 +47,7 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
             Collection = Database.GetCollection<T>(typeof(T).Name);
         }
     }
-    
+
     public MongoRepository(IMongoDatabase database, IAuditInfoProvider auditInfoProvider)
     {
         Database = database;
@@ -278,27 +277,6 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
             await Collection.UpdateManyAsync(filter, combinedUpdate);
         else
             await Collection.UpdateOneAsync(filter, combinedUpdate);
-    }
-
-    /// <summary>
-    ///     Delete subdocument
-    /// </summary>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="element"></param>
-    /// <returns></returns>
-    public virtual async Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
-    {
-        var update = Builders<T>.Update.Pull(field, element);
-
-        var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
-        var updateUser = Builders<T>.Update.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
-        var combinedUpdate = Builders<T>.Update.Combine(update, updateDate, updateUser);
-
-        if (string.IsNullOrEmpty(id))
-            await Collection.UpdateManyAsync(Builders<T>.Filter.Where(x => true), combinedUpdate);
-        else
-            await Collection.UpdateOneAsync(Builders<T>.Filter.Eq(x => x.Id, id), combinedUpdate);
     }
 
     /// <summary>

--- a/src/Core/Grand.Data/Mongo/MongoRepository.cs
+++ b/src/Core/Grand.Data/Mongo/MongoRepository.cs
@@ -213,7 +213,7 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     /// <param name="field"></param>
     /// <param name="value"></param>
     /// <returns></returns>
-    public virtual async Task AddToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value)
+    public virtual async Task AddToCollectionField<U>(string id, Expression<Func<T, IEnumerable<U>>> field, U value)
     {
         var builder = Builders<T>.Filter;
         var filter = builder.Eq(x => x.Id, id);
@@ -229,37 +229,11 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     ///     Update subdocument
     /// </summary>
     /// <typeparam name="U">Document</typeparam>
-    /// <typeparam name="Z">Subdocuments</typeparam>
     /// <param name="id">Ident of entitie</param>
     /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="elemMatch">Subdocument ident value</param>
+    /// <param name="elemFieldMatch">Subdocument predicate to match</param>
     /// <param name="value">Subdocument - to update (all values)</param>
-    public virtual async Task UpdateToSet<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, Z>> elemFieldMatch, Z elemMatch, U value)
-    {
-        var filter = Builders<T>.Filter.Eq(x => x.Id, id)
-                     & Builders<T>.Filter.ElemMatch(field, Builders<U>.Filter.Eq(elemFieldMatch, elemMatch));
-
-        var me = (MemberExpression)field.Body;
-        var minfo = me.Member;
-        var update = Builders<T>.Update.Set($"{minfo.Name}.$", value);
-        var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
-        var updateUser = Builders<T>.Update.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
-        var combinedUpdate = Builders<T>.Update.Combine(update, updateDate, updateUser);
-
-        await Collection.UpdateOneAsync(filter, combinedUpdate);
-    }
-
-    /// <summary>
-    ///     Update subdocument
-    /// </summary>
-    /// <typeparam name="U">Document</typeparam>
-    /// <param name="id">Ident of entitie</param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    public virtual async Task UpdateToSet<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
+    public virtual async Task UpdateCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
         Expression<Func<U, bool>> elemFieldMatch, U value)
     {
         var filter = string.IsNullOrEmpty(id)
@@ -281,49 +255,20 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     }
 
     /// <summary>
-    ///     Update subdocuments
-    /// </summary>
-    /// <typeparam name="T">Document</typeparam>
-    /// <typeparam name="U"></typeparam>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch">Subdocument field to match</param>
-    /// <param name="value">Subdocument - to update (all values)</param>
-    /// <returns></returns>
-    public virtual async Task UpdateToSet<U>(Expression<Func<T, IEnumerable<U>>> field, U elemFieldMatch, U value)
-    {
-        var me = (MemberExpression)field.Body;
-        var minfo = me.Member;
-
-        var filter = new BsonDocument {
-            new BsonElement(minfo.Name, elemFieldMatch.ToString())
-        };
-
-        var update = Builders<T>.Update.Set($"{minfo.Name}.$", value);
-
-        var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
-        var updateUser = Builders<T>.Update.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
-        var combinedUpdate = Builders<T>.Update.Combine(update, updateDate, updateUser);
-
-        await Collection.UpdateManyAsync(filter, combinedUpdate);
-    }
-
-    /// <summary>
     ///     Delete subdocument
     /// </summary>
     /// <typeparam name="U"></typeparam>
-    /// <typeparam name="Z"></typeparam>
     /// <param name="id"></param>
     /// <param name="field"></param>
     /// <param name="elemFieldMatch"></param>
-    /// <param name="elemMatch"></param>
     /// <returns></returns>
-    public virtual async Task PullFilter<U, Z>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, Z>> elemFieldMatch, Z elemMatch)
+    public virtual async Task RemoveCollectionFieldItem<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
+        Expression<Func<U, bool>> elemFieldMatch)
     {
         var filter = string.IsNullOrEmpty(id)
             ? Builders<T>.Filter.Where(x => true)
             : Builders<T>.Filter.Eq(x => x.Id, id);
-        var update = Builders<T>.Update.PullFilter(field, Builders<U>.Filter.Eq(elemFieldMatch, elemMatch));
+        var update = Builders<T>.Update.PullFilter(field, elemFieldMatch);
 
         var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
         var updateUser = Builders<T>.Update.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
@@ -338,32 +283,11 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     /// <summary>
     ///     Delete subdocument
     /// </summary>
-    /// <typeparam name="U"></typeparam>
-    /// <param name="id"></param>
-    /// <param name="field"></param>
-    /// <param name="elemFieldMatch"></param>
-    /// <returns></returns>
-    public virtual async Task PullFilter<U>(string id, Expression<Func<T, IEnumerable<U>>> field,
-        Expression<Func<U, bool>> elemFieldMatch)
-    {
-        var filter = Builders<T>.Filter.Eq(x => x.Id, id);
-        var update = Builders<T>.Update.PullFilter(field, elemFieldMatch);
-
-        var updateDate = Builders<T>.Update.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
-        var updateUser = Builders<T>.Update.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
-        var combinedUpdate = Builders<T>.Update.Combine(update, updateDate, updateUser);
-
-        await Collection.UpdateOneAsync(filter, combinedUpdate);
-    }
-
-    /// <summary>
-    ///     Delete subdocument
-    /// </summary>
     /// <param name="id"></param>
     /// <param name="field"></param>
     /// <param name="element"></param>
     /// <returns></returns>
-    public virtual async Task Pull(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
+    public virtual async Task RemoveCollectionFieldValue(string id, Expression<Func<T, IEnumerable<string>>> field, string element)
     {
         var update = Builders<T>.Update.Pull(field, element);
 

--- a/src/Core/Grand.Data/Mongo/MongoRepository.cs
+++ b/src/Core/Grand.Data/Mongo/MongoRepository.cs
@@ -177,16 +177,16 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     /// <summary>
     ///     Updates a single entity.
     /// </summary>
-    /// <param name="filterExpression"></param>
+    /// <param name="filterexpression"></param>
     /// <param name="updateBuilder"></param>
     /// <returns></returns>
-    public virtual async Task UpdateOneAsync(Expression<Func<T, bool>> filterExpression,
+    public virtual async Task UpdateOneAsync(Expression<Func<T, bool>> filterexpression,
         UpdateBuilder<T> updateBuilder)
     {
         updateBuilder.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
         updateBuilder.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
         var update = Builders<T>.Update.Combine(updateBuilder.Fields);
-        await Collection.UpdateOneAsync(filterExpression, update);
+        await Collection.UpdateOneAsync(filterexpression, update);
     }
 
     /// <summary>
@@ -195,13 +195,13 @@ public class MongoRepository<T> : IRepository<T> where T : BaseEntity
     /// <param name="filterExpression"></param>
     /// <param name="updateBuilder"></param>
     /// <returns></returns>
-    public virtual async Task UpdateManyAsync(Expression<Func<T, bool>> filterExpression,
+    public virtual async Task UpdateManyAsync(Expression<Func<T, bool>> filterexpression,
         UpdateBuilder<T> updateBuilder)
     {
         updateBuilder.Set(x => x.UpdatedOnUtc, _auditInfoProvider.GetCurrentDateTime());
         updateBuilder.Set(x => x.UpdatedBy, _auditInfoProvider.GetCurrentUser());
         var update = Builders<T>.Update.Combine(updateBuilder.Fields);
-        await Collection.UpdateManyAsync(filterExpression, update);
+        await Collection.UpdateManyAsync(filterexpression, update);
     }
 
     /// <summary>

--- a/src/Tests/Grand.Business.Customers.Tests/Services/VendorServiceTests.cs
+++ b/src/Tests/Grand.Business.Customers.Tests/Services/VendorServiceTests.cs
@@ -8,6 +8,7 @@ using Grand.Infrastructure.Tests.Caching;
 using MediatR;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System.Linq.Expressions;
 
 namespace Grand.Business.Customers.Tests.Services;
 
@@ -108,7 +109,7 @@ public class VendorServiceTests
     public async Task InsertVendorNote_ValidArguments_InvokeRepositoryAndPublishEvent()
     {
         await _vendorService.InsertVendorNote(new VendorNote(), "1");
-        _repoMock.Verify(c => c.AddToSet(It.IsAny<string>(), x => x.VendorNotes, It.IsAny<VendorNote>()), Times.Once);
+        _repoMock.Verify(c => c.AddToCollectionField(It.IsAny<string>(), x => x.VendorNotes, It.IsAny<VendorNote>()), Times.Once);
         _mediatorMock.Verify(c => c.Publish(It.IsAny<EntityInserted<VendorNote>>(), default), Times.Once);
     }
 
@@ -116,7 +117,7 @@ public class VendorServiceTests
     public async Task DeleteVendorNote_ValidArguments_SoftDeleteAndPublishEvent()
     {
         await _vendorService.DeleteVendorNote(new VendorNote(), "1");
-        _repoMock.Verify(c => c.PullFilter(It.IsAny<string>(), x => x.VendorNotes, x => x.Id, It.IsAny<string>()),
+        _repoMock.Verify(c => c.RemoveCollectionFieldItem(It.IsAny<string>(), x => x.VendorNotes, It.IsAny<Expression<Func<VendorNote, bool>>>()),
             Times.Once);
         _mediatorMock.Verify(c => c.Publish(It.IsAny<EntityDeleted<VendorNote>>(), default), Times.Once);
     }

--- a/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryTests.cs
+++ b/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryTests.cs
@@ -183,7 +183,7 @@ public class LiteDbRepositoryTests
         };
         products.ForEach(x => myRepository.Insert(x));
         //Act
-        await myRepository.RemoveCollectionFieldValue("1", x => x.Phones, "Phone2");
+        await myRepository.RemoveCollectionFieldItem("1", x => x.Phones, y => y == "Phone2");
         var p = myRepository.GetById("1");
 
         //Assert
@@ -211,7 +211,7 @@ public class LiteDbRepositoryTests
         products.ForEach(x => myRepository.Insert(x));
 
         //Act
-        await myRepository.RemoveCollectionFieldValue(string.Empty, x => x.Phones, "Phone2");
+        await myRepository.RemoveCollectionFieldItem(string.Empty, x => x.Phones, y => y == "Phone2");
 
         var p1 = myRepository.GetById("1");
         var p2 = myRepository.GetById("2");

--- a/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryTests.cs
+++ b/src/Tests/Grand.Data.Tests/LiteDb/LiteDbRepositoryTests.cs
@@ -109,11 +109,11 @@ public class LiteDbRepositoryTests
         var product = new SampleCollection { Id = "1" };
         await myRepository.InsertAsync(product);
 
-        await myRepository.AddToSet("1", x => x.UserFields,
+        await myRepository.AddToCollectionField("1", x => x.UserFields,
             new UserField { Key = "key", Value = "value", StoreId = "" });
 
         //Act
-        await myRepository.AddToSet("1", x => x.UserFields,
+        await myRepository.AddToCollectionField("1", x => x.UserFields,
             new UserField { Key = "key2", Value = "value2", StoreId = "" });
         var p = myRepository.GetById("1");
 
@@ -183,7 +183,7 @@ public class LiteDbRepositoryTests
         };
         products.ForEach(x => myRepository.Insert(x));
         //Act
-        await myRepository.Pull("1", x => x.Phones, "Phone2");
+        await myRepository.RemoveCollectionFieldValue("1", x => x.Phones, "Phone2");
         var p = myRepository.GetById("1");
 
         //Assert
@@ -211,7 +211,7 @@ public class LiteDbRepositoryTests
         products.ForEach(x => myRepository.Insert(x));
 
         //Act
-        await myRepository.Pull(string.Empty, x => x.Phones, "Phone2");
+        await myRepository.RemoveCollectionFieldValue(string.Empty, x => x.Phones, "Phone2");
 
         var p1 = myRepository.GetById("1");
         var p2 = myRepository.GetById("2");
@@ -244,7 +244,7 @@ public class LiteDbRepositoryTests
         };
         products.ForEach(x => myRepository.Insert(x));
         //Act
-        await myRepository.PullFilter("1", x => x.UserFields, x => x.Value == "value");
+        await myRepository.RemoveCollectionFieldItem("1", x => x.UserFields, x => x.Value == "value");
 
         var p1 = myRepository.GetById("1");
 
@@ -274,7 +274,7 @@ public class LiteDbRepositoryTests
         products.ForEach(x => myRepository.Insert(x));
 
         //Act
-        await myRepository.PullFilter("1", x => x.UserFields, x => x.Value, "value");
+        await myRepository.RemoveCollectionFieldItem("1", x => x.UserFields, x => x.Value == "value");
 
         var p1 = myRepository.GetById("1");
 
@@ -311,7 +311,7 @@ public class LiteDbRepositoryTests
         products.ForEach(x => myRepository.Insert(x));
 
         //Act
-        await myRepository.PullFilter(string.Empty, x => x.UserFields, x => x.Value, "value");
+        await myRepository.RemoveCollectionFieldItem(string.Empty, x => x.UserFields, x => x.Value == "value");
 
         var p1 = myRepository.GetById("1");
         var p2 = myRepository.GetById("2");
@@ -514,8 +514,7 @@ public class LiteDbRepositoryTests
         products.ForEach(x => myRepository.Insert(x));
 
         //Act
-        await myRepository.UpdateToSet("1", x => x.UserFields, z => z.Key, "key",
-            new UserField { Key = "key", Value = "update", StoreId = "1" });
+        await myRepository.UpdateCollectionFieldItem("1", x => x.UserFields, z => z.Key == "key", new UserField { Key = "key", Value = "update", StoreId = "1" });
         var p = myRepository.GetById("1");
 
         //Assert
@@ -543,7 +542,7 @@ public class LiteDbRepositoryTests
         };
         products.ForEach(x => myRepository.Insert(x));
         //Act
-        await myRepository.UpdateToSet("1", x => x.UserFields, z => z.Key == "key",
+        await myRepository.UpdateCollectionFieldItem("1", x => x.UserFields, z => z.Key == "key",
             new UserField { Key = "key", Value = "update", StoreId = "1" });
 
         var p = myRepository.GetById("1");

--- a/src/Tests/Grand.Data.Tests/MongoDb/MongoRepositoryTests.cs
+++ b/src/Tests/Grand.Data.Tests/MongoDb/MongoRepositoryTests.cs
@@ -90,11 +90,11 @@ public class MongoRepositoryTests
         var product = new SampleCollection { Id = "1" };
         await _myRepository.InsertAsync(product);
 
-        await _myRepository.AddToSet("1", x => x.UserFields,
+        await _myRepository.AddToCollectionField("1", x => x.UserFields,
             new UserField { Key = "key", Value = "value", StoreId = "" });
 
         //Act
-        await _myRepository.AddToSet("1", x => x.UserFields,
+        await _myRepository.AddToCollectionField("1", x => x.UserFields,
             new UserField { Key = "key2", Value = "value2", StoreId = "" });
 
         var p = _myRepository.GetById("1");
@@ -173,7 +173,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.Pull("1", x => x.Phones, "Phone2");
+        await _myRepository.RemoveCollectionFieldValue("1", x => x.Phones, "Phone2");
 
         var p = _myRepository.GetById("1");
 
@@ -203,7 +203,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.Pull(string.Empty, x => x.Phones, "Phone2");
+        await _myRepository.RemoveCollectionFieldValue(string.Empty, x => x.Phones, "Phone2");
 
         var p1 = _myRepository.GetById("1");
         var p2 = _myRepository.GetById("2");
@@ -238,7 +238,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.PullFilter("1", x => x.UserFields, x => x.Value == "value");
+        await _myRepository.RemoveCollectionFieldItem("1", x => x.UserFields, x => x.Value == "value");
 
         var p1 = _myRepository.GetById("1");
 
@@ -269,7 +269,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.PullFilter("1", x => x.UserFields, x => x.Value, "value");
+        await _myRepository.RemoveCollectionFieldItem("1", x => x.UserFields, x => x.Value == "value");
 
         var p1 = _myRepository.GetById("1");
 
@@ -307,7 +307,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.PullFilter(string.Empty, x => x.UserFields, x => x.Value, "value");
+        await _myRepository.RemoveCollectionFieldItem(string.Empty, x => x.UserFields, x => x.Value == "value");
 
         var p1 = _myRepository.GetById("1");
         var p2 = _myRepository.GetById("2");
@@ -502,8 +502,7 @@ public class MongoRepositoryTests
         };
         products.ForEach(x => _myRepository.Insert(x));
         //Act
-        await _myRepository.UpdateToSet("1", x => x.UserFields, z => z.Key, "key",
-            new UserField { Key = "key", Value = "update", StoreId = "1" });
+        await _myRepository.UpdateCollectionFieldItem("1", x => x.UserFields, z => z.Key == "key", new UserField { Key = "key", Value = "update", StoreId = "1" });
         var p = _myRepository.GetById("1");
 
         //Assert

--- a/src/Tests/Grand.Data.Tests/MongoDb/MongoRepositoryTests.cs
+++ b/src/Tests/Grand.Data.Tests/MongoDb/MongoRepositoryTests.cs
@@ -173,7 +173,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.RemoveCollectionFieldValue("1", x => x.Phones, "Phone2");
+        await _myRepository.RemoveCollectionFieldItem("1", x => x.Phones, y => y == "Phone2");
 
         var p = _myRepository.GetById("1");
 
@@ -203,7 +203,7 @@ public class MongoRepositoryTests
         products.ForEach(x => _myRepository.Insert(x));
 
         //Act
-        await _myRepository.RemoveCollectionFieldValue(string.Empty, x => x.Phones, "Phone2");
+        await _myRepository.RemoveCollectionFieldItem(string.Empty, x => x.Phones, y => y == "Phone2");
 
         var p1 = _myRepository.GetById("1");
         var p2 = _myRepository.GetById("2");


### PR DESCRIPTION
## Summary
- Renamed `IRepository<T>` methods that leaked MongoDB terminology to storage-neutral names: `AddToSet` → `AddToCollectionField`, `UpdateToSet` → `UpdateCollectionFieldItem`, `PullFilter` → `RemoveCollectionFieldItem`, `Pull` → `RemoveCollectionFieldValue`.
- Collapsed the redundant `field == value` overloads of `UpdateCollectionFieldItem`/`RemoveCollectionFieldItem` into their predicate-based (`Expression<Func<U, bool>>`) equivalents, since a predicate is a strict superset of a field/value pair. ~49 call sites updated accordingly.
- Removed the single-caller, no-`id` mass-update overload of `UpdateCollectionFieldItem` (used only by `ProductTagService.UpdateProductTag` to rename a tag across all products); its Mongo/LiteDb implementations relied on fragile `ToString()`-based matching. Replaced with an explicit find + `UpdateField` loop in `ProductTagService`.
- Fixed a real behavior bug caught by existing tests during the overload merge: LiteDb's predicate-based remove only deleted the *first* matching array element, while the removed `field == value` overload (and Mongo's `$pull`) removes *all* matches. LiteDb's implementation now removes all matches, consistent with Mongo.

This is prep work for keeping the repository abstraction storage-agnostic (no more MongoDB-only method names/shapes in the shared interface).

## Test plan
- [x] `dotnet build GrandNode.sln` — 0 errors
- [x] `Grand.Data.Tests` (Mongo + LiteDb repository unit tests) — 45/45 passed
- [x] `Grand.Business.Customers.Tests` — 118/118 passed
- [x] `Grand.Business.Catalog.Tests` — 349/349 passed (1 pre-existing skip)