### PR TITLE
Add AI agent skill library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Repository Agent Instructions
+
+## Purpose
+Provide model-agnostic operating instructions for AI agents working in this repository.
+
+## When To Use
+Use this file before making or reviewing repository changes. Use the review skills in `skills/` when the task matches their domain.
+
+## Skill Routing
+- Use `skills/reviews/architecture-review/SKILL.md` for design, layering, dependency, module boundary, public contract, and maintainability reviews.
+- Use `skills/reviews/security-review/SKILL.md` for authentication, authorization, input handling, secrets, cryptography, sensitive data, and trust-boundary reviews.
+- Use `skills/reviews/dotnet-review/SKILL.md` for C#, .NET, ASP.NET Core, MongoDB repository usage, NuGet, MSBuild, and .NET test reviews.
+- Use `skills/reviews/database-review/SKILL.md` for migrations, schema, indexes, queries, transactions, ORM mappings, and data integrity reviews.
+- Use `skills/reviews/mongodb-review/SKILL.md` for MongoDB collections, filters, projections, indexes, repository queries, aggregations, updates, and data migrations.
+- Use `skills/plugins/plugin-module/SKILL.md` for GrandNode plugins and modules, including provider plugins, themes, API modules, migrations, and installer behavior.
+- Use `skills/plugins/plugin-shipping/SKILL.md` for shipping rate calculation plugins (IShippingRateCalculationProvider), GetShippingOptions, ShippingOption, ShippingRateCalculationType, and IShipmentTracker.
+- Use `skills/plugins/plugin-payment/SKILL.md` for payment method plugins (IPaymentProvider), Standard vs Redirection flow, ProcessPayment, Capture, Refund, Void, and PaymentTransaction status.
+- Use `skills/plugins/plugin-widget/SKILL.md` for widget plugins (IWidgetProvider), GetWidgetZones, view components, widget zone names, and GDPR consent gating.
+- Use `skills/plugins/plugin-discount-rules/SKILL.md` for discount rule plugins (IDiscountProvider, IDiscountRule), CheckRequirement, DiscountRule.Metadata, and rule configuration controllers.
+- Use `skills/template-creation/SKILL.md` for Razor views, layouts, partials, view components, plugin views, theme overrides, Vue-in-Razor templates, PDF templates, and DotLiquid message templates.
+- Use `skills/frontend-bundle-workflow/SKILL.md` for Vue/Vite build, theme CSS changes, when to run `npm run build`, bundle output files, and committing bundles alongside source.
+- Use `skills/admin-area-changes/SKILL.md` for admin-facing changes that may affect Main Admin, Store Owner, Vendor, shared admin models, permissions, navigation, validation, or scoped data access.
+- Use `skills/project-structure/SKILL.md` to understand repository structure, technology ownership, layer responsibilities, and how to expand GrandNode consistently.
+- Use `skills/settings-and-localization/SKILL.md` for settings classes, store-scoped overrides, ISettingService, localization resources, ITranslationService, IPluginTranslateResource, localized domain entities, and localized admin models.
+- Use `skills/message-notification/SKILL.md` for message templates, DotLiquid tokens and drops, IMessageProviderService, queued email lifecycle, LiquidObjectBuilder, MessageTokensAddedEvent plugin extension, and domain event notification handlers.
+- Use `skills/scheduled-task/SKILL.md` for scheduled task classes, IScheduleTask, AddKeyedScoped registration, ScheduleTask seed, multi-instance distributed locking, error handling, and task migrations.
+- Use `skills/permission-navigation/SKILL.md` for permissions, PermissionSystemName, PermissionActionName, StandardPermission, PermissionProvider, controller authorization attributes, AdminSiteMap entries, and permission or navigation migrations.
+- Use `skills/best-practices/async.md` for async/await patterns, CancellationToken, Task vs ValueTask, and blocking anti-patterns.
+- Use `skills/best-practices/mongodb.md` for IRepository<T> usage, query patterns, partial updates, and write conventions.
+- Use `skills/best-practices/performance.md` for ICacheBase, CacheKey constants, cache invalidation, pagination, and partial field writes.
+- Use `skills/best-practices/security.md` for authorization checks, FluentValidation patterns, guard clauses, HTML encoding, and safe MongoDB queries.
+- Use `skills/best-practices/architecture.md` for layering rules, DI lifetimes, MediatR commands/queries, and domain events.
+- Use `skills/best-practices/tests.md` for MSTest + Moq patterns, test structure, validator testing, and controller test setup.
+- Use `skills/best-practices/dotnet.md` for C# idioms: records, guard clauses, result objects, pattern matching, nullable types, and configuration binding.
+- Use multiple skills when a change crosses domains.
+
+## Operating Rules
+1. Read the user's goal before inspecting files.
+2. Inspect existing repository patterns before proposing changes.
+3. Keep changes limited to the requested scope.
+4. Preserve user work and unrelated local changes.
+5. Prefer existing abstractions, conventions, and test utilities.
+6. Validate changes with the narrowest meaningful build or test command when execution is available.
+7. Report commands that were run and any commands that could not be run.
+8. Provide concrete file references for findings or changes.
+
+## Constraints
+- Never overwrite unrelated changes.
+- Never invent requirements or repository conventions.
+- Never broaden scope without a clear reason.
+- Never leave generated, temporary, or diagnostic artifacts unless they are part of the requested output.
+
+## Expected Output
+Return a concise result that states what changed, what was reviewed, what was validated, and what risk remains.

--- a/skills/admin-area-changes/SKILL.md
+++ b/skills/admin-area-changes/SKILL.md
@@ -1,0 +1,108 @@
+# Admin Area Changes
+
+## Purpose
+Handle GrandNode administration changes that may affect the main Admin panel, Store Owner panel, Vendor panel, shared admin models, permissions, navigation, validation, and scoped data access.
+
+## When To Use
+Use this skill when changing admin-facing features, management screens, grids, forms, reports, settings, permissions, menu items, admin shared models, validators, mapper profiles, controllers, or views.
+
+Use this skill when a change in `Grand.Web.Admin` may also require corresponding changes in `Grand.Web.Store`, `Grand.Web.Vendor`, or `Grand.Web.AdminShared`.
+
+Use this skill for product, order, shipment, merchandise return, payment transaction, report, customer, vendor, store, discount, message template, setting, catalog, and configuration management changes.
+
+## When Not To Use
+Do not use this skill for public storefront-only pages, API-only changes, plugin-only changes with no admin UI, or backend service changes that do not affect management workflows.
+
+Do not use this skill as the primary review for MongoDB query safety, template markup details, or security vulnerabilities; combine it with the relevant skill when those concerns are present.
+
+## Inputs Required
+- Repository root.
+- Target admin feature or changed files.
+- Intended user role: system admin, store owner, vendor, or multiple roles.
+- Affected entity, workflow, or setting.
+- Existing closest controller, view, model, validator, mapper, and permission.
+- Store, vendor, customer group, language, currency, and permission scope requirements.
+- Tests, build commands, and UI validation target.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify whether the change belongs to Admin, Store Owner, Vendor, AdminShared, or multiple areas.
+2. Read `references/admin-areas.md` before creating or changing an admin workflow.
+3. Locate matching controllers in `src/Web/Grand.Web.Admin/Controllers`, `src/Web/Grand.Web.Store/Controllers`, and `src/Web/Grand.Web.Vendor/Controllers`.
+4. Locate matching views in `src/Web/Grand.Web.Admin/Areas/Admin/Views`, `src/Web/Grand.Web.Store/Areas/Store/Views`, and `src/Web/Grand.Web.Vendor/Areas/Vendor/Views`.
+5. Locate shared models, validators, and mapper profiles in `src/Web/Grand.Web.AdminShared`.
+6. Determine whether the same feature must exist in the Store Owner or Vendor panel.
+7. Determine whether the feature must be hidden, read-only, filtered, or unavailable for Store Owner or Vendor users.
+8. Preserve controller base class conventions: admin controllers use `BaseAdminController`, store controllers use `BaseStoreController`, and vendor controllers use `BaseVendorController`.
+9. Preserve permission checks using the existing `StandardPermission` or permission service pattern for the target area.
+10. Preserve site map and menu behavior when adding, removing, or moving management pages.
+11. Preserve store scope for Store Owner workflows.
+12. Preserve vendor scope for Vendor workflows.
+13. Never rely on UI-only filtering to enforce Store Owner or Vendor restrictions.
+14. Update shared model, validator, mapper, and view changes together when a field or workflow changes.
+15. Update list models, search models, grid columns, create/edit models, popup models, and tab partials consistently.
+16. Preserve antiforgery behavior for forms and AJAX grid mutations.
+17. Preserve localization resource keys for labels, validation messages, menu items, and notifications.
+18. Check whether settings changes need store-scope override UI or store-specific persistence.
+19. Check whether notifications or message templates must change when an admin workflow changes.
+20. Check whether product, order, shipment, payment, discount, customer, vendor, or store workflows require domain-specific validation.
+21. Add or update tests for controller behavior, validators, mapper profiles, permissions, and scoped filtering when applicable.
+22. Run the narrowest relevant build or tests when execution is available.
+23. State which panels were checked and which were not applicable.
+
+### Recommendations
+1. Prefer updating `Grand.Web.AdminShared` when Admin, Store Owner, and Vendor panels share the same model contract.
+2. Prefer separate controllers and views when role-specific behavior is materially different.
+3. Prefer explicit scope filters in service or query calls over filtering results after loading.
+4. Prefer adding a disabled or read-only state over duplicating markup when only editing permissions differ.
+5. Prefer matching existing tab, popup, grid, and partial naming conventions.
+6. Prefer reviewing parallel workflows by entity name across all three panels before editing.
+
+## Constraints
+- Never add a field only to the Admin panel when Store Owner or Vendor uses the same shared model and requires the field.
+- Never expose global Admin actions to Store Owner or Vendor users.
+- Never allow Store Owner or Vendor users to access records outside their scope.
+- Never add a menu item without matching permission and route behavior.
+- Never add a form mutation without server-side permission and scope validation.
+- Never break existing shared validators or mapper profiles for another panel.
+- Never hardcode display text when localization resources are expected.
+- Never change shared admin models without checking every panel that uses them.
+
+## Expected Output
+Produce one of these results:
+- A completed admin-area change across all required panels.
+- A review report listing missing Admin, Store Owner, Vendor, shared model, permission, navigation, validation, or scope updates.
+- A concise implementation plan when role ownership cannot be determined from the repository.
+
+Include affected panels, changed files, permission impact, scope impact, validation commands, and remaining risks.
+
+## Validation Checklist
+- [ ] The affected panels were identified.
+- [ ] Parallel Admin, Store Owner, and Vendor workflows were checked.
+- [ ] Shared models, validators, and mapper profiles were checked.
+- [ ] Controllers and views were updated consistently.
+- [ ] Permissions were checked server-side.
+- [ ] Store and vendor scope were enforced server-side where relevant.
+- [ ] Menus and site map entries were checked where relevant.
+- [ ] Localization resources were checked.
+- [ ] Forms and AJAX preserve antiforgery behavior.
+- [ ] Tests or build commands were run or reported as not run.
+
+## Examples
+
+### Example 1: Product Field
+Input: Add a new editable product field.
+
+Output: Update `ProductModel`, mapper profile, validator, Admin product views, Store Owner product views, Vendor product views if vendors may edit the field, server-side save logic, permissions or read-only behavior, localization resources, and relevant tests.
+
+### Example 2: Order Action
+Input: Add an action to mark an order with an internal review flag.
+
+Output: Add the action only where the role is allowed, enforce permission in the controller, enforce store or vendor scope before mutation, update grids or order detail tabs, add localization resources, and test unauthorized and out-of-scope access.
+
+### Example 3: Setting
+Input: Add a setting that affects vendor behavior.
+
+Output: Update the shared settings model, settings mapper, Admin settings view, store-scope behavior if configurable per store, vendor panel visibility if the setting changes vendor UI, seeded resources, and validation.
+

--- a/skills/admin-area-changes/references/admin-areas.md
+++ b/skills/admin-area-changes/references/admin-areas.md
@@ -1,0 +1,146 @@
+# GrandNode Admin Areas
+
+## Panel Inventory
+- Main Admin panel: `src/Web/Grand.Web.Admin`
+- Store Owner panel: `src/Web/Grand.Web.Store`
+- Vendor panel: `src/Web/Grand.Web.Vendor`
+- Shared admin contracts: `src/Web/Grand.Web.AdminShared`
+
+## Controller Locations
+Controllers are directly under each web project:
+- Admin: `src/Web/Grand.Web.Admin/Controllers`
+- Store Owner: `src/Web/Grand.Web.Store/Controllers`
+- Vendor: `src/Web/Grand.Web.Vendor/Controllers`
+
+Use the matching base controller:
+- Admin: `BaseAdminController`
+- Store Owner: `BaseStoreController`
+- Vendor: `BaseVendorController`
+
+## View Locations
+Views are under area folders:
+- Admin: `src/Web/Grand.Web.Admin/Areas/Admin/Views`
+- Store Owner: `src/Web/Grand.Web.Store/Areas/Store/Views`
+- Vendor: `src/Web/Grand.Web.Vendor/Areas/Vendor/Views`
+
+Use nearby view patterns for:
+- `List.cshtml`
+- `Create.cshtml`
+- `Edit.cshtml`
+- popup views
+- `Partials/CreateOrUpdate.cshtml`
+- `Partials/CreateOrUpdate.Tab*.cshtml`
+- `Partials/*.cshtml`
+
+## Shared Admin Contracts
+Shared models, validators, and mapper profiles live in:
+- `src/Web/Grand.Web.AdminShared/Models`
+- `src/Web/Grand.Web.AdminShared/Validators`
+- `src/Web/Grand.Web.AdminShared/Mapper`
+
+Check `AdminShared` first when a model is used by more than one panel.
+
+Common shared areas include:
+- catalog and product models
+- order, shipment, payment transaction, and merchandise return models
+- customer, customer group, and vendor models
+- discount models
+- message template models
+- store and settings models
+- validators for create, edit, delete, popup, and relation models
+- mapper profiles between domain entities and admin models
+
+## Parallel Workflow Check
+When changing an entity, search for matching names across all panels.
+
+Examples:
+- Product: check Admin `ProductController`, Store `ProductController`, Vendor `ProductController`, product views, `ProductModel`, `ProductValidator`, and `ProductProfile`.
+- Order: check Admin `OrderController`, Store `OrderController`, Vendor `OrderController`, order views, `OrderModel`, order validators, and order-related reports.
+- Shipment: check Admin `ShipmentController`, Store `ShipmentController`, Vendor `ShipmentController`, shipment views, `ShipmentModel`, and shipment permissions.
+- Vendor: check Admin `VendorController`, Vendor `VendorInfoController`, vendor settings, vendor review flows, `VendorModel`, `VendorProfile`, and `VendorValidator`.
+- Message templates: check Admin and Store `MessageTemplateController`, views, `MessageTemplateModel`, validator, mapper, and DotLiquid message template behavior.
+
+## Permission Rules
+Use existing permission patterns from nearby controllers.
+
+Check:
+- `StandardPermission` usage
+- `_permissionService.Authorize(...)`
+- area-specific access checks
+- menu permission names in `src/Modules/Grand.Module.Installer/Utilities/StandardAdminSiteMap.cs`
+- seeded permission names in installer utilities when adding new management areas
+
+Do not expose Admin-only permissions to Store Owner or Vendor panels.
+
+## Scope Rules
+Admin can usually access global data when permission allows it.
+
+Store Owner workflows must enforce store scope. Check:
+- selected store context
+- store-limited entities
+- store-specific settings
+- ACL and store mapping helpers
+- search filters that include store ID
+
+Vendor workflows must enforce vendor scope. Check:
+- current vendor identity
+- product vendor ID
+- order item vendor ownership
+- shipment and merchandise return ownership
+- vendor editable settings
+- vendor-specific reports
+
+Server-side scope is mandatory. UI hiding is not enough.
+
+## Navigation Rules
+Main Admin menu entries are seeded in:
+- `src/Modules/Grand.Module.Installer/Utilities/StandardAdminSiteMap.cs`
+
+When adding a new admin page:
+- Add or update the site map entry only if the page should appear in navigation.
+- Use an existing resource key naming pattern.
+- Use the correct controller and action.
+- Attach the correct permission names.
+- Check whether Store Owner or Vendor navigation also requires a corresponding entry.
+
+## Form And Grid Rules
+Follow existing area conventions for:
+- admin tag helpers
+- tab partials
+- popup forms
+- Kendo grids
+- AJAX data functions
+- `addAntiForgeryToken(data)`
+- validation summary and field validation spans
+- localized labels through `GrandResourceDisplayName`
+
+When adding a field:
+- Update model.
+- Update mapper profile.
+- Update validator.
+- Update create/edit views.
+- Update list/search models if the field is searchable or visible in grids.
+- Update controller binding and save logic.
+- Update localization resources.
+- Update tests.
+
+## Settings Rules
+When changing settings:
+- Check settings model in `AdminShared`.
+- Check mapper profile.
+- Check Admin settings controller and view.
+- Check store-scope override behavior.
+- Check whether Store Owner can configure the setting.
+- Check whether Vendor panel needs read-only behavior or visibility changes.
+- Update resource keys and validation.
+
+## Test Targets
+Prefer narrow tests:
+- controller action authorization and scope tests
+- validator tests
+- mapper profile tests
+- service tests for scoped queries
+- UI model preparation tests
+
+Run a targeted project build when tests are not available.
+

--- a/skills/best-practices/architecture.md
+++ b/skills/best-practices/architecture.md
@@ -1,0 +1,127 @@
+# Best Practice: Architecture
+
+Patterns from `Grand.Infrastructure`, `Grand.Business.*`, `Grand.Domain`. Complementary to `skills/reviews/architecture-review/SKILL.md`.
+
+---
+
+## Layering
+
+```
+Grand.Web / Grand.Module.Api   — HTTP, ViewModels, Controllers
+Grand.Business.*               — Use cases, Services, Validators
+Grand.Domain                   — Entities, Value objects (no dependencies)
+Grand.Data / Grand.Infrastructure — DB access, Caching, Infrastructure
+Grand.SharedKernel             — Interfaces and utilities shared across all layers
+```
+
+Rules:
+- Domain has no dependencies on infrastructure or business layers.
+- Business layer depends on Domain and Data abstractions (`IRepository<T>`), not on concrete Mongo types.
+- Controllers delegate to MediatR — never contain business logic.
+- Infrastructure registrations go in `IStartupApplication`, not `Program.cs`.
+
+---
+
+## Dependency Injection Registration
+
+Implement `IStartupApplication` in each project that owns services. Split registration into private static `Register*` methods:
+
+```csharp
+public class StartupApplication : IStartupApplication
+{
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        RegisterOrdersService(services);
+        RegisterPaymentsService(services);
+    }
+
+    private static void RegisterOrdersService(IServiceCollection services)
+    {
+        services.AddScoped<IOrderService, OrderService>();
+        services.AddScoped<IOrderCalculationService, OrderCalculationService>();
+    }
+
+    private static void RegisterPaymentsService(IServiceCollection services)
+    {
+        services.AddScoped<IPaymentService, PaymentService>();
+    }
+}
+```
+
+### Lifetimes
+
+| Lifetime | When to use |
+|---|---|
+| `AddScoped` | Business services, repositories — default choice |
+| `AddSingleton` | Stateless infrastructure: `IMongoDatabase`, cache providers, `IAuditInfoProvider` |
+| `AddTransient` | Rare; lightweight per-resolve objects with no shared state |
+| `AddKeyedScoped` | Scheduled tasks (key must equal `ScheduleTask.ScheduleTaskName`) |
+
+---
+
+## MediatR — Commands and Queries
+
+All mutations (writes) go through commands; all reads go through queries. Controllers only call `_mediator.Send(...)`.
+
+### Command
+
+```csharp
+// in Grand.Business.Core/Commands/
+public class MaxOrderNumberCommand : IRequest<int?>
+{
+    public int? OrderNumber { get; set; }
+}
+
+// in Grand.Business.Checkout/Commands/Handlers/
+public class MaxOrderNumberCommandHandler : IRequestHandler<MaxOrderNumberCommand, int?>
+{
+    public async Task<int?> Handle(MaxOrderNumberCommand request, CancellationToken cancellationToken)
+    {
+        // write logic
+    }
+}
+```
+
+### Query
+
+```csharp
+// in Grand.Business.Core/Queries/
+public class GetSuggestedProductsQuery : IRequest<IList<Product>>
+{
+    public string[] CustomerTagIds { get; set; }
+    public int ProductsNumber { get; set; }
+}
+```
+
+Command/query definitions belong in `Grand.Business.Core`; handlers belong in the relevant `Grand.Business.*` project.
+
+---
+
+## Domain Events
+
+Publish domain events after every repository mutation so event handlers can react (cache clearing, side effects, integrations).
+
+```csharp
+await _repository.InsertAsync(entity);
+await _mediator.EntityInserted(entity);
+
+await _repository.UpdateAsync(entity);
+await _mediator.EntityUpdated(entity);
+
+await _repository.DeleteAsync(entity);
+await _mediator.EntityDeleted(entity);
+```
+
+Event handlers implement `INotificationHandler<EntityInserted<T>>` (or Updated/Deleted). Place them in `Grand.Business.*/Events/Handlers/`.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Correct |
+|---|---|
+| Business logic in a controller | Move to a command handler, call via `_mediator.Send` |
+| Registering services in `Program.cs` | Register in `IStartupApplication.ConfigureServices` |
+| Injecting `IMongoDatabase` into a business service | Inject `IRepository<T>` |
+| Forgetting `_mediator.EntityUpdated` after `_repo.UpdateAsync` | Always publish after every mutation |
+| Singleton service with `IRepository<T>` dependency | `IRepository<T>` is Scoped — its consumer must also be Scoped |

--- a/skills/best-practices/async.md
+++ b/skills/best-practices/async.md
@@ -1,0 +1,138 @@
+# Best Practice: Async / Await
+
+Patterns derived from the GrandNode codebase. Every rule below has a real counterpart in production code.
+
+---
+
+## Rules
+
+### Always use `async Task`, never `async void`
+
+`async void` cannot be awaited; exceptions escape to `UnobservedTaskException`.
+
+```csharp
+// correct
+public async Task HandleAsync(Command request, CancellationToken cancellationToken) { ... }
+
+// never
+public async void HandleAsync() { ... }
+```
+
+### Accept and forward CancellationToken throughout the call chain
+
+Every MediatR handler already accepts `CancellationToken`. Pass it to every async call you make.
+
+```csharp
+public async Task<int?> Handle(MaxOrderNumberCommand request, CancellationToken cancellationToken)
+{
+    await _orderRepository.InsertAsync(new Order { ... }, cancellationToken);
+}
+```
+
+If an API or repository method doesn't accept `CancellationToken`, you don't need to invent one — just don't create a new `CancellationToken.None` at the call site. Use the one provided.
+
+### Never use `.Result`, `.Wait()`, or `.GetAwaiter().GetResult()`
+
+These block the thread and risk deadlocks under ASP.NET Core.
+
+```csharp
+// wrong — blocks thread
+var product = _productService.GetProductByIdAsync(id).Result;
+
+// correct
+var product = await _productService.GetProductByIdAsync(id);
+```
+
+### Do NOT add `ConfigureAwait(false)`
+
+ASP.NET Core has no synchronization context. `ConfigureAwait(false)` is noise here — the codebase does not use it and neither should you.
+
+### Don't wrap I/O in `Task.Run`
+
+`Task.Run` is for CPU-bound work. Database and network calls are already async at the driver level.
+
+```csharp
+// wrong — wastes a thread pool thread
+var result = await Task.Run(() => _repository.GetByIdAsync(id));
+
+// correct
+var result = await _repository.GetByIdAsync(id);
+```
+
+### Use `ValueTask` only when the hot path frequently returns synchronously
+
+`ValueTask` avoids allocation for code that often returns a cached result without awaiting. Do not retrofit existing `Task`-returning code unless profiling shows allocation is a problem.
+
+### Avoid `.ToList()` inside async lambdas passed to cache
+
+`IQueryable<T>.ToList()` is synchronous and blocks. Use LINQ's `ToList()` only on in-memory sequences, or use repository methods that return `Task<IList<T>>`.
+
+```csharp
+// This is fine — the LINQ query is materialised synchronously here
+// because Table is IQueryable against MongoDB, not EF
+var productIds = query.Take(request.ProductsNumber).ToList();
+```
+
+### Run independent operations concurrently with `Task.WhenAll`
+
+When two or more async operations are independent, start all of them before awaiting:
+
+```csharp
+// GetProductOverviewHandler.cs — real codebase example
+var tasks = new List<Task<ProductOverviewModel>>();
+foreach (var product in request.Products)
+    tasks.Add(GetProductOverviewModel(product, ...));
+
+var result = await Task.WhenAll(tasks);
+```
+
+Don't `await` each item in a `foreach` loop if the iterations don't depend on each other — that forces sequential execution.
+
+### LINQ + async: force evaluation before `Task.WhenAll`
+
+LINQ uses deferred execution. If you build a task list with `Select(id => GetAsync(id))`, the tasks don't start until the sequence is iterated. Call `.ToArray()` or `.ToList()` immediately to start all tasks:
+
+```csharp
+// correct — all tasks start immediately
+var tasks = ids.Select(id => GetProductByIdAsync(id)).ToArray();
+var products = await Task.WhenAll(tasks);
+
+// wrong — tasks created lazily, may not all start
+var tasks = ids.Select(id => GetProductByIdAsync(id)); // no ToArray()
+```
+
+### `await Task.Delay` instead of `Thread.Sleep`
+
+`Thread.Sleep` blocks the thread. `await Task.Delay` releases it back to the pool during the wait:
+
+```csharp
+// wrong
+Thread.Sleep(1000);
+
+// correct
+await Task.Delay(1000);
+```
+
+---
+
+## Blocking-to-Async Replacement Table
+
+| Blocking (avoid) | Async equivalent |
+|---|---|
+| `task.Wait()` | `await task` |
+| `task.Result` | `await task` |
+| `Task.WaitAll(t1, t2)` | `await Task.WhenAll(t1, t2)` |
+| `Task.WaitAny(t1, t2)` | `await Task.WhenAny(t1, t2)` |
+| `Thread.Sleep(ms)` | `await Task.Delay(ms)` |
+
+---
+
+## Summary
+
+| Rule | Reason |
+|------|--------|
+| `async Task` everywhere | `async void` exceptions are unobservable |
+| Pass `CancellationToken` | Enables cooperative cancellation |
+| No `.Result` / `.Wait()` | Deadlock risk |
+| No `ConfigureAwait(false)` | No sync context in ASP.NET Core |
+| No `Task.Run` for I/O | Wastes threads; I/O is already async |

--- a/skills/best-practices/dotnet.md
+++ b/skills/best-practices/dotnet.md
@@ -1,0 +1,175 @@
+# Best Practice: C# / .NET Idioms
+
+Patterns found across the GrandNode codebase. Covers C# language features and .NET conventions used here.
+
+---
+
+## Immutable Input Types — Records for Validators
+
+Use positional records as input to FluentValidation validators. Records are immutable and their equality is structural:
+
+```csharp
+public record ShoppingCartStandardValidatorRecord(
+    Customer Customer,
+    Product Product,
+    ShoppingCartItem ShoppingCartItem);
+
+public class ShoppingCartStandardValidator : AbstractValidator<ShoppingCartStandardValidatorRecord>
+{ ... }
+```
+
+---
+
+## Guard Clauses — ArgumentNullException
+
+Use the built-in static helpers at the top of service methods. Do not write `if (x == null) throw new ArgumentNullException(...)` manually:
+
+```csharp
+public async Task SaveDeliveryDate(DeliveryDate deliveryDate)
+{
+    ArgumentNullException.ThrowIfNull(deliveryDate);
+    // ...
+}
+
+public void Initialize(string keyId, string secretKey, string bucket)
+{
+    ArgumentNullException.ThrowIfNullOrEmpty(keyId);
+    ArgumentNullException.ThrowIfNullOrEmpty(secretKey);
+    ArgumentNullException.ThrowIfNullOrEmpty(bucket);
+}
+```
+
+---
+
+## Result Objects Instead of Exceptions for Expected Failures
+
+For operations where failure is a valid business outcome, use a result object rather than throwing exceptions:
+
+```csharp
+public class PlaceOrderResult
+{
+    public bool Success => Errors.Count == 0;
+    public IList<string> Errors { get; set; } = new List<string>();
+    public Order PlacedOrder { get; set; }
+
+    public void AddError(string error) => Errors.Add(error);
+}
+```
+
+Exceptions are for unexpected, unrecoverable conditions. Validation failures, business rule violations, and "entity not found" are expected — return a result object.
+
+---
+
+## Pattern Matching
+
+Use `switch` with `when` guards rather than nested `if/else`:
+
+```csharp
+switch (cartItem.ShoppingCartTypeId)
+{
+    case ShoppingCartType.ShoppingCart when product.DisableBuyButton:
+        context.AddFailure(translationService.GetResource("ShoppingCart.BuyingDisabled"));
+        break;
+    case ShoppingCartType.Wishlist when product.DisableWishlistButton:
+        context.AddFailure(translationService.GetResource("ShoppingCart.WishlistDisabled"));
+        break;
+}
+```
+
+---
+
+## Nullable Reference Types
+
+The project has nullable reference types enabled. Follow these conventions:
+
+- `string` — the property/parameter is never null; calling code must not pass null.
+- `string?` — explicitly nullable; caller or callee handles null.
+- Do not suppress warnings with `!` unless you are certain the value cannot be null at that point.
+
+---
+
+## Configuration Binding
+
+GrandNode uses direct `Bind` rather than `IOptions<T>`:
+
+```csharp
+var dbConfig = new DatabaseConfig();
+configuration.GetSection("Database").Bind(dbConfig);
+```
+
+Do not introduce `IOptions<T>`, `IOptionsMonitor<T>`, or `IOptionsSnapshot<T>` — they are not used in this codebase and would be inconsistent.
+
+---
+
+## LINQ Expression Trees in Predicates
+
+Repository methods accept `Expression<Func<T, bool>>`, not strings. Always use typed lambda predicates:
+
+```csharp
+// correct — type-safe, translates to a MongoDB query
+var entity = await _repository.GetOneAsync(x => x.ExternalId == externalId);
+
+// wrong — string-based, no compile-time safety
+var entity = await collection.Find("{externalId: '" + externalId + "'}").FirstOrDefaultAsync();
+```
+
+---
+
+## Naming Conventions
+
+| Concept | Convention | Example |
+|---|---|---|
+| Private fields | `_camelCase` | `_orderRepository` |
+| Constants | `UPPER_SNAKE_CASE` | `CacheKey.PRODUCTS_BY_ID` |
+| Async methods | `Async` suffix | `GetByIdAsync` |
+| Event handlers | `EntityDeletedEventHandler` | `ProductDeletedEventHandler` |
+| Command | `*Command` | `PlaceOrderCommand` |
+| Query | `*Query` | `GetSuggestedProductsQuery` |
+| Validator input record | `*ValidatorRecord` | `ShoppingCartStandardValidatorRecord` |
+
+---
+
+## `using` Declaration for Disposables
+
+Use the modern `using` declaration instead of a `try/finally` block with `Dispose`. The variable is disposed at the end of the enclosing scope:
+
+```csharp
+// correct — disposed when method exits
+await using var response = await httpClient.GetStreamAsync(url);
+
+// also correct for sync disposables
+using var stream = File.OpenRead(path);
+
+// old style — still valid but more verbose
+using (var stream = File.OpenRead(path))
+{
+    // ...
+}
+```
+
+The `await using` form is required for `IAsyncDisposable` (e.g., async streams).
+
+## `var` Usage Conventions
+
+Use `var` when the type is obvious from the right-hand side (constructor, cast, literal). Don't use it when the type is only readable from a method name:
+
+```csharp
+// clear — type is obvious
+var product = new Product();
+var products = await _productRepository.GetByIdAsync(id);
+
+// prefer explicit — type is not obvious from method name alone
+IList<Product> products = _catalogService.GetFeaturedProducts();
+```
+
+## Anti-Patterns
+
+| Anti-pattern | Correct |
+|---|---|
+| `if (x == null) throw new ArgumentNullException(nameof(x))` | `ArgumentNullException.ThrowIfNull(x)` |
+| Throwing `Exception` for a business rule violation | Return a result object with `.AddError(...)` |
+| `IOptions<T>` for configuration | `configuration.GetSection(...).Bind(config)` |
+| String-based MongoDB queries | LINQ expression predicates |
+| `null!` suppression without a documented reason | Remove the null, or handle it |
+| `try/finally { Dispose() }` | `using var x = ...` or `await using var x = ...` |
+| `new HttpClient()` in a service | Inject `IHttpClientFactory`, call `CreateClient()` |

--- a/skills/best-practices/mongodb.md
+++ b/skills/best-practices/mongodb.md
@@ -1,0 +1,128 @@
+# Best Practice: MongoDB / Repository
+
+Patterns derived from `Grand.Data` and `Grand.Business.*`. Never bypass the repository abstraction.
+
+---
+
+## IRepository\<T\> — the only data access surface
+
+Inject `IRepository<T>` where `T : BaseEntity`. Never inject `IMongoCollection<T>` or `IMongoDatabase` directly in business code.
+
+```csharp
+public class MyService
+{
+    private readonly IRepository<Product> _productRepository;
+    
+    public MyService(IRepository<Product> productRepository)
+    {
+        _productRepository = productRepository;
+    }
+}
+```
+
+---
+
+## Query Patterns
+
+### Fetch by ID
+
+```csharp
+var product = await _productRepository.GetByIdAsync(id);
+```
+
+### Fetch single by predicate
+
+```csharp
+var product = await _productRepository.GetOneAsync(p => p.Sku == sku);
+```
+
+### Fetch list with LINQ on `Table`
+
+`Table` is `IQueryable<T>` backed by MongoDB driver; the query is translated and executed on the database, not in memory.
+
+```csharp
+var query = from cr in _customerTagProductRepository.Table
+            where request.CustomerTagIds.Contains(cr.CustomerTagId)
+            orderby cr.DisplayOrder
+            select cr.ProductId;
+
+var ids = query.Take(limit).ToList();
+```
+
+### Paginated list
+
+```csharp
+public async Task<IPagedList<PickupPoint>> GetAllPickupPoints(
+    string storeId = "", int pageIndex = 0, int pageSize = int.MaxValue)
+{
+    var query = _pickupPointsRepository.Table;
+    if (!string.IsNullOrEmpty(storeId))
+        query = query.Where(pp => pp.StoreId == storeId);
+    query = query.OrderBy(pp => pp.DisplayOrder);
+    return await PagedList<PickupPoint>.Create(query, pageIndex, pageSize);
+}
+```
+
+---
+
+## Write Patterns
+
+### Insert
+
+```csharp
+await _repository.InsertAsync(entity);
+```
+
+After insert, publish the domain event:
+
+```csharp
+await _mediator.EntityInserted(entity);
+```
+
+### Full document replace (update all fields)
+
+```csharp
+await _repository.UpdateAsync(entity);
+await _mediator.EntityUpdated(entity);
+```
+
+### Partial field update — prefer over full replace
+
+Use `UpdateField` / `UpdateOneAsync` with `UpdateBuilder` when only one or a few fields change. This reduces write size and avoids overwriting concurrent changes.
+
+```csharp
+// update a single field
+await _repository.UpdateField(id, x => x.DisplayOrder, newOrder);
+
+// update multiple fields
+await _repository.UpdateOneAsync(
+    x => x.Id == id,
+    new UpdateBuilder<Product>()
+        .Set(x => x.Published, true)
+        .Set(x => x.UpdatedOnUtc, DateTime.UtcNow));
+```
+
+### Delete
+
+```csharp
+await _repository.DeleteAsync(entity);
+await _mediator.EntityDeleted(entity);
+```
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Correct alternative |
+|---|---|
+| `_repository.Table.ToList()` on large collections | Add `.Where(...)` before `.ToList()`, or use `PagedList` |
+| Fetching full document to update one field | `UpdateField<U>(id, x => x.Field, value)` |
+| Fetching by ID then checking null inside a loop | Batch by IDs with `GetProductsByIds` style method |
+| String-interpolated filter conditions | LINQ expression predicate — never string concatenation |
+| Calling `_repository.Table.Count()` without filter | Can be expensive on large collections; filter first |
+
+---
+
+## Index Awareness
+
+Queries on un-indexed fields cause collection scans. Before adding a query on a new field, check whether a MongoDB index exists in the migration files under `Grand.Module.Migration`. If not, add one.

--- a/skills/best-practices/performance.md
+++ b/skills/best-practices/performance.md
@@ -1,0 +1,147 @@
+# Best Practice: Performance
+
+Patterns from `Grand.Infrastructure.Caching`, `Grand.Business.*`, and `Grand.Domain`.
+
+---
+
+## Caching
+
+### Rule: every read-only service method that hits the DB must be cached
+
+Wrap database calls with `ICacheBase.GetAsync`. Direct repository calls without a cache check are a performance bug.
+
+```csharp
+public virtual Task<PickupPoint> GetPickupPointById(string pickupPointId)
+{
+    var key = string.Format(CacheKey.PICKUPPOINTS_BY_ID_KEY, pickupPointId);
+    return _cacheBase.GetAsync(key, () => _pickupPointsRepository.GetByIdAsync(pickupPointId));
+}
+```
+
+### Define cache keys as `static string` in the `CacheKey` partial class
+
+There are 21+ `CacheKey` partial classes under `Grand.Infrastructure/Caching/Constants/`. Add your keys there, not as inline strings.
+
+```csharp
+// in CacheKey partial for your domain area
+public static string PICKUPPOINTS_BY_ID_KEY => "Grand.pickuppoint.id-{0}";
+public static string PICKUPPOINTS_PATTERN_KEY => "Grand.pickuppoint.";
+```
+
+Use a dedicated pattern key for invalidation by prefix:
+
+```csharp
+await _cacheBase.RemoveByPrefix(CacheKey.PICKUPPOINTS_PATTERN_KEY);
+```
+
+### Invalidate after every write
+
+Call `RemoveByPrefix` or `RemoveAsync` in Insert/Update/Delete service methods so the cache stays consistent.
+
+```csharp
+await _pickupPointsRepository.UpdateAsync(pickupPoint);
+await _cacheBase.RemoveByPrefix(CacheKey.PICKUPPOINTS_PATTERN_KEY);
+await _mediator.EntityUpdated(pickupPoint);
+```
+
+### Cache key format
+
+```
+"Grand.{entity}.{discriminator}-{param}"
+```
+
+Use `string.Format(CacheKey.MY_KEY, id)` at the call site, not string interpolation, to keep the key format centralised.
+
+---
+
+## Pagination
+
+Never load an entire collection into memory. Use `PagedList<T>` with explicit page parameters.
+
+```csharp
+// admin list — large page size is acceptable
+var list = await _service.GetAll(pageIndex: 0, pageSize: int.MaxValue);
+
+// storefront — always constrain
+var list = await _service.GetAll(pageIndex: pageIndex, pageSize: pageSize);
+```
+
+`PagedList<T>.Create(query, pageIndex, pageSize)` issues a `Count()` and a `Skip/Take` on the database, not in memory.
+
+---
+
+## Partial Writes
+
+Replacing a full document when only one field changes wastes bandwidth and triggers index updates for every field. Use `UpdateField` for targeted writes:
+
+```csharp
+// instead of: entity.Published = true; await _repo.UpdateAsync(entity);
+await _repository.UpdateField(id, x => x.Published, true);
+```
+
+---
+
+## Projection
+
+Fetch only the fields you need. On `Table` (IQueryable) this translates to a MongoDB projection:
+
+```csharp
+var productIds = _productRepository.Table
+    .Where(p => p.Published)
+    .Select(p => p.Id)       // projection — only Id is fetched
+    .ToList();
+```
+
+Avoid pulling full documents just to read one property.
+
+---
+
+## HTTP Clients
+
+Never `new HttpClient()` directly — use `IHttpClientFactory`. The push notifications service and exchange rate plugin are the canonical examples:
+
+```csharp
+// Startup registration
+serviceCollection.AddHttpClient<IPushNotificationsService, PushNotificationsService>();
+
+// Named client registration (plugin)
+serviceCollection.AddHttpClient(Constant.DefaultHttpClientName);
+
+// Consumption via IHttpClientFactory
+public NbpExchange(IHttpClientFactory httpClientFactory)
+{
+    _httpClientFactory = httpClientFactory;
+}
+
+var client = _httpClientFactory.CreateClient(Constant.DefaultHttpClientName);
+```
+
+Instantiating `HttpClient` directly leaves sockets in `TIME_WAIT` and exhausts available connections under load.
+
+## Exceptions Are Not Flow Control
+
+Throwing an exception is expensive (stack walk, allocation). Use result objects for expected outcomes:
+
+```csharp
+// correct — expected failure as a result object
+var result = new PlaceOrderResult();
+result.AddError("Product is out of stock");
+return result;
+
+// avoid — throwing for an expected condition
+throw new Exception("Product is out of stock");
+```
+
+This is enforced throughout the codebase by `PlaceOrderResult`, `CapturePaymentResult`, etc.
+
+## Anti-Patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Repository call without cache | DB hit on every request | Wrap in `ICacheBase.GetAsync` |
+| `Table.ToList()` without filter | Full collection scan | Add `.Where(...)` first |
+| Cache key as inline `$"key-{id}"` | Bypasses central key registry | Use `CacheKey.MY_KEY` constant |
+| `int.MaxValue` page size on storefront | Returns entire collection to browser | Constrain to display page size |
+| Full replace to update one field | Over-writes concurrent partial updates | Use `UpdateField<U>` |
+| `new HttpClient()` directly | Socket exhaustion under load | Use `IHttpClientFactory` |
+| `throw new Exception(...)` for a business rule | Expensive; hard to handle | Return a result object |

--- a/skills/best-practices/security.md
+++ b/skills/best-practices/security.md
@@ -1,0 +1,119 @@
+# Best Practice: Security
+
+Patterns from `Grand.Web`, `Grand.Module.Api`, `Grand.Business.*`. Complementary to `skills/reviews/security-review/SKILL.md`.
+
+---
+
+## Authorization
+
+### Check permission before touching data
+
+Every API and admin controller action must call `IPermissionService.Authorize` before returning any data or performing any mutation.
+
+```csharp
+public async Task<IActionResult> Get()
+{
+    if (!await _permissionService.Authorize(PermissionSystemName.Brands))
+        return Forbid();
+    
+    return Ok(await _mediator.Send(new GetGenericQuery<BrandDto, Brand>()));
+}
+```
+
+Return `Forbid()` (403), not `Unauthorized()` (401), when the user is authenticated but lacks the required permission. 401 implies "not logged in".
+
+### Use `[PermissionAuthorize]` for simple cases
+
+For a controller where every action requires the same permission, prefer the attribute over per-action code:
+
+```csharp
+[PermissionAuthorize(PermissionSystemName.Brands)]
+public class BrandController : BaseAdminController { ... }
+```
+
+---
+
+## Input Validation
+
+### Use FluentValidation with record input types
+
+Define a record for the validator's subject to make the input immutable and explicit:
+
+```csharp
+public record ShoppingCartStandardValidatorRecord(
+    Customer Customer,
+    Product Product,
+    ShoppingCartItem ShoppingCartItem);
+
+public class ShoppingCartStandardValidator : AbstractValidator<ShoppingCartStandardValidatorRecord>
+{
+    public ShoppingCartStandardValidator(ITranslationService translationService, IAclService aclService)
+    {
+        RuleFor(x => x).Custom((value, context) =>
+        {
+            if (!value.Product.Published)
+                context.AddFailure(translationService.GetResource("ShoppingCart.ProductUnpublished"));
+        });
+    }
+}
+```
+
+### Guard at service entry points
+
+Use `ArgumentNullException.ThrowIfNull` / `ThrowIfNullOrEmpty` at the top of every service method that accepts reference parameters:
+
+```csharp
+public async Task SaveDeliveryDate(DeliveryDate deliveryDate)
+{
+    ArgumentNullException.ThrowIfNull(deliveryDate);
+    // ...
+}
+```
+
+---
+
+## Output Encoding
+
+### HTML-encode user-controlled text before rendering
+
+Any text that originates from user input and is rendered into HTML must be encoded with `WebUtility.HtmlEncode`:
+
+```csharp
+name = WebUtility.HtmlEncode(_product.GetTranslation(x => x.Name, _language.Id));
+```
+
+In Razor views, `@value` auto-encodes. Never use `@Html.Raw(userInput)`.
+
+---
+
+## Query Safety
+
+### Never build MongoDB filter strings from user input
+
+Use LINQ expression predicates or typed `FilterDefinition<T>`. The MongoDB LINQ provider translates them to safe queries — there is no query injection risk through typed expressions.
+
+```csharp
+// safe — LINQ expression
+var product = await _repository.GetOneAsync(p => p.Sku == userInput);
+
+// never — would open injection if the driver used string parsing
+var product = await collection.Find($"{{ sku: '{userInput}' }}").FirstOrDefaultAsync();
+```
+
+---
+
+## Secrets
+
+Never commit connection strings, API keys, or credentials to source. Use `appsettings.json` with `UserSecrets` in development and environment variables / Azure Key Vault in production. No hardcoded credentials anywhere in code.
+
+---
+
+## Summary Checklist
+
+- [ ] Every action checks `IPermissionService.Authorize` before data access
+- [ ] Returns `Forbid()` not `Unauthorized()` for permission failures
+- [ ] Business rule validation uses FluentValidation with record input types
+- [ ] Service entry points guard null arguments with `ArgumentNullException.ThrowIfNull`
+- [ ] User text rendered as HTML goes through `WebUtility.HtmlEncode`
+- [ ] MongoDB queries use LINQ expressions, never string interpolation
+- [ ] No secrets in source code

--- a/skills/best-practices/security.md
+++ b/skills/best-practices/security.md
@@ -8,7 +8,7 @@ Patterns from `Grand.Web`, `Grand.Module.Api`, `Grand.Business.*`. Complementary
 
 ### Check permission before touching data
 
-Every API and admin controller action must call `IPermissionService.Authorize` before returning any data or performing any mutation.
+Every API and admin controller action must enforce permissions (either via `[PermissionAuthorize]` / `[PermissionAuthorizeAction]` attributes or explicit `IPermissionService.Authorize` checks) before returning any data or performing any mutation.
 
 ```csharp
 public async Task<IActionResult> Get()

--- a/skills/best-practices/tests.md
+++ b/skills/best-practices/tests.md
@@ -1,0 +1,177 @@
+# Best Practice: Tests
+
+Patterns from `src/Tests/**`. Framework: **MSTest** + **Moq**.
+
+---
+
+## Project Naming
+
+Each business project has a sibling test project:
+
+```
+Grand.Business.Checkout   →  Grand.Business.Checkout.Tests
+Grand.Business.Catalog    →  Grand.Business.Catalog.Tests
+Grand.Web                 →  Grand.Web.Store.Tests
+```
+
+---
+
+## Test Structure
+
+### Framework attributes
+
+```csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+[TestClass]
+public class PickupPointServiceTests
+{
+    private Mock<IRepository<PickupPoint>> _repositoryMock;
+    private Mock<ICacheBase> _cacheMock;
+    private PickupPointService _service;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _repositoryMock = new Mock<IRepository<PickupPoint>>();
+        _cacheMock = new Mock<ICacheBase>();
+        _service = new PickupPointService(_repositoryMock.Object, _cacheMock.Object);
+    }
+}
+```
+
+- `[TestClass]` marks the class.
+- `[TestMethod]` marks each test.
+- `[TestInitialize]` runs before every test — initialize mocks and the subject under test here.
+
+### Arrange / Act / Assert
+
+Always structure test bodies with the three sections, using comment separators when the test is non-trivial:
+
+```csharp
+[TestMethod]
+public async Task Methods_ReturnPaymentMethodsForCurrentStore()
+{
+    // Arrange
+    _paymentServiceMock.Setup(p => p.LoadAllPaymentMethods(null, StoreId, ""))
+        .ReturnsAsync(new List<IPaymentProvider> { CreateProvider() });
+    
+    // Act
+    var result = await _controller.Methods();
+    
+    // Assert
+    var data = (DataSourceResult)((JsonResult)result).Value;
+    Assert.AreEqual(1, data.Total);
+    _paymentServiceMock.Verify(p => p.LoadAllPaymentMethods(null, StoreId, ""), Times.Once);
+}
+```
+
+### Test naming
+
+```
+MethodName_WhenCondition_ThenResult
+
+Examples:
+GetPickupPointById_WhenExists_ReturnsPoint
+PlaceOrder_WhenProductOutOfStock_ReturnsError
+ShoppingCartAuctionValidator_Fail
+```
+
+---
+
+## Mocking Patterns
+
+### Setup return values
+
+```csharp
+_settingServiceMock
+    .Setup(s => s.LoadSetting<PaymentSettings>(StoreId))
+    .ReturnsAsync(new PaymentSettings { ... });
+```
+
+### Translation service (always needed for validators)
+
+Every test that instantiates a FluentValidation validator must stub `ITranslationService`:
+
+```csharp
+_translationServiceMock
+    .Setup(t => t.GetResource(It.IsAny<string>()))
+    .Returns("resource");
+```
+
+### Verify interactions
+
+```csharp
+_paymentServiceMock.Verify(p => p.LoadAllPaymentMethods(null, StoreId, ""), Times.Once);
+_settingServiceMock.Verify(s => s.LoadSetting<PaymentSettings>(StoreId), Times.Once);
+```
+
+---
+
+## Testing Validators
+
+Use the record input types. Test both success and failure paths:
+
+```csharp
+[TestMethod]
+public void ShoppingCartAuctionValidator_Success()
+{
+    var validator = new ShoppingCartAuctionValidator(_translationServiceMock.Object);
+    
+    var result = validator.Validate(new ShoppingCartAuctionValidatorRecord(
+        new Customer(),
+        new Product { AvailableEndDateTimeUtc = DateTime.UtcNow.AddDays(1) },
+        new ShoppingCartItem(),
+        bidAmount: 10));
+    
+    Assert.IsTrue(result.IsValid);
+}
+
+[TestMethod]
+public void ShoppingCartAuctionValidator_Fail()
+{
+    var validator = new ShoppingCartAuctionValidator(_translationServiceMock.Object);
+    
+    var result = validator.Validate(new ShoppingCartAuctionValidatorRecord(
+        new Customer(),
+        new Product { AvailableEndDateTimeUtc = DateTime.UtcNow.AddDays(1), StartPrice = 20 },
+        new ShoppingCartItem(),
+        bidAmount: 10));     // bid below start price
+    
+    Assert.IsFalse(result.IsValid);
+}
+```
+
+---
+
+## Testing Controllers with AutoMapper
+
+Controllers that use the custom mapping framework need `AutoMapperConfig.Init` in setup:
+
+```csharp
+[TestInitialize]
+public void Setup()
+{
+    var mapperConfig = new MapperConfiguration(cfg =>
+    {
+        cfg.AddProfile<PaymentMethodProfile>();
+        cfg.AddProfile<CountryProfile>();
+    });
+    AutoMapperConfig.Init(mapperConfig);
+    
+    // ... rest of setup
+}
+```
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| No `[TestInitialize]` — new mocks inline | Mocks recreated manually in each test | Use `[TestInitialize]` |
+| No translation stub in validator tests | NullReferenceException at runtime | Always stub `GetResource` to return a string |
+| `Assert.IsTrue(result != null)` | Vague failure message | `Assert.IsNotNull(result)` |
+| Not verifying service calls | Test passes even if method was never called | Add `.Verify(...)` for critical interactions |
+| Hardcoded sleep / `Task.Delay` | Flaky tests | Design code to be testable without timing |

--- a/skills/best-practices/tests.md
+++ b/skills/best-practices/tests.md
@@ -11,8 +11,8 @@ Each business project has a sibling test project:
 ```
 Grand.Business.Checkout   →  Grand.Business.Checkout.Tests
 Grand.Business.Catalog    →  Grand.Business.Catalog.Tests
-Grand.Web                 →  Grand.Web.Store.Tests
-```
+Grand.Web                 →  Grand.Web.Tests
+Grand.Web.Store           →  Grand.Web.Store.Tests
 
 ---
 

--- a/skills/frontend-bundle-workflow/SKILL.md
+++ b/skills/frontend-bundle-workflow/SKILL.md
@@ -1,0 +1,146 @@
+# Skill: frontend-bundle-workflow
+
+## Purpose
+
+Guide agents making frontend changes in GrandNode's storefront: when to run the build, what gets rebuilt, and that the output must be committed alongside source.
+
+---
+
+## Project Location
+
+Single npm project at:
+
+```
+src/Web/Grand.Web/vueapp/
+```
+
+No other npm project in the solution (the old webpack project at `Grand.Web/` root was removed).
+
+---
+
+## Output Files (Committed to Git)
+
+All output lives in `src/Web/Grand.Web/wwwroot/bundles/` and is **tracked by git**:
+
+| File | Contents | Rebuilt by |
+|------|----------|------------|
+| `app.runtime.bundle.js` | Vue 3 + compat layer + views + behaviours + theme scripts | `vite build` |
+| `libs.css` | Bootstrap 5 + Bootstrap Icons + Pikaday + animate.css | `vite build` |
+| `style.min.css` | Six theme CSS parts minified and concatenated | `build-theme-css.mjs` |
+| `style.rtl.min.css` | Same as above, RTL variants | `build-theme-css.mjs` |
+| `fonts/` | Bootstrap Icons font files | written once, `emptyOutDir: false` preserves them |
+
+`npm run build` runs both steps in sequence. Never run only `vite build` directly if theme CSS has changed.
+
+---
+
+## When to Run `npm run build`
+
+Run the build after changing **any** of:
+
+- `vueapp/src/**` — Vue views, behaviours, theme scripts, compat layer
+- `wwwroot/theme/css/**` — theme stylesheets (`common/`, `header/`, `catalog/`, `product/`, `customer/`, `cart/`)
+- `vueapp/package.json` — dependency change (after `npm install`)
+
+Do **not** run the build for:
+- Server-side C# / Razor changes that don't touch JS or CSS
+- Changes inside `wwwroot/theme/script/app.js` or `Content/script/app.js` (theme-owned, not bundled here)
+- Changes to `public.checkout.js` (loaded separately, not part of this bundle)
+
+---
+
+## Build Commands
+
+```bash
+# one-time setup
+cd src/Web/Grand.Web/vueapp
+npm install
+
+# production build (always use this, not bare vite build)
+npm run build
+
+# lint
+npm run lint
+
+# dev server (hot reload against a running ASP.NET backend)
+npm run dev
+```
+
+`npm run dev` is optional. Changes are visible instantly via the dev server but still require a `npm run build` + commit before the bundle in the repo reflects them.
+
+---
+
+## Theme CSS Pipeline
+
+Source files are **not** directly served. `Head.cshtml` uses the raw files in Development but loads the minified bundles in Production.
+
+Cascade order (must not change):
+
+```
+common → header → catalog → product → customer → cart
+```
+
+Each part folder contains a regular file and an RTL variant:
+```
+wwwroot/theme/css/
+  common/common.css  common/common.rtl.css
+  header/header.css  header/header.rtl.css
+  catalog/...
+  product/...
+  customer/...
+  cart/...
+```
+
+`build-theme-css.mjs` generates `style.min.css` from the LTR files and `style.rtl.min.css` from the RTL variants using esbuild. The script is invoked automatically by `npm run build`.
+
+---
+
+## Commit Rules
+
+**Always commit the built output in the same commit as the source change.**
+
+The CI pipeline (`azure-pipelines.yml`) has no frontend build step — bundles are intentionally version-controlled. A PR that changes source files without updating `wwwroot/bundles/` will ship stale output.
+
+Checklist before committing a frontend change:
+
+1. Run `npm run build` from `vueapp/`.
+2. Stage source files AND the changed files in `wwwroot/bundles/` together.
+3. Verify `app.runtime.bundle.js`, `libs.css`, `style.min.css`, `style.rtl.min.css` are all staged when relevant.
+4. Do **not** stage `fonts/` unless bootstrap-icons was updated — they don't change on every build.
+
+---
+
+## Vite Config Notes
+
+- **Format:** IIFE (not ESM). The bundle assigns `window.Vue`, `window.bootstrap`, `window.axios` etc. and is loaded via `<script src>`. Any ESM change will break this.
+- **Base:** `/bundles/` — font url() references inside `libs.css` are rewritten against this prefix.
+- **`emptyOutDir: false`** — intentional; prevents deleting committed fonts and theme CSS on rebuild.
+- **`cssCodeSplit: false`** — all CSS from npm dependencies lands in `libs.css`.
+- **Vue alias:** resolves to `vue.esm-bundler.js` (includes template compiler) because templates are parsed from the DOM at runtime.
+
+---
+
+## Vue Source Structure
+
+```
+vueapp/src/
+  main.js          entry point — registers views and behaviours
+  views/           per-page Vue apps (19 files), mounted by Razor views
+  behaviours/      DOM enhancement modules (22 files), no Vue dependency
+  theme/           axios-cart.js, common.js, push-notifications.js
+  compat/          Vue 2 → 3 migration compatibility layer
+```
+
+Views are mounted by Razor views; behaviours run on `DOMContentLoaded` without a Vue instance.
+
+---
+
+## Theme Script Files Outside This Bundle
+
+Two files are **not** part of `vueapp` and must not be moved here:
+
+| File | Owner |
+|------|-------|
+| `wwwroot/theme/script/app.js` | Default theme |
+| `Plugins/Theme.Modern/Content/script/app.js` | Theme.Modern plugin |
+| `wwwroot/js/public.checkout.js` | Checkout-only script |

--- a/skills/message-notification/SKILL.md
+++ b/skills/message-notification/SKILL.md
@@ -1,0 +1,213 @@
+# Message and Notification
+
+## Purpose
+Create, modify, and review GrandNode email message templates, DotLiquid tokens, message sending flows, queued email lifecycle, and domain event notification handlers.
+
+## When To Use
+Use this skill when adding or changing a message template, adding new DotLiquid tokens or drop properties, triggering a new email notification from business code, seeding message templates in the installer, extending an existing `Liquid*` drop class, or wiring a MediatR event handler that sends a notification.
+
+## When Not To Use
+Do not use this skill for general admin UI work, settings, or localization changes beyond message template resource keys; combine it with `admin-area-changes` or `settings-and-localization` when those are also involved.
+
+Do not use this skill as the primary review for MongoDB queries or security; combine with the relevant skill when those concerns apply.
+
+## Inputs Required
+- Repository root.
+- Trigger event or business action that should send the notification.
+- Recipient type: customer, store owner, vendor, or arbitrary address.
+- Domain entities whose data must appear in the template body.
+- Whether the template is new or an existing one is being updated.
+- Required subject line and HTML body structure.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Message Templates
+1. Define the template name as a `public const string` in `MessageTemplateNames` at `src/Business/Grand.Business.Messages/Services/MessageTemplateNames.cs`. Follow the existing `Subject.RecipientNotification` naming convention.
+2. Seed the default template in `src/Modules/Grand.Module.Installer/Services/InstallDataMessageTemplates.cs` inside `InstallMessageTemplates()`. Every seeded template must reference a default email account, set `IsActive = true`, and include a valid DotLiquid `Subject` and `Body`.
+3. Keep template `Name` consistent with the constant defined in `MessageTemplateNames`. Code that sends the template looks it up by this name.
+4. Use `ITranslationEntity.Locales` on `MessageTemplate` for per-language subject and body overrides. Never store language-specific copies as separate documents.
+5. Only use tokens that are exposed by the relevant `Liquid*` drop classes or by `LiquidStore`. Do not invent tokens that have no backing drop property.
+6. Use DotLiquid syntax: `{{Drop.Property}}` for values, `{% if condition %}...{% endif %}` for conditions, `{% for item in Collection %}...{% endfor %}` for loops.
+
+#### Sending Messages
+7. Add a typed send method to `IMessageProviderService` in `src/Business/Grand.Business.Core/Interfaces/Messages/IMessageProviderService.cs` when the trigger is a recurring, well-defined business event. Follow the signature pattern:
+   ```csharp
+   Task<int> SendXxxMessage(TEntity entity, Store store, string languageId);
+   ```
+8. Implement the method in `MessageProviderService` at `src/Business/Grand.Business.Messages/Services/MessageProviderService.cs`. The standard implementation pattern is:
+   1. Get `MessageTemplate` by name using `IMessageTemplateService.GetMessageTemplateByName(name, store.Id)`.
+   2. Return 0 if the template is not active.
+   3. Resolve `EmailAccount` using the template's `EmailAccountId` and `IEmailAccountService`.
+   4. Build tokens with `LiquidObjectBuilder` using the appropriate `AddXxxTokens()` methods.
+   5. Call `await builder.Build()` to get the populated `LiquidObject`.
+   6. Call `await SendNotification(messageTemplate, emailAccount, languageId, liquidObject, toEmail, toName)`.
+9. Use the generic `SendNotification` overload directly when a one-off or plugin-triggered send does not justify a dedicated typed method.
+
+#### DotLiquid Drops and Tokens
+10. Add new token properties to an existing `Liquid*` drop class in `src/Business/Grand.Business.Core/Utilities/Messages/DotLiquidDrops/` when the data already belongs to that drop's entity. Do not add properties that require loading additional entities unless those are already available in the drop constructor.
+11. Add a new drop class inheriting from `DotLiquid.Drop` only when the new template uses a domain entity that has no existing drop. Place it in the drops folder and wire it via a new MediatR `GetXxxTokensCommand` following the pattern of existing token commands under `src/Business/Grand.Business.Core/Commands/Messages/Tokens/`.
+12. Handle `MessageTokensAddedEvent` in a MediatR `INotificationHandler` to inject extra tokens from a plugin without modifying core drop classes. The event carries the `MessageTemplate` name and the current `LiquidObject`.
+13. Never access `ITranslationService`, repositories, or services directly from inside a `Liquid*` drop property getter. Populate all values in the command handler that constructs the drop.
+
+#### Queued Emails
+14. All outgoing emails are persisted as `QueuedEmail` documents before they are sent. `SendNotification` queues the email via `IQueuedEmailService.InsertQueuedEmail`. Never call `IEmailSender` directly from business code.
+15. Respect `MessageTemplate.DelayBeforeSend` and `MessageTemplate.DelayPeriodId` — `SendNotification` converts these to `QueuedEmail.DontSendBeforeDateUtc`. Do not override or ignore the delay.
+16. The scheduled task `QueuedMessagesSendScheduleTask` in `Grand.Module.ScheduledTasks` sends queued emails. Do not introduce an alternative sending path.
+
+#### Domain Events and Handlers
+17. Raise domain events via `IMediator.Publish(new XxxEvent(...))` after the triggering business action completes. Do not publish inside a repository or data layer.
+18. Implement `INotificationHandler<TEvent>` in the relevant `Grand.Business.*` project when the notification should be sent in response to a domain event.
+19. Register event handlers automatically — MediatR scans assemblies registered in startup. No explicit handler registration is required beyond ensuring the assembly is included.
+
+### Recommendations
+1. Prefer adding a property to an existing drop over creating a new drop when the entity is already available in the build pipeline.
+2. Prefer the `MessageTokensAddedEvent` handler for plugin-specific tokens rather than modifying core drop classes.
+3. Prefer reusing `{{Store.Name}}`, `{{Store.URL}}`, and `{{Store.AdminEmail}}` tokens that are always available via `LiquidStore`.
+4. Prefer the `Reference` enum field on `QueuedEmail` (e.g., `Reference.Order`, `Reference.Customer`) to link queued emails to the source entity for audit purposes.
+5. Prefer testing `MessageProviderService` with a mock `IMessageTemplateService` that returns a pre-built `MessageTemplate` to verify the queuing call.
+
+## Constraints
+- Never hardcode email addresses in `SendXxx` methods; always resolve them from `EmailAccount` or from the entity being notified.
+- Never bypass `IQueuedEmailService`; do not call SMTP directly from business or web code.
+- Never use tokens that are not backed by a drop property — they will render as empty strings.
+- Never add rendering logic (formatting, currency, date) to drop property getters unless the same pattern is already used in that drop.
+- Never store multiple language copies of a template as separate `MessageTemplate` documents; use the `Locales` collection.
+- Never call `IMessageProviderService` from inside a Razor view or a controller action directly — trigger sends from handlers or services.
+
+## Key Contracts
+
+### IMessageProviderService (`src/Business/Grand.Business.Core/Interfaces/Messages/IMessageProviderService.cs`)
+Typed send methods follow the pattern:
+```csharp
+Task<int> SendCustomerRegisteredMessage(Customer customer, Store store, string languageId);
+Task<int> SendOrderPlacedCustomerMessage(Order order, Customer customer, Store store, string languageId);
+// ... one method per template
+```
+
+Generic send:
+```csharp
+Task<int> SendNotification(
+    MessageTemplate messageTemplate, EmailAccount emailAccount,
+    string languageId, LiquidObject liquidObject,
+    string toEmailAddress, string toName,
+    string attachmentFilePath = null, string attachmentFileName = null,
+    IEnumerable<string> attachedDownloads = null,
+    string replyToEmailAddress = null, string replyToName = null,
+    string fromEmail = null, string fromName = null, string subject = null,
+    Reference reference = Reference.None, string objectId = "");
+```
+
+### LiquidObjectBuilder (`src/Business/Grand.Business.Core/Utilities/Messages/DotLiquidDrops/LiquidObjectBuilder.cs`)
+```csharp
+var liquidObject = await new LiquidObjectBuilder(_mediator)
+    .AddStoreTokens(store, language, emailAccount)
+    .AddOrderTokens(order, customer, store, host)
+    .AddCustomerTokens(customer, store, host, language)
+    .Build();
+```
+
+### MessageTokensAddedEvent (`src/Business/Grand.Business.Core/Events/Messages/MessageTokensAddedEvent.cs`)
+```csharp
+public class MessageTokensAddedEvent : INotification {
+    public MessageTemplate Message { get; }
+    public LiquidObject LiquidObject { get; }
+}
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| MessageTemplate entity | `src/Core/Grand.Domain/Messages/MessageTemplate.cs` |
+| QueuedEmail entity | `src/Core/Grand.Domain/Messages/QueuedEmail.cs` |
+| EmailAccount entity | `src/Core/Grand.Domain/Messages/EmailAccount.cs` |
+| MessageTemplateNames constants | `src/Business/Grand.Business.Messages/Services/MessageTemplateNames.cs` |
+| IMessageProviderService interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IMessageProviderService.cs` |
+| MessageProviderService implementation | `src/Business/Grand.Business.Messages/Services/MessageProviderService.cs` |
+| IMessageTemplateService interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IMessageTemplateService.cs` |
+| IQueuedEmailService interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IQueuedEmailService.cs` |
+| IEmailAccountService interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IEmailAccountService.cs` |
+| IEmailSender interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IEmailSender.cs` |
+| DotLiquid drop classes | `src/Business/Grand.Business.Core/Utilities/Messages/DotLiquidDrops/` |
+| LiquidObjectBuilder | `src/Business/Grand.Business.Core/Utilities/Messages/DotLiquidDrops/LiquidObjectBuilder.cs` |
+| Token commands | `src/Business/Grand.Business.Core/Commands/Messages/Tokens/` |
+| MessageTokensAddedEvent | `src/Business/Grand.Business.Core/Events/Messages/MessageTokensAddedEvent.cs` |
+| IMessageTokenProvider interface | `src/Business/Grand.Business.Core/Interfaces/Messages/IMessageTokenProvider.cs` |
+| MessageTokenProvider implementation | `src/Business/Grand.Business.Messages/Services/MessageTokenProvider.cs` |
+| Installer — template seed | `src/Modules/Grand.Module.Installer/Services/InstallDataMessageTemplates.cs` |
+| Send scheduled task | `src/Modules/Grand.Module.ScheduledTasks/BackgroundServices/QueuedMessagesSendScheduleTask.cs` |
+| Tests | `src/Tests/Grand.Business.Messages.Tests/Services/` |
+
+## Available Liquid Drops
+
+| Drop class | Token prefix | Entity |
+|---|---|---|
+| `LiquidStore` | `{{Store.*}}` | Store, EmailAccount |
+| `LiquidCustomer` | `{{Customer.*}}` | Customer |
+| `LiquidOrder` | `{{Order.*}}`, `{{Order.OrderItems}}` | Order, OrderItem |
+| `LiquidShipment` | `{{Shipment.*}}` | Shipment |
+| `LiquidProduct` | `{{Product.*}}` | Product |
+| `LiquidMerchandiseReturn` | `{{MerchandiseReturn.*}}` | MerchandiseReturn |
+| `LiquidGiftVoucher` | `{{GiftVoucher.*}}` | GiftVoucher |
+| `LiquidNewsLetterSubscription` | `{{NewsLetterSubscription.*}}` | NewsLetterSubscription |
+| `LiquidVendor` | `{{Vendor.*}}` | Vendor |
+| `LiquidBlogComment` | `{{BlogComment.*}}` | BlogComment |
+| `LiquidNewsComment` | `{{NewsComment.*}}` | NewsComment |
+| `LiquidProductReview` | `{{ProductReview.*}}` | ProductReview |
+| `LiquidContactUs` | `{{ContactUs.*}}` | ContactUs |
+| `LiquidAskQuestion` | `{{AskQuestion.*}}` | AskQuestion |
+
+## Expected Output
+Produce one of these results:
+- A new or modified message template with matching constant, installer seed, send method, drop properties, and test.
+- A review report listing message and notification issues by severity.
+- A plugin token extension using `MessageTokensAddedEvent` without modifying core drops.
+
+Include changed files, token list, installer seed status, queuing behavior, and remaining risks.
+
+## Validation Checklist
+- [ ] Template name constant added or updated in `MessageTemplateNames`.
+- [ ] Template seeded in `InstallDataMessageTemplates` with active flag and email account.
+- [ ] Template name matches constant and lookup key in `SendXxx` method.
+- [ ] Only tokens backed by existing drop properties are used in subject and body.
+- [ ] New drop properties are populated in the command handler, not in the getter.
+- [ ] `LiquidObjectBuilder` includes all required `AddXxxTokens()` calls.
+- [ ] Send method calls `GetMessageTemplateByName`, resolves `EmailAccount`, builds tokens, and calls `SendNotification`.
+- [ ] Early return when template `IsActive == false`.
+- [ ] Emails are queued via `IQueuedEmailService`; `IEmailSender` is not called directly.
+- [ ] Template delay is not overridden in the send method.
+- [ ] Domain event handlers are in the correct `Grand.Business.*` project.
+- [ ] Tests cover the send method queuing call and inactive-template early return.
+
+## Examples
+
+### Example 1: New Order Status Email
+Input: Send an email to the customer when an order reaches a custom "Ready for pickup" status.
+
+Output:
+1. Add `const string SendOrderReadyForPickupCustomerMessage = "OrderReadyForPickup.CustomerNotification"` to `MessageTemplateNames`.
+2. Seed the template in `InstallDataMessageTemplates` with subject `"Your order {{Order.OrderNumber}} is ready"` and a body using `{{Order.*}}` and `{{Store.*}}` tokens.
+3. Add `Task<int> SendOrderReadyForPickupCustomerMessage(Order order, Customer customer, Store store, string languageId)` to `IMessageProviderService`.
+4. Implement the method in `MessageProviderService`: load template by name, return 0 if inactive, build `LiquidObjectBuilder` with `AddStoreTokens` + `AddOrderTokens` + `AddCustomerTokens`, call `SendNotification` with the customer's email.
+5. Publish `OrderReadyForPickupEvent` from the order status-change service and handle it in a `INotificationHandler<OrderReadyForPickupEvent>` that calls `_messageProviderService.SendOrderReadyForPickupCustomerMessage(...)`.
+
+### Example 2: Plugin Token Extension
+Input: A loyalty plugin needs to include a customer's loyalty points balance in existing order emails.
+
+Output:
+1. Create an `INotificationHandler<MessageTokensAddedEvent>` in the plugin.
+2. In `Handle`, check `notification.Message.Name` to filter only the relevant templates.
+3. Load the loyalty balance for the customer referenced in the existing `LiquidCustomer` drop on `notification.LiquidObject`.
+4. Assign a new `LiquidLoyaltyPoints` drop (or a simple string property) to `notification.LiquidObject`.
+5. Use `{{LoyaltyPoints.Balance}}` in the template body — it resolves from the drop set on `LiquidObject`.
+6. No changes to core drop classes are needed.
+
+### Example 3: Update Existing Template Body
+Input: Add the vendor name to the existing shipment sent email.
+
+Output:
+1. Confirm `LiquidShipment` or `LiquidVendor` already exposes a vendor name property; if not, add the property to the drop and populate it in `GetShipmentTokensCommand`.
+2. Update the `ShipmentSent.CustomerNotification` body in `InstallDataMessageTemplates` with the new token (for new installations).
+3. Provide a migration that updates the template body for existing installations in `Grand.Module.Migration`.

--- a/skills/permission-navigation/SKILL.md
+++ b/skills/permission-navigation/SKILL.md
@@ -1,0 +1,204 @@
+# Permission and Navigation
+
+## Purpose
+Create, modify, and review GrandNode permissions, controller authorization attributes, admin sitemap entries, and permission seeding for new features and panels.
+
+## When To Use
+Use this skill when adding a new admin feature that requires a permission check, adding a menu item to the Admin panel, changing which customer groups have access to a feature, adding a fine-grained action-level permission, reviewing controller authorization, or seeding permissions and navigation entries for existing or new installations.
+
+## When Not To Use
+Do not use this skill for Store Owner or Vendor panel UI work without a permission change; combine with `admin-area-changes` when controllers and views are also involved.
+
+Do not use this skill as the primary review for MongoDB query safety or authentication flow; combine with `security-review` or `dotnet-review` when those concerns apply.
+
+## Inputs Required
+- Repository root.
+- Feature name and affected panel: Admin, Store Owner, Vendor, or public store.
+- Required permission system name and category.
+- Actions the permission should gate: List, Create, Edit, Preview, Delete, Export, Import, etc.
+- Which customer groups should receive the permission by default.
+- Whether a sitemap (navigation) entry is required and where it should appear.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Defining a Permission
+1. Add a `public const string` to `PermissionSystemName` in `src/Core/Grand.Domain/Permissions/PermissionSystemName.cs`. Use `PascalCase` for the value, e.g. `"ManageRewards"`.
+2. Add a `public static readonly Permission` field to the appropriate `StandardPermission*` partial class in `src/Core/Grand.Domain/Permissions/`. Choose the file that matches the feature category (Catalog, Customer, Order, Marketing, Content, Configuration, System, Report, Vendor, Store, PublicStore). Create a new partial-class file only when none of the existing categories fits.
+3. Set these fields on the permission entry:
+   - `Name` — human-readable, e.g. `"Manage Rewards"`.
+   - `SystemName` — the `PermissionSystemName` constant defined in step 1.
+   - `Area` — use `"Admin area"`, `"Vendor area"`, `"Store area"`, or `"Public store"` matching the target panel.
+   - `Category` — match the private category constant used by the sibling permissions in the same file.
+   - `Actions` — list only the `PermissionActionName` constants that apply. Omit unused actions.
+4. Register the permission in `PermissionProvider.GetPermissions()` at `src/Business/Grand.Business.Common/Services/Security/PermissionProvider.cs`.
+5. Add a `DefaultPermission` entry in `PermissionProvider.GetDefaultPermissions()` to assign the permission to the correct customer group(s) by default. Use the group system names from `SystemCustomerGroupNames` (e.g., `Administrators`).
+
+#### Seeding for New Installations
+6. The installer reads permissions from `IPermissionProvider`. No separate installer file change is required when `PermissionProvider` is updated correctly — the installer calls `IPermissionProvider.GetPermissions()` and `GetDefaultPermissions()` during `InstallPermissions()` in `src/Modules/Grand.Module.Installer/Services/InstallDataPermissions.cs`.
+
+#### Seeding for Existing Installations
+7. Add a migration under `src/Modules/Grand.Module.Migration/Migrations/` when a new permission must appear on existing installations. In the migration, check whether the permission already exists by `SystemName` before inserting it to keep the migration idempotent.
+
+#### Authorizing Controllers
+8. Apply `[AuthorizeAdmin]` at class level on every Admin controller to enforce access to the admin panel. This checks `ManageAccessAdminPanel` and rejects vendor and store manager sessions.
+9. Apply `[AuthorizeVendor]` at class level on every Vendor controller. This checks `ManageAccessVendorPanel`, verifies the user is in the Vendors customer group, and verifies an active vendor account.
+10. Apply `[AuthorizeStore]` at class level on every Store Owner controller. This checks `ManageAccessStoreManagerPanel`, verifies the StoreManagers group, and verifies a `StaffStoreId` assignment.
+11. Apply `[PermissionAuthorize(PermissionSystemName.X)]` at class level on Admin, Store, or Vendor controllers to gate the entire controller on a specific feature permission. This must come after the panel-level attribute.
+12. Apply `[PermissionAuthorizeAction(PermissionActionName.X)]` at action method level to enforce granular action gating within a controller that already carries `[PermissionAuthorize(...)]`. This checks both the class-level permission and the named action.
+13. Never substitute `IPermissionService.Authorize(...)` in a controller action for the attribute-based approach unless the check is conditional on runtime data. Attribute checks run before the action body executes.
+
+#### Admin Sitemap (Navigation)
+14. Add a new `AdminSiteMap` entry to `StandardAdminSiteMap.SiteMap` in `src/Modules/Grand.Module.Installer/Utilities/StandardAdminSiteMap.cs` for new installations. Set:
+   - `SystemName` — unique identifier string.
+   - `ResourceName` — localization key, e.g. `"Admin.Catalog.Rewards.Manage"`.
+   - `ControllerName` and `ActionName` — must match the route. Use `Url` only when a controller/action pair does not apply.
+   - `PermissionNames` — list of `PermissionSystemName` constants; the menu item is hidden when the user lacks all listed permissions (or any, when `AllPermissions = false`).
+   - `AllPermissions` — set `true` only when the page genuinely requires every listed permission simultaneously.
+   - `IconClass` — copy an icon class from a sibling entry in the same category group.
+   - `DisplayOrder` — order within its parent `ChildNodes` list.
+15. Place leaf items inside the `ChildNodes` of the appropriate root category node. Do not add top-level root nodes unless the feature cannot belong to any existing category.
+16. Add a migration that inserts the `AdminSiteMap` entry for existing installations using `IAdminSiteMapService.InsertSiteMap(...)`. Check whether the entry already exists by `SystemName` before inserting.
+17. Add the corresponding localization resource key to `DefaultLanguage.xml` (`src/Web/Grand.Web/App_Data/Resources/DefaultLanguage.xml`) so the menu label renders correctly.
+
+### Recommendations
+1. Prefer existing `PermissionActionName` constants over inventing new action name strings.
+2. Prefer placing a new permission in an existing `StandardPermission*` partial class over adding a new file.
+3. Prefer assigning new admin-area permissions to the `Administrators` group by default; leave Store and Vendor area permissions to their respective groups.
+4. Prefer an empty `PermissionNames` list on parent category nodes and explicit `PermissionNames` on leaf nodes, matching the pattern of sibling entries.
+5. Prefer verifying the permission check at the controller or action level rather than inside the view template.
+
+## Constraints
+- Never place a permission constant directly in a controller instead of referencing `PermissionSystemName`.
+- Never hardcode a customer group ID in `DefaultPermission`; use `SystemCustomerGroupNames` constants.
+- Never add a sitemap entry without a matching permission or without confirming the route exists.
+- Never skip the migration for existing installations when a new permission or sitemap entry is required.
+- Never apply `[PermissionAuthorizeAction(...)]` on an action whose class does not carry `[PermissionAuthorize(...)]`.
+- Never use UI-side hiding alone to restrict access; server-side attribute checks are mandatory.
+
+## Key Contracts
+
+### Permission entity (`src/Core/Grand.Domain/Permissions/Permission.cs`)
+```csharp
+public class Permission : BaseEntity {
+    public string Name       { get; set; }   // display name
+    public string SystemName { get; set; }   // unique key, matches PermissionSystemName constant
+    public string Area       { get; set; }   // "Admin area" | "Vendor area" | "Store area" | "Public store"
+    public string Category   { get; set; }   // grouping label shown in ACL grid
+    public ICollection<string> CustomerGroups { get; set; }  // assigned group IDs
+    public ICollection<string> Actions       { get; set; }   // gatable sub-actions
+}
+```
+
+### Authorization attributes
+
+| Attribute | Target | Checks |
+|---|---|---|
+| `[AuthorizeAdmin]` | Controller class | `ManageAccessAdminPanel`; rejects vendors/store managers |
+| `[AuthorizeVendor]` | Controller class | `ManageAccessVendorPanel` + Vendors group + active vendor |
+| `[AuthorizeStore]` | Controller class | `ManageAccessStoreManagerPanel` + StoreManagers group + StaffStoreId |
+| `[AuthorizeAdminOrStore]` | Controller class | Admin OR Store Owner; includes IP restriction check |
+| `[PermissionAuthorize("SystemName")]` | Controller class | Named feature permission for current customer |
+| `[PermissionAuthorizeAction("ActionName")]` | Action method | Named action within the class-level feature permission |
+
+### PermissionActionName constants (`src/Core/Grand.Domain/Permissions/PermissionActionName.cs`)
+`List`, `Preview`, `Create`, `Edit`, `Delete`, `Export`, `Import`, `Payments`, `Cancel`, plus sub-entity variants for Weights, Dimensions, Units.
+
+### AdminSiteMap entity (`src/Core/Grand.Domain/Admin/AdminSiteMap.cs`)
+```csharp
+public class AdminSiteMap : BaseEntity {
+    public string SystemName    { get; set; }
+    public string ResourceName  { get; set; }   // localization key
+    public string ControllerName { get; set; }
+    public string ActionName    { get; set; }
+    public string Url           { get; set; }   // use when no controller/action
+    public IList<AdminSiteMap> ChildNodes   { get; set; }
+    public string IconClass     { get; set; }
+    public int    DisplayOrder  { get; set; }
+    public IList<string> PermissionNames { get; set; }
+    public bool   AllPermissions { get; set; }  // false = ANY permission; true = ALL
+}
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| Permission entity | `src/Core/Grand.Domain/Permissions/Permission.cs` |
+| PermissionSystemName constants | `src/Core/Grand.Domain/Permissions/PermissionSystemName.cs` |
+| PermissionActionName constants | `src/Core/Grand.Domain/Permissions/PermissionActionName.cs` |
+| StandardPermission (panel access) | `src/Core/Grand.Domain/Permissions/StandardPermission.cs` |
+| StandardPermission by category | `src/Core/Grand.Domain/Permissions/StandardPermission*.cs` |
+| DefaultPermission entity | `src/Core/Grand.Domain/Permissions/DefaultPermission.cs` |
+| IPermissionProvider interface | `src/Business/Grand.Business.Core/Interfaces/Common/Security/IPermissionProvider.cs` |
+| PermissionProvider implementation | `src/Business/Grand.Business.Common/Services/Security/PermissionProvider.cs` |
+| IPermissionService interface | `src/Business/Grand.Business.Core/Interfaces/Common/Security/IPermissionService.cs` |
+| AuthorizeAdmin attribute | `src/Web/Grand.Web.Common/Filters/AuthorizeAdminAttribute.cs` |
+| AuthorizeVendor attribute | `src/Web/Grand.Web.Common/Filters/AuthorizeVendorAttribute.cs` |
+| AuthorizeStore attribute | `src/Web/Grand.Web.Common/Filters/AuthorizeStoreAttribute.cs` |
+| AuthorizeAdminOrStore attribute | `src/Web/Grand.Web.Common/Filters/AuthorizeAdminOrStoreAttribute.cs` |
+| PermissionAuthorize attribute | `src/Web/Grand.Web.Common/Security/Authorization/PermissionAuthorizeAttribute.cs` |
+| PermissionAuthorizeAction attribute | `src/Web/Grand.Web.Common/Security/Authorization/PermissionAuthorizeActionAttribute.cs` |
+| AdminSiteMap entity | `src/Core/Grand.Domain/Admin/AdminSiteMap.cs` |
+| StandardAdminSiteMap seed | `src/Modules/Grand.Module.Installer/Utilities/StandardAdminSiteMap.cs` |
+| IAdminSiteMapService | `src/Business/Grand.Business.Core/Interfaces/System/Admin/IAdminSiteMapService.cs` |
+| AdminSiteMapService | `src/Web/Grand.Web.Common/Menu/AdminSiteMapService.cs` |
+| Installer — permissions seed | `src/Modules/Grand.Module.Installer/Services/InstallDataPermissions.cs` |
+| Tests — PermissionService | `src/Tests/Grand.Business.Common.Tests/Services/Security/PermissionServiceTests.cs` |
+| Tests — PermissionProvider | `src/Tests/Grand.Business.Common.Tests/Services/Security/PermissionProviderTests.cs` |
+| Tests — AdminSiteMapService | `src/Tests/Grand.Web.Common.Tests/Services/Admin/AdminSiteMapServiceTests.cs` |
+
+## Expected Output
+Produce one of these results:
+- A new permission constant, `StandardPermission` entry, `PermissionProvider` update, migration, controller attributes, and sitemap entry.
+- A review report listing missing or incorrectly applied permission checks.
+- A plan when the feature scope or customer group mapping cannot be determined from the repository.
+
+Include changed files, permission system name, customer group assignment, sitemap location, migration status, and remaining risks.
+
+## Validation Checklist
+- [ ] `PermissionSystemName` constant added.
+- [ ] `StandardPermission` static field added with correct `Area`, `Category`, and `Actions`.
+- [ ] Permission registered in `PermissionProvider.GetPermissions()`.
+- [ ] Default group assignment added in `PermissionProvider.GetDefaultPermissions()`.
+- [ ] Migration adds the permission for existing installations (idempotent check by `SystemName`).
+- [ ] Admin controllers carry `[AuthorizeAdmin]` at class level.
+- [ ] Vendor controllers carry `[AuthorizeVendor]` at class level.
+- [ ] Store controllers carry `[AuthorizeStore]` at class level.
+- [ ] Feature controllers carry `[PermissionAuthorize(PermissionSystemName.X)]` at class level.
+- [ ] Action-level `[PermissionAuthorizeAction(...)]` used only on controllers that already carry `[PermissionAuthorize(...)]`.
+- [ ] Sitemap leaf entry added to `StandardAdminSiteMap` under the correct parent node.
+- [ ] Sitemap migration adds the entry for existing installations (idempotent check by `SystemName`).
+- [ ] Localization resource key added to `DefaultLanguage.xml` for the menu label.
+
+## Examples
+
+### Example 1: New Admin Feature with Permission and Menu Entry
+Input: Add a "Manage Rewards" feature in the Catalog section for administrators.
+
+Output:
+1. Add `public const string Rewards = "ManageRewards"` to `PermissionSystemName`.
+2. Add `public static readonly Permission ManageRewards` to `StandardPermissionCatalog.cs` with `Area = "Admin area"`, `Category = CategoryCatalog`, `Actions = [List, Create, Edit, Delete]`.
+3. Register in `PermissionProvider.GetPermissions()` and add a `DefaultPermission` mapping to `Administrators` in `GetDefaultPermissions()`.
+4. Create a migration that inserts the permission when `SystemName == "ManageRewards"` does not yet exist.
+5. Decorate `RewardsController` with `[AuthorizeAdmin]` and `[PermissionAuthorize(PermissionSystemName.Rewards)]`. Add `[PermissionAuthorizeAction(PermissionActionName.Create)]` on the POST create action.
+6. Add a sitemap leaf entry to the Catalog `ChildNodes` in `StandardAdminSiteMap` with `PermissionNames = ["ManageRewards"]` and the `Admin.Catalog.Rewards.Manage` resource key.
+7. Add a migration that inserts the sitemap entry by `SystemName` when it does not yet exist.
+8. Add `admin.catalog.rewards.manage` to `DefaultLanguage.xml`.
+
+### Example 2: Restrict an Existing Action
+Input: The "Delete" action on the blog controller should be available to administrators only, not store managers.
+
+Output:
+1. Verify `[PermissionAuthorize(PermissionSystemName.Blog)]` is already on the controller.
+2. Add `[PermissionAuthorizeAction(PermissionActionName.Delete)]` to the DELETE action method.
+3. In the admin ACL configuration, remove the `Delete` action from the `ManageBlog` permission for the StoreManagers customer group by updating the default in `PermissionProvider.GetDefaultPermissions()` or via a migration that updates the allowed actions.
+
+### Example 3: Vendor-Specific Permission Check
+Input: A vendor controller action should verify the user is in the Vendors group and has the `ManageVendorReviews` permission before loading reviews.
+
+Output:
+1. Confirm `[AuthorizeVendor]` is at class level (enforces panel access and active vendor account).
+2. Add `[PermissionAuthorize(PermissionSystemName.VendorReviews)]` at class level to enforce the feature permission on top of panel access.
+3. No sitemap change is needed because vendor navigation is not database-driven.

--- a/skills/permission-navigation/SKILL.md
+++ b/skills/permission-navigation/SKILL.md
@@ -42,9 +42,9 @@ Do not use this skill as the primary review for MongoDB query safety or authenti
 7. Add a migration under `src/Modules/Grand.Module.Migration/Migrations/` when a new permission must appear on existing installations. In the migration, check whether the permission already exists by `SystemName` before inserting it to keep the migration idempotent.
 
 #### Authorizing Controllers
-8. Apply `[AuthorizeAdmin]` at class level on every Admin controller to enforce access to the admin panel. This checks `ManageAccessAdminPanel` and rejects vendor and store manager sessions.
-9. Apply `[AuthorizeVendor]` at class level on every Vendor controller. This checks `ManageAccessVendorPanel`, verifies the user is in the Vendors customer group, and verifies an active vendor account.
-10. Apply `[AuthorizeStore]` at class level on every Store Owner controller. This checks `ManageAccessStoreManagerPanel`, verifies the StoreManagers group, and verifies a `StaffStoreId` assignment.
+8. Ensure Admin controllers inherit from `BaseAdminController` (it already applies `[AuthorizeAdmin]`) to enforce access to the admin panel.
+9. Ensure Vendor controllers inherit from `BaseVendorController` (it already applies `[AuthorizeVendor]`) to enforce vendor panel access.
+10. Ensure Store Owner controllers inherit from `BaseStoreController` (it already applies `[AuthorizeStore]`) to enforce store panel access.
 11. Apply `[PermissionAuthorize(PermissionSystemName.X)]` at class level on Admin, Store, or Vendor controllers to gate the entire controller on a specific feature permission. This must come after the panel-level attribute.
 12. Apply `[PermissionAuthorizeAction(PermissionActionName.X)]` at action method level to enforce granular action gating within a controller that already carries `[PermissionAuthorize(...)]`. This checks both the class-level permission and the named action.
 13. Never substitute `IPermissionService.Authorize(...)` in a controller action for the attribute-based approach unless the check is conditional on runtime data. Attribute checks run before the action body executes.

--- a/skills/plugins/plugin-discount-rules/SKILL.md
+++ b/skills/plugins/plugin-discount-rules/SKILL.md
@@ -1,0 +1,153 @@
+# Plugin — Discount Rules Provider
+
+## Purpose
+Create, modify, and review GrandNode discount rule plugins that implement `IDiscountProvider` and one or more `IDiscountRule` classes.
+
+## When To Use
+Use this skill when building a new discount requirement rule, adding a rule type to an existing plugin, changing rule validation logic, building a rule configuration UI, or reviewing discount rule correctness.
+
+## When Not To Use
+Do not use this skill for discount domain entity management, pricing calculation, or general plugin infrastructure; combine with `plugin-module` when foundational setup is needed.
+
+## Inputs Required
+- Repository root.
+- The condition the rule validates (e.g., customer group, minimum spend, product ownership).
+- Whether the rule needs admin configuration per discount instance.
+- What data the rule needs at validation time (customer, cart, store, etc.).
+
+## Instructions
+
+### Mandatory Rules
+
+#### Provider and Rule Interfaces
+1. Implement `IDiscountProvider` from `Grand.Business.Core.Interfaces.Catalog.Discounts`. This extends `IProvider` requiring `ConfigurationUrl`, `SystemName`, `FriendlyName`, `Priority`, `LimitedToStores`, `LimitedToGroups`.
+2. Implement `IDiscountProvider.GetRequirementRules()` to return all `IDiscountRule` instances this plugin provides.
+3. For each rule type, create a class implementing `IDiscountRule`:
+
+| Member | Requirement |
+|---|---|
+| `string SystemName` | Unique identifier in the format `"{PluginSystemName}.{RuleName}"`, e.g. `"DiscountRules.Standard.MustBeAssignedToCustomerGroup"`. |
+| `string FriendlyName` | Human-readable rule name shown in the admin discount editor. |
+| `Task<DiscountRuleValidationResult> CheckRequirement(request)` | Validation logic. Return `result.IsValid = true` on pass; set `result.UserError` when the rule fails and you want a customer-facing message. |
+| `string GetConfigurationUrl(discountId, requirementId)` | Return the URL of the rule's admin configuration page. Format: `"/{ControllerName}/Configure/?discountId={discountId}&discountRequirementId={requirementId}"`. Return `""` if the rule needs no configuration. |
+
+4. Keep `CheckRequirement` idempotent and side-effect free — it is called on every cart recalculation.
+5. Read rule configuration from `request.DiscountRule.Metadata` (a string stored per `DiscountRule` instance). Parse the format you write during configuration (plain string, ID, JSON, etc.).
+
+#### DiscountRuleValidationRequest (key fields)
+```csharp
+Discount      Discount     { get; }   // the discount being validated
+DiscountRule  DiscountRule { get; }   // the rule instance (carries Metadata)
+Customer      Customer     { get; }   // current customer
+Store         Store        { get; }   // current store
+```
+
+#### Admin Configuration Controller
+6. Create a storefront-accessible controller (no `[Area("Admin")]`) for each rule that requires configuration. The route must match `GetConfigurationUrl`.
+7. The controller renders a configuration form that saves the chosen value (customer group ID, amount, product ID, etc.) back to `DiscountRule.Metadata` via the discount service.
+8. Inject `IDiscountService` to load and update the `DiscountRule` entity during save.
+9. Protect the configuration controller with `[AuthorizeAdmin]` since it is accessed from the admin discount edit page via an iframe or popup. Use `[Area("Admin")]` when it is admin-routed; omit the area when it is accessed from the public route prefix (follow the nearest existing rule controller pattern).
+
+#### DI Registration
+10. Register the provider and all rule classes in `StartupApplication.ConfigureServices`:
+    ```csharp
+    services.AddScoped<IDiscountProvider, YourDiscountProvider>();
+    services.AddScoped<YourRule1>();
+    services.AddScoped<YourRule2>();
+    ```
+    Inject the rule instances into the provider constructor and return them from `GetRequirementRules()`.
+
+#### Project Structure
+11. Use `Microsoft.NET.Sdk.Razor` when configuration views are present; `Microsoft.NET.Sdk` otherwise.
+12. Set output path to `..\..\Web\Grand.Web\Plugins\{SystemName}\`.
+13. Mark all GrandNode project references `Private="false"`.
+14. Include `logo.jpg` with `CopyToOutputDirectory = Always`.
+
+#### Manifest, Defaults, Settings
+15. Define `[assembly: PluginInfo(...)]` with `Group = "Discount rules"`.
+16. Define a `Defaults` class with `ProviderSystemName`, `FriendlyName` (resource key), and system names for each rule type.
+17. Plugin-level `ISettings` is only needed when the plugin itself has shared configuration across all rule instances. Per-instance rule config goes in `DiscountRule.Metadata`.
+
+#### Startup and Install
+18. In `Install()`: register localization keys for the plugin and each rule's `FriendlyName`. Call `base.Install()` last.
+19. In `Uninstall()`: remove resource keys. Call `base.Uninstall()` last. If the plugin owns no settings, `DeleteSetting` is not needed.
+
+### Recommendations
+1. Prefer `DiscountRules.Standard` as the template — it bundles multiple rules in one plugin, showing the full pattern.
+2. Prefer storing a single domain ID (group ID, product ID) as `Metadata` for simple rules rather than serializing complex objects.
+3. Prefer returning an empty `UserError` when the rule fails silently (cart recalculation); populate it only when the customer should see an explanation.
+4. Prefer early-return `result.IsValid = false` with no error for cases where the customer simply doesn't meet the condition yet (e.g., not enough spend).
+
+## Key Contracts
+
+### IDiscountProvider
+```csharp
+IList<IDiscountRule> GetRequirementRules();
+// + all IProvider members: ConfigurationUrl, SystemName, FriendlyName, Priority, LimitedToStores, LimitedToGroups
+```
+
+### IDiscountRule
+```csharp
+string SystemName   { get; }
+string FriendlyName { get; }
+Task<DiscountRuleValidationResult> CheckRequirement(DiscountRuleValidationRequest request);
+string GetConfigurationUrl(string discountId, string discountRequirementId);
+```
+
+### DiscountRuleValidationResult
+```csharp
+public bool   IsValid    { get; set; }
+public string UserError  { get; set; }   // shown to customer; empty = silent fail
+```
+
+### DiscountRule entity (key fields used by rules)
+```csharp
+public string DiscountRequirementRuleSystemName { get; set; }  // matches IDiscountRule.SystemName
+public string Metadata                          { get; set; }  // rule-specific config (group ID, amount, etc.)
+```
+
+### Discount entity (key fields relevant to rules)
+```csharp
+public bool   RequiresCouponCode  { get; set; }
+public bool   IsCumulative        { get; set; }
+public int    DiscountLimitationId { get; set; }
+public ICollection<DiscountRule> DiscountRules { get; set; }
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| IDiscountProvider | `src/Business/Grand.Business.Core/Interfaces/Catalog/Discounts/IDiscountProvider.cs` |
+| IDiscountRule | `src/Business/Grand.Business.Core/Interfaces/Catalog/Discounts/IDiscountRule.cs` |
+| DiscountRuleValidationRequest | `src/Business/Grand.Business.Core/Utilities/Catalog/DiscountRuleValidationRequest.cs` |
+| DiscountRuleValidationResult | `src/Business/Grand.Business.Core/Utilities/Catalog/DiscountRuleValidationResult.cs` |
+| Discount entity | `src/Core/Grand.Domain/Discounts/Discount.cs` |
+| DiscountRule entity | `src/Core/Grand.Domain/Discounts/DiscountRule.cs` |
+| IDiscountService | `src/Business/Grand.Business.Core/Interfaces/Catalog/Discounts/IDiscountService.cs` |
+| Example — multiple rules | `src/Plugins/DiscountRules.Standard/` |
+
+## Validation Checklist
+- [ ] `IDiscountProvider` and `IProvider` members all implemented.
+- [ ] `GetRequirementRules()` returns all rule instances.
+- [ ] Each `IDiscountRule` has a globally unique `SystemName`.
+- [ ] `CheckRequirement` is side-effect free and reads config from `request.DiscountRule.Metadata`.
+- [ ] `GetConfigurationUrl` returns a URL matching the configuration controller route, or `""` for rules with no config.
+- [ ] Each rule class registered in DI individually via `AddScoped<YourRule>()`.
+- [ ] Provider registered with `AddScoped<IDiscountProvider, ...>`.
+- [ ] Output path set to `Grand.Web/Plugins/{SystemName}/`.
+- [ ] `Install` registers resource keys; `Uninstall` removes them.
+
+## Examples
+
+### Example 1: Customer Group Rule
+`CheckRequirement` reads `request.DiscountRule.Metadata` as a customer group ID and checks `request.Customer.Groups.Contains(groupId)`. Configuration controller shows a dropdown of customer groups and saves the selected ID to `DiscountRule.Metadata`.
+
+### Example 2: Minimum Spend Rule
+`CheckRequirement` reads a minimum amount from `Metadata`, retrieves the customer's order history total via `IOrderService`, and returns `IsValid = true` when the total meets or exceeds the threshold.
+
+### Example 3: Has Specific Product in Cart Rule
+`CheckRequirement` reads a product ID from `Metadata`, iterates the customer's current cart items (accessible via cart session or passed context), and returns `IsValid = true` when the product is found.
+
+### Example 4: Multiple Rules in One Plugin
+Pattern from `DiscountRules.Standard`: define `CustomerGroupDiscountRule`, `HadSpentAmountDiscountRule`, `HasAllProductsDiscountRule`, `HasOneProductDiscountRule`, `ShoppingCartDiscountRule` as separate classes. Register each with `AddScoped<T>()`. Inject all into `DiscountProvider` constructor and return them from `GetRequirementRules()`.

--- a/skills/plugins/plugin-module/SKILL.md
+++ b/skills/plugins/plugin-module/SKILL.md
@@ -1,0 +1,105 @@
+# Plugin Module
+
+## Purpose
+Create, modify, and review GrandNode plugins and modules using the repository's existing extension patterns.
+
+## When To Use
+Use this skill when working in `src/Plugins`, `src/Modules`, plugin manifests, provider implementations, plugin settings, plugin install or uninstall logic, plugin controllers, plugin views, module startup, module output paths, or extension-point registrations.
+
+Use this skill when asked to create a new payment, shipping, tax, widget, authentication, discount rule, exchange rate, theme, API, migration, installer, or scheduled task extension.
+
+## When Not To Use
+Do not use this skill for ordinary core, business, domain, or web changes that do not add or modify plugins or modules.
+
+Do not use this skill as the primary review for payment correctness, tenant isolation, MongoDB query safety, or security-sensitive behavior; combine it with the relevant skill when those concerns are present.
+
+## Inputs Required
+- Repository root.
+- Target extension type: plugin or module.
+- Existing extension to use as the closest template.
+- Desired system name, friendly name, group, and feature scope.
+- Required provider interface or module startup behavior.
+- Admin or store configuration requirements.
+- Settings, localization resources, static assets, views, and tests required by the change.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify whether the work is a plugin under `src/Plugins` or a module under `src/Modules`.
+2. Identify the closest existing implementation and follow its folder, namespace, project, startup, controller, view, setting, and test patterns.
+3. Read `references/plugin-types.md` before creating or changing a plugin.
+4. Read `references/module-types.md` before creating or changing a module.
+5. Use a stable system name that matches the repository convention, such as `Payments.X`, `Shipping.X`, `Tax.X`, `Widgets.X`, `Authentication.X`, `DiscountRules.X`, `ExchangeRate.X`, or `Theme.X`.
+6. Add or update `Manifest.cs` for plugins with `[assembly: PluginInfo(...)]`.
+7. Add or update a plugin class that derives from `BasePlugin` when install, uninstall, or configuration behavior is required.
+8. Register provider and service implementations in `StartupApplication : IStartupApplication`.
+9. Keep `Priority`, `BeforeConfigure`, and `Configure` behavior consistent with nearby extensions unless the feature requires a different startup order.
+10. Put plugin build output under `src/Web/Grand.Web/Plugins/{SystemName}` and module build output under `src/Web/Grand.Web/Modules/{ModuleName}`.
+11. Set project references to shared GrandNode projects with `Private=false` or the existing local casing and runtime exclusion pattern used by the closest template.
+12. Add settings classes only when values must be persisted or configured.
+13. Add install logic for default settings and localization resources.
+14. Add uninstall logic that removes plugin-owned settings and localization resources.
+15. Add admin or store controllers only when configuration or interaction is required.
+16. Use `BaseAdminPluginController`, `BasePluginController`, or the existing module controller base that matches the nearest implementation.
+17. Add Razor views, `_ViewImports.cshtml`, components, static assets, and route providers only when the extension needs UI.
+18. Ensure plugin provider `SystemName` equals the default constant and manifest system name.
+19. Ensure provider `ConfigurationUrl`, `FriendlyName`, `Priority`, `LimitedToStores`, and `LimitedToGroups` follow the provider contract.
+20. Add tests or update existing tests for provider behavior, startup registration, install or uninstall effects, and domain-specific behavior.
+21. Build the specific plugin or module project when execution is available.
+22. State any build or test command that was not run.
+
+### Recommendations
+1. Prefer copying the nearest existing extension shape before inventing a new structure.
+2. Prefer constants in a `Defaults` class for provider system name, friendly name resource key, configuration URL, route names, and asset paths.
+3. Prefer `ISettingService` for plugin settings and `IPluginTranslateResource` for plugin-owned localization resources.
+4. Prefer store-specific settings only when the existing service resolves store overrides.
+5. Prefer small provider methods that delegate complex behavior to plugin services.
+6. Prefer adding a new reference file only when a new extension type appears in the repository.
+
+## Constraints
+- Never create a plugin or module outside `src/Plugins` or `src/Modules`.
+- Never use a system name that conflicts with an existing plugin or provider.
+- Never register a provider without a matching provider interface expected by the target subsystem.
+- Never put plugin-owned binaries, views, or assets directly into `Grand.Web` source folders.
+- Never skip install or uninstall cleanup for settings and localization resources owned by the plugin.
+- Never hardcode secrets, API keys, tokens, callback URLs, or environment-specific connection strings.
+- Never introduce a package version outside central package management unless the repository pattern explicitly requires it.
+- Never change shared build props to make one plugin work unless the change is necessary for all plugins or modules.
+
+## Expected Output
+Produce one of these results:
+- A new or modified plugin or module that follows GrandNode conventions.
+- A review report with findings ordered by severity.
+- A creation plan when implementation details are missing and cannot be inferred safely.
+
+Include changed files, selected template, extension type, validation commands, and remaining risks.
+
+## Validation Checklist
+- [ ] The correct plugin or module type was selected.
+- [ ] The closest existing template was identified.
+- [ ] Manifest, system name, defaults, provider, startup, settings, and plugin class are consistent.
+- [ ] Build output path targets `src/Web/Grand.Web/Plugins` or `src/Web/Grand.Web/Modules`.
+- [ ] Provider interface registration is present and scoped correctly.
+- [ ] Install and uninstall handle plugin-owned settings and localization resources.
+- [ ] Controllers, routes, views, components, and assets are present only when needed.
+- [ ] Store, vendor, group, language, currency, and permission scope were checked where relevant.
+- [ ] Domain-specific behavior was checked with the matching review skill when needed.
+- [ ] The narrowest relevant build or test command was run or reported as not run.
+
+## Examples
+
+### Example 1: Payment Plugin
+Input: Create a redirect payment plugin named `Payments.ExamplePay`.
+
+Output: Create `src/Plugins/Payments.ExamplePay`, add `Manifest.cs`, `ExamplePayDefaults.cs`, `ExamplePayPaymentPlugin`, `ExamplePayPaymentProvider : IPaymentProvider`, `StartupApplication`, settings, configuration controller and view, logo asset, project output path, install and uninstall resources, and payment provider tests.
+
+### Example 2: Widget Plugin
+Input: Add a public tracking widget.
+
+Output: Create a widget provider implementing `IWidgetProvider`, register it in startup, define widget zones, add a view component and view under the plugin, add settings and consent behavior when needed, and validate rendering in the selected zone.
+
+### Example 3: Scheduled Task Module Change
+Input: Add a task that recalculates stale catalog data.
+
+Output: Add an `IScheduleTask` implementation under `Grand.Module.ScheduledTasks`, register it with `AddKeyedScoped<IScheduleTask, TaskType>("Task name")`, keep the module output path unchanged, and add tests for idempotent task execution.
+

--- a/skills/plugins/plugin-module/references/module-types.md
+++ b/skills/plugins/plugin-module/references/module-types.md
@@ -1,0 +1,101 @@
+# GrandNode Module Types
+
+## Existing Module Inventory
+- `Grand.Module.Api`
+- `Grand.Module.Installer`
+- `Grand.Module.Migration`
+- `Grand.Module.ScheduledTasks`
+
+## Common Module Structure
+Use modules for application-level features that are not installable provider plugins.
+
+Use this structure unless the closest existing module uses a narrower shape:
+- `{ModuleName}.csproj`
+- `Startup/StartupApplication.cs` or `Infrastructure/*Startup.cs`
+- `Controllers`, `Commands`, `Queries`, `Handlers`, `DTOs`, `Validators`, or services as needed
+- module-specific configuration, mapping, endpoints, and tests
+
+## Project Rules
+Set Debug and Release output paths to:
+
+```xml
+<OutputPath>..\..\Web\Grand.Web\Modules\{ModuleName}\</OutputPath>
+<OutDir>$(OutputPath)</OutDir>
+```
+
+Use `Microsoft.NET.Sdk` unless Razor views are required.
+
+Use central package versions. Add `<PackageReference Include="PackageName" />` without a version when listed in `Directory.Packages.props`.
+
+Set shared GrandNode project references to `Private=False` and `ExcludeAssets=runtime` when following existing module patterns.
+
+## Startup Rules
+Use `IStartupApplication` for module service registration and middleware setup.
+
+Register services in `ConfigureServices`.
+
+Keep `Configure` empty unless the module owns middleware, endpoints, OpenAPI setup, CORS, authentication, or other pipeline behavior.
+
+Set `Priority` deliberately:
+- Use nearby module priority for similar behavior.
+- Use a higher priority only when dependencies must be registered after core services.
+- Use `BeforeConfigure` only when middleware must run before normal application configuration.
+
+## API Module
+Use `Grand.Module.Api` for REST API controllers, DTOs, validators, mapping profiles, JWT, OpenAPI, query filters, and API-specific security.
+
+Check:
+- controller authorization
+- model validation
+- DTO mapping
+- command and query handler behavior
+- OpenAPI metadata
+- status codes
+- store, vendor, customer, and permission scope
+
+Combine with `api-review`, `security-review`, and `mongodb-review` when relevant.
+
+## Installer Module
+Use `Grand.Module.Installer` for installation flow, initial data, permission seeding, settings seeding, store setup, and first-run behavior.
+
+Check:
+- idempotency
+- default admin and store setup
+- seeded permissions
+- seeded settings
+- sample data safety
+- localization resources
+- database connection handling
+
+## Migration Module
+Use `Grand.Module.Migration` for versioned data and configuration migrations.
+
+Check:
+- version ordering
+- idempotency
+- resumability
+- mixed-version compatibility
+- data loss risk
+- rollback expectations
+- batch behavior for large collections
+
+Combine with `mongodb-review` for data migrations.
+
+## Scheduled Tasks Module
+Use `Grand.Module.ScheduledTasks` for recurring background tasks.
+
+Register tasks with keyed scoped registration:
+
+```csharp
+serviceCollection.AddKeyedScoped<IScheduleTask, TaskType>("Task name");
+```
+
+Check:
+- task name matches installed or migrated schedule task data
+- idempotency
+- cancellation behavior
+- retry and partial failure behavior
+- concurrent execution risk
+- store, language, currency, and customer context
+- logging and observability
+

--- a/skills/plugins/plugin-module/references/plugin-types.md
+++ b/skills/plugins/plugin-module/references/plugin-types.md
@@ -1,0 +1,286 @@
+# GrandNode Plugin Types
+
+## Existing Plugin Inventory
+- `Authentication.Facebook`
+- `Authentication.Google`
+- `DiscountRules.Standard`
+- `ExchangeRate.McExchange`
+- `Payments.BrainTree`
+- `Payments.CashOnDelivery`
+- `Payments.StripeCheckout`
+- `Shipping.ByWeight`
+- `Shipping.FixedRateShipping`
+- `Shipping.ShippingPoint`
+- `Tax.CountryStateZip`
+- `Tax.FixedRate`
+- `Theme.Modern`
+- `Widgets.FacebookPixel`
+- `Widgets.GoogleAnalytics`
+- `Widgets.Slider`
+
+## Common Plugin Structure
+Use this structure unless the closest existing plugin uses a narrower shape:
+
+- `{SystemName}.csproj`
+- `Manifest.cs`
+- `{Feature}Defaults.cs`
+- `{Feature}Plugin.cs`
+- `{Feature}Provider.cs`
+- `{Feature}Settings.cs`, when settings are persisted
+- `StartupApplication.cs` or `Infrastructure/StartupApplication.cs`
+- `Areas/Admin/Controllers`, when admin configuration is required
+- `Areas/Admin/Views`, when admin configuration uses Razor
+- `Controllers`, `Views`, `Components`, or `EndpointProvider.cs`, when public UI or routes are required
+- `logo.jpg`, when the plugin appears in plugin lists
+
+## Manifest Rules
+Create `Manifest.cs` with an assembly-level `PluginInfo` attribute:
+
+```csharp
+[assembly: PluginInfo(
+    FriendlyName = "Friendly name",
+    Group = "Plugin group",
+    SystemName = Defaults.ProviderSystemName,
+    Author = "grandnode team",
+    Version = "1.0.0"
+)]
+```
+
+Use existing group names when possible:
+- `Payment methods`
+- `Shipping rate`
+- `Tax providers`
+- `Widgets`
+- `External authentication`
+- `Discount rules`
+- `Exchange rate`
+- `Themes`
+
+## Project Rules
+Use `Microsoft.NET.Sdk.Razor` when the plugin contains Razor views.
+
+Set Debug and Release output paths to:
+
+```xml
+<OutputPath>..\..\Web\Grand.Web\Plugins\{SystemName}\</OutputPath>
+<OutDir>$(OutputPath)</OutDir>
+```
+
+Use central package versions. Add `<PackageReference Include="PackageName" />` without a version when the package is listed in `Directory.Packages.props`.
+
+Set shared GrandNode project references to `Private=false` or the local equivalent used by the nearest plugin.
+
+Copy plugin-owned static assets with `CopyToOutputDirectory` when needed.
+
+## Startup Rules
+Register providers and plugin services in `StartupApplication : IStartupApplication`.
+
+Use scoped registration for providers unless the closest existing plugin uses a different lifetime:
+
+```csharp
+services.AddScoped<IPaymentProvider, ExamplePaymentProvider>();
+```
+
+Keep:
+- `Priority => 10` unless startup order matters.
+- `BeforeConfigure => false` unless middleware must run before normal configuration.
+- Empty `Configure` unless middleware or endpoints are required.
+
+## Install And Uninstall Rules
+Derive the plugin class from `BasePlugin` when installation or configuration behavior is needed.
+
+In `Install`:
+- Save default settings with `ISettingService`.
+- Add plugin-owned resources with `IPluginTranslateResource`.
+- Call `base.Install()` last.
+
+In `Uninstall`:
+- Delete plugin-owned settings.
+- Delete plugin-owned resources.
+- Call `base.Uninstall()` last.
+
+## Provider Contract
+Every provider that implements `IProvider` must define:
+- `ConfigurationUrl`
+- `SystemName`
+- `FriendlyName`
+- `Priority`
+- `LimitedToStores`
+- `LimitedToGroups`
+
+Return the provider system name from a defaults constant. Keep manifest, provider, settings keys, route names, and plugin output folder aligned.
+
+## Payment Plugins
+Use for checkout payment methods.
+
+Template examples:
+- `Payments.StripeCheckout` for redirect payment.
+- `Payments.CashOnDelivery` for simple offline payment.
+- `Payments.BrainTree` for gateway integration.
+
+Implement:
+- `IPaymentProvider`
+- `{Feature}PaymentPlugin : BasePlugin, IPlugin`
+- `{Feature}PaymentProvider`
+- settings class
+- configuration controller and view when configurable
+- payment info route or redirect route when needed
+
+Check:
+- `PaymentMethodType`
+- `ProcessPayment`
+- `PostProcessPayment`
+- `PostRedirectPayment`
+- `ValidatePaymentForm`
+- `SavePaymentInfo`
+- `Capture`, `Refund`, `Void`, and support flags
+- `CanRePostRedirectPayment`
+- `LogoURL`
+- webhook or callback idempotency when external gateways are used
+- transaction status transitions and order lookup safety
+
+Use the payment review skill for gateway correctness.
+
+## Shipping Plugins
+Use for shipping rate calculation and pickup point logic.
+
+Template examples:
+- `Shipping.FixedRateShipping`
+- `Shipping.ByWeight`
+- `Shipping.ShippingPoint`
+
+Implement:
+- `IShippingRateCalculationProvider`
+- plugin class deriving from `BasePlugin`
+- settings or rate models when rates are configurable
+- admin configuration controller and view when needed
+
+Check:
+- country, state, warehouse, pickup, store, currency, and customer group behavior
+- free shipping and shipping restriction interactions
+- deterministic rate ordering
+- handling of empty carts and non-shippable products
+
+## Tax Plugins
+Use for tax rate calculation.
+
+Template examples:
+- `Tax.FixedRate`
+- `Tax.CountryStateZip`
+
+Implement:
+- `ITaxProvider`
+- plugin class deriving from `BasePlugin`
+- settings or rate service when rates are configurable
+- admin or store configuration views when needed
+
+Check:
+- `TaxRequest`
+- store-specific rates
+- country, state, zip, tax category, and customer tax context
+- default rate fallback
+- precision and rounding expectations
+
+## Widget Plugins
+Use for public or admin widgets rendered in widget zones.
+
+Template examples:
+- `Widgets.GoogleAnalytics`
+- `Widgets.FacebookPixel`
+- `Widgets.Slider`
+
+Implement:
+- `IWidgetProvider`
+- plugin class deriving from `BasePlugin`
+- view component and view
+- settings and consent cookie when tracking or analytics are used
+- widget zones returned by `GetWidgetZones`
+
+Check:
+- exact widget zone names
+- script injection safety
+- consent behavior
+- store and customer group limitations
+- asset copy behavior
+
+## Authentication Plugins
+Use for external login providers.
+
+Template examples:
+- `Authentication.Google`
+- `Authentication.Facebook`
+
+Implement:
+- `IExternalAuthenticationProvider`
+- plugin class deriving from `BasePlugin`
+- authentication builder or endpoint provider when callback routes are required
+- public view component for login button
+- admin configuration controller and view
+
+Check:
+- callback route names
+- client ID and secret storage
+- failed login handling
+- account linking behavior
+- event consumers that send registration or welcome messages
+
+Use the security review skill for OAuth, callbacks, secrets, and account linking.
+
+## Discount Rule Plugins
+Use for discount requirement rules.
+
+Template example:
+- `DiscountRules.Standard`
+
+Implement:
+- `IDiscountProvider`
+- one or more `IDiscountRule` implementations
+- configuration controllers deriving from the existing discount rule base controller
+- configuration views for each rule
+- endpoint provider when routes are needed
+
+Check:
+- `CheckRequirement`
+- `GetConfigurationUrl`
+- discount rule system names
+- metadata parsing
+- store, customer group, product, cart, and order scope
+- permission checks for discount management
+
+## Exchange Rate Plugins
+Use for currency exchange rate providers.
+
+Template example:
+- `ExchangeRate.McExchange`
+
+Implement:
+- `IExchangeRateProvider`
+- provider-specific rate fetchers when multiple upstream sources exist
+- plugin class deriving from `BasePlugin` when install state is enough
+
+Check:
+- primary exchange currency support
+- HTTP client usage
+- upstream failure behavior
+- currency code normalization
+- duplicate or stale rates
+
+## Theme Plugins
+Use for storefront theme replacement or extension.
+
+Template example:
+- `Theme.Modern`
+
+Implement:
+- theme plugin class deriving from `BasePlugin`
+- theme view registration class when required by the existing theme pattern
+- views under `Views/{ThemeName}`
+- content under `Content`
+
+Check:
+- view path and `_ViewStart.cshtml`
+- shared layout and component overrides
+- static asset copy behavior
+- responsive behavior
+- compatibility with storefront models and components
+

--- a/skills/plugins/plugin-payment/SKILL.md
+++ b/skills/plugins/plugin-payment/SKILL.md
@@ -1,0 +1,173 @@
+# Plugin — Payment Provider
+
+## Purpose
+Create, modify, and review GrandNode payment plugins that implement `IPaymentProvider`.
+
+## When To Use
+Use this skill when building a new payment method plugin, changing payment flow, adding capture/refund/void support, implementing a redirect gateway, or reviewing payment provider correctness and security.
+
+## When Not To Use
+Do not use this skill for order processing business logic outside the payment flow, or for general plugin infrastructure; combine with `plugin-module` when foundational setup is needed.
+
+## Inputs Required
+- Repository root.
+- Payment method type: Standard (inline form) or Redirection (external gateway).
+- Gateway or PSP API being integrated.
+- Which operations must be supported: capture, refund, partial refund, void.
+- Whether additional handling fees apply.
+- Whether a custom checkout form step is required.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Provider Interface
+1. Implement `IPaymentProvider` from `Grand.Business.Core.Interfaces.Checkout.Payments`. This extends `IProvider` which requires `ConfigurationUrl`, `SystemName`, `FriendlyName`, `Priority`, `LimitedToStores`, and `LimitedToGroups`.
+2. Implement every member. For methods that are not supported, return a result with `result.AddError("Method not supported")` rather than throwing. Required behavior per member:
+
+| Member | Standard payment | Redirect payment |
+|---|---|---|
+| `InitPaymentTransaction()` | Return `null` (framework creates transaction) | Return `null` |
+| `ProcessPayment(tx)` | Set `result.NewPaymentTransactionStatus` (typically `Pending`) | Return empty result; processing happens after redirect |
+| `PostProcessPayment(tx)` | Usually empty (`Task.CompletedTask`) | Usually empty |
+| `PostRedirectPayment(tx)` | Return `string.Empty` | Return the gateway redirect URL |
+| `CanRePostRedirectPayment(tx)` | Return `false` | Return `true` when the user can re-initiate |
+| `ValidatePaymentForm(model)` | Validate custom form fields; return error list | Return empty list |
+| `SavePaymentInfo(model)` | Save form data to `PaymentTransaction` fields; return updated tx or `null` | Return `null` |
+| `GetControllerRouteName()` | Route name of the storefront payment-info controller, or `""` when `SkipPaymentInfo` | Route name or `""` |
+| `PaymentMethodType` | `PaymentMethodType.Standard` | `PaymentMethodType.Redirection` |
+| `SkipPaymentInfo()` | Return `true` to skip the payment info step | Usually `false` |
+| `Description()` | Translatable description shown on checkout | Same |
+| `LogoURL` | `"/Plugins/{SystemName}/logo.jpg"` | Same |
+| `Capture/Refund/Void/Cancel` | Implement if supported; return error result if not | Same |
+| `SupportCapture/Refund/PartialRefund/Void` | Return `true`/`false` matching what is implemented | Same |
+| `GetAdditionalHandlingFee(cart)` | Return the calculated fee in the working currency | Same |
+| `HidePaymentMethod(cart)` | Return `true` to suppress the method for this cart | Same |
+
+3. Set `TransactionStatus` via `result.NewPaymentTransactionStatus` in `ProcessPayment`. Common values:
+   - `TransactionStatus.Pending` — order placed but not yet confirmed.
+   - `TransactionStatus.Authorized` — gateway authorized; capture is separate.
+   - `TransactionStatus.Paid` — payment fully captured immediately.
+4. Resolve `FriendlyName` through `ITranslationService.GetResource(Defaults.FriendlyName)`.
+5. Set `LogoURL` to `"/Plugins/{SystemName}/logo.jpg"`.
+
+#### Redirect Payment Flow
+6. When `PaymentMethodType == Redirection`: `PostRedirectPayment` returns the URL; the checkout redirects the customer there. The gateway posts back to a return controller action in the plugin.
+7. Implement a public storefront controller (`[Area("")]` without `[AuthorizeAdmin]`) as the redirect return handler. The controller receives the gateway callback, updates the `PaymentTransaction`, and redirects to order confirmation.
+8. Register the return controller route in `EndpointProvider` or via a convention route in `StartupApplication.Configure`.
+
+#### Operations: Capture, Refund, Void
+9. Implement `Capture`, `Refund`, and `Void` only when the gateway supports them. Return `result.AddError("Capture method not supported")` for unsupported operations.
+10. Return `SupportCapture() => true` only when `Capture` is actually implemented; same for Refund, PartiallyRefund, and Void. Returning `true` causes the admin UI to show the corresponding action button.
+11. In `CancelPayment`, update `paymentTransaction.TransactionStatus = TransactionStatus.Canceled` and persist via `IPaymentTransactionService.UpdatePaymentTransaction`.
+
+#### Project Structure
+12. Use `Microsoft.NET.Sdk.Razor` as SDK.
+13. Set output path to `..\..\Web\Grand.Web\Plugins\{SystemName}\`.
+14. Mark all GrandNode project references `Private="false"`.
+15. Include `logo.jpg` with `CopyToOutputDirectory = Always`.
+
+#### Manifest, Defaults, Settings
+16. Define `[assembly: PluginInfo(...)]` with `Group = "Payment methods"`.
+17. Define `{Plugin}Defaults` with `ProviderSystemName`, `FriendlyName` (resource key), `ConfigurationUrl`, and — for redirect plugins — `ReturnHandlerRouteName`.
+18. Define `{Plugin}Settings : ISettings` with at minimum `DisplayOrder`, `AdditionalFee`, `AdditionalFeePercentage`, and `SkipPaymentInfo`. Add gateway-specific fields (API keys, endpoint URLs).
+
+#### Startup and Install
+19. Register the provider:
+    ```csharp
+    services.AddScoped<IPaymentProvider, YourPaymentProvider>();
+    ```
+20. In `Install()`: save default settings, register localization keys. Call `base.Install()` last.
+21. In `Uninstall()`: delete settings, remove resource keys. Call `base.Uninstall()` last.
+
+#### Admin Configuration
+22. Create an admin controller with `[AuthorizeAdmin]`, `[Area("Admin")]`, and `[PermissionAuthorize(PermissionSystemName.PaymentMethods)]`.
+23. Use `IAdminStoreService.GetActiveStore()`, `LoadSetting`, `SaveSetting`, `ClearCache` for store-scoped config.
+
+### Security Requirements
+24. Never log or store raw card numbers, CVVs, or full PANs. Store only tokens, last-4, and transaction IDs from the gateway.
+25. Never construct redirect return URLs from unvalidated query parameters; validate the gateway callback signature or token before updating the transaction.
+26. Store gateway API keys in settings via `ISettingService`, not in source code or configuration files.
+
+### Recommendations
+1. Prefer `Payments.CashOnDelivery` as a template for Standard payment and `Payments.StripeCheckout` for Redirect payment.
+2. Prefer returning `TransactionStatus.Pending` from `ProcessPayment` for Standard methods unless the gateway confirms synchronously.
+3. Prefer `GetAdditionalHandlingFee` for fixed or percentage fees; use `IOrderCalculationService.GetShoppingCartSubTotal` for percentage-based calculation.
+
+## Key Contracts
+
+### ProcessPaymentResult
+```csharp
+public bool          Success                      { get; }           // no errors
+public List<string>  Errors                       { get; }
+public TransactionStatus NewPaymentTransactionStatus { get; set; }  // default Pending
+public double        PaidAmount                   { get; set; }
+result.AddError("message");
+```
+
+### TransactionStatus enum (key values)
+```csharp
+Pending = 0, Authorized = 10, PartialPaid = 15, Paid = 20,
+PartiallyRefunded = 25, Refunded = 30, Voided = 40, Canceled = 50
+```
+
+### PaymentMethodType enum
+```csharp
+Standard    = 1   // inline checkout form
+Redirection = 2   // customer sent to external gateway
+Other       = 3
+```
+
+### CapturePaymentResult / RefundPaymentResult / VoidPaymentResult
+```csharp
+result.AddError("message");
+result.CaptureTransactionId = "...";      // CapturePaymentResult only
+result.NewPaymentStatus = TransactionStatus.Paid;
+```
+
+### RefundPaymentRequest
+```csharp
+PaymentTransaction PaymentTransaction { get; }
+double AmountToRefund { get; }
+bool IsPartialRefund { get; }
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| IPaymentProvider | `src/Business/Grand.Business.Core/Interfaces/Checkout/Payments/IPaymentProvider.cs` |
+| ProcessPaymentResult | `src/Business/Grand.Business.Core/Utilities/Checkout/ProcessPaymentResult.cs` |
+| CapturePaymentResult | `src/Business/Grand.Business.Core/Utilities/Checkout/CapturePaymentResult.cs` |
+| RefundPaymentResult / RefundPaymentRequest | `src/Business/Grand.Business.Core/Utilities/Checkout/` |
+| VoidPaymentResult | `src/Business/Grand.Business.Core/Utilities/Checkout/VoidPaymentResult.cs` |
+| PaymentTransaction entity | `src/Core/Grand.Domain/Payments/PaymentTransaction.cs` |
+| TransactionStatus enum | `src/Core/Grand.Domain/Payments/TransactionStatus.cs` |
+| PaymentMethodType enum | `src/Business/Grand.Business.Core/Enums/Checkout/PaymentMethodType.cs` |
+| IPaymentTransactionService | `src/Business/Grand.Business.Core/Interfaces/Checkout/Payments/IPaymentTransactionService.cs` |
+| Example — Standard | `src/Plugins/Payments.CashOnDelivery/` |
+| Example — Redirect | `src/Plugins/Payments.StripeCheckout/` |
+| Example — Advanced | `src/Plugins/Payments.BrainTree/` |
+
+## Validation Checklist
+- [ ] All `IPaymentProvider` and `IProvider` members implemented.
+- [ ] Methods that are not supported return `result.AddError(...)` not throw.
+- [ ] `SupportCapture/Refund/PartialRefund/Void` match actual implementation.
+- [ ] `PaymentMethodType` set correctly (Standard vs Redirection).
+- [ ] Redirect plugins have a return controller action that validates the gateway callback.
+- [ ] No raw card data stored or logged.
+- [ ] Gateway secrets stored via `ISettingService`, not hardcoded.
+- [ ] Output path set to `Grand.Web/Plugins/{SystemName}/`.
+- [ ] `Install` saves settings and resource keys; `Uninstall` cleans them up.
+- [ ] Admin controller uses `[PermissionAuthorize(PermissionSystemName.PaymentMethods)]`.
+
+## Examples
+
+### Example 1: Standard Payment (Invoice/COD)
+Set `PaymentMethodType.Standard`. `ProcessPayment` returns `TransactionStatus.Pending`. `PostRedirectPayment` returns `""`. All capture/refund/void methods return an error result. `SkipPaymentInfo` driven from settings.
+
+### Example 2: Redirect Gateway (e.g., Stripe Checkout)
+Set `PaymentMethodType.Redirection`. `ProcessPayment` returns an empty result. `PostRedirectPayment` calls the gateway SDK to create a session and returns the session URL. Implement a public return controller that verifies the webhook/callback and calls `IPaymentTransactionService.UpdatePaymentTransaction`.
+
+### Example 3: Authorize-and-Capture Gateway
+Set `PaymentMethodType.Standard`. `ProcessPayment` calls the gateway authorize API and sets `TransactionStatus.Authorized`. Implement `Capture` to charge the authorization. Return `SupportCapture() => true`. Implement `Void` to cancel the authorization.

--- a/skills/plugins/plugin-shipping/SKILL.md
+++ b/skills/plugins/plugin-shipping/SKILL.md
@@ -1,0 +1,133 @@
+# Plugin — Shipping Rate Provider
+
+## Purpose
+Create, modify, and review GrandNode shipping rate calculation plugins that implement `IShippingRateCalculationProvider`.
+
+## When To Use
+Use this skill when building a new shipping rate plugin, changing rate calculation logic, adding a custom shipping form, or reviewing an existing shipping provider for correctness.
+
+## When Not To Use
+Do not use this skill for shipping method domain data (managed via `IShippingMethodService` in the Admin), for free-shipping logic, or for general plugin infrastructure; combine with `plugin-module` when foundational plugin setup is needed.
+
+## Inputs Required
+- Repository root.
+- Closest existing shipping plugin to use as template.
+- Rate calculation approach: fixed rate, weight-based, real-time API.
+- Whether a custom checkout form step is required.
+- Required admin configuration settings.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Provider Interface
+1. Implement `IShippingRateCalculationProvider` from `Grand.Business.Core.Interfaces.Checkout.Shipping`. This extends `IProvider` which requires `ConfigurationUrl`, `SystemName`, `FriendlyName`, `Priority`, `LimitedToStores`, and `LimitedToGroups`.
+2. Implement all `IShippingRateCalculationProvider` members:
+
+| Member | Requirement |
+|---|---|
+| `GetShippingOptions(request)` | **Required.** Build and return a `GetShippingOptionResponse` with one `ShippingOption` per available method. Add errors to `response.AddError(msg)` instead of throwing. |
+| `GetFixedRate(request)` | Return a known rate when a single rate can be computed before checkout, or `null` when rates vary. Used for cart estimate display. |
+| `HideShipmentMethods(cart)` | Return `true` to suppress this provider during checkout for this cart (e.g., no shippable items). Return `false` otherwise. |
+| `ValidateShippingForm(option, data)` | Return a list of validation error strings for any custom form submitted during the shipping step. Return empty list when no custom form is used. |
+| `GetControllerRouteName()` | Return the public route name of a storefront controller that renders a custom shipping form, or empty string when no form is needed. |
+| `ShippingRateCalculationType` | `ShippingRateCalculationType.Off` for pre-configured rates; `ShippingRateCalculationType.Real` for live API rates. |
+| `ShipmentTracker` | Return `null` if shipment tracking is not supported; return an `IShipmentTracker` implementation otherwise. |
+
+3. Resolve `FriendlyName` through `ITranslationService.GetResource(Defaults.FriendlyName)` so it is localizable.
+4. Resolve `Priority` from the plugin settings `DisplayOrder` property.
+5. Use `IShippingMethodService.GetAllShippingMethods(restrictByCountryId, customer, storeId)` to iterate over admin-configured methods and build a `ShippingOption` for each.
+6. Set `ShippingOption.Name` and `ShippingOption.Description` using `shippingMethod.GetTranslation(x => x.Name, languageId)`.
+7. Convert rates to the working currency using `ICurrencyService.ConvertFromPrimaryStoreCurrency(rate, workingCurrency)`.
+
+#### Project Structure
+8. Use `Microsoft.NET.Sdk.Razor` as the project SDK even when no Razor views are present, for consistency with existing shipping plugins.
+9. Set both `<OutputPath>` and `<OutDir>` to `..\..\Web\Grand.Web\Plugins\{SystemName}\`.
+10. Mark all GrandNode project references as `Private="false"` so they are not copied to the plugin output folder.
+11. Include `logo.jpg` with `<CopyToOutputDirectory>Always</CopyToOutputDirectory>`.
+
+#### Manifest, Defaults, Settings
+12. Define the assembly-level `[assembly: PluginInfo(...)]` in `Manifest.cs` with `Group = "Shipping rate"`.
+13. Define a `{Plugin}Defaults` class with `ProviderSystemName`, `FriendlyName` (resource key), and `ConfigurationUrl` constants.
+14. Define `{Plugin}Settings : ISettings` with at minimum a `DisplayOrder` property. Add any plugin-specific rate settings here.
+
+#### Startup and Install
+15. Register the provider in `StartupApplication.ConfigureServices`:
+    ```csharp
+    services.AddScoped<IShippingRateCalculationProvider, YourShippingProvider>();
+    ```
+    Register any additional plugin services (repositories, calculation services) in the same method.
+16. Implement `Install()` in the plugin class: save default settings with `ISettingService.SaveSetting` and register localization keys with `IPluginTranslateResource.AddOrUpdatePluginTranslateResource`. Call `base.Install()` last.
+17. Implement `Uninstall()`: delete settings with `ISettingService.DeleteSetting<T>()` and remove resource keys. Call `base.Uninstall()` last.
+
+#### Admin Configuration
+18. Create an admin controller with `[AuthorizeAdmin]`, `[Area("Admin")]`, and `[PermissionAuthorize(PermissionSystemName.ShippingSettings)]`.
+19. Use `IAdminStoreService.GetActiveStore()` and `ISettingService.LoadSetting<T>(storeScope)` / `SaveSetting<T>(settings, storeScope)` / `ClearCache()` for store-scoped settings.
+
+### Recommendations
+1. Prefer `Shipping.FixedRateShipping` as a template for simple pre-configured rates and `Shipping.ByWeight` for weight-based calculation.
+2. Return a meaningful error string via `response.AddError(...)` rather than returning an empty response when the provider cannot compute rates.
+3. Prefer returning `null` from `GetFixedRate` when different methods have different rates — this prevents displaying a misleading single price in cart estimates.
+
+## Key Contracts
+
+### GetShippingOptionResponse / ShippingOption
+```csharp
+// ShippingOption fields relevant to populate:
+public string Name { get; set; }
+public string Description { get; set; }
+public double Rate { get; set; }
+public string ShippingRateProviderSystemName { get; set; }  // set automatically by framework
+
+// GetShippingOptionResponse helpers:
+response.AddError("message");               // records a non-fatal error
+response.ShippingOptions.Add(option);
+```
+
+### GetShippingOptionRequest (key fields)
+```csharp
+Customer Customer { get; }
+IList<PackageItem> Items { get; }           // wraps ShoppingCartItem
+Address ShippingAddress { get; }
+```
+
+### ShippingRateCalculationType enum
+```csharp
+Off  = 0   // rate configured via admin; no live API call
+Real = 10  // live calculation via external service
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| IShippingRateCalculationProvider | `src/Business/Grand.Business.Core/Interfaces/Checkout/Shipping/IShippingRateCalculationProvider.cs` |
+| IShippingMethodService | `src/Business/Grand.Business.Core/Interfaces/Checkout/Shipping/IShippingMethodService.cs` |
+| IShipmentTracker | `src/Business/Grand.Business.Core/Interfaces/Checkout/Shipping/IShipmentTracker.cs` |
+| GetShippingOptionRequest/Response | `src/Business/Grand.Business.Core/Utilities/Checkout/` |
+| ShippingOption | `src/Core/Grand.Domain/Shipping/ShippingOption.cs` |
+| ShippingRateCalculationType | `src/Business/Grand.Business.Core/Enums/Checkout/ShippingRateCalculationType.cs` |
+| Example — fixed rate | `src/Plugins/Shipping.FixedRateShipping/` |
+| Example — by weight | `src/Plugins/Shipping.ByWeight/` |
+| Example — shipping point | `src/Plugins/Shipping.ShippingPoint/` |
+
+## Validation Checklist
+- [ ] All `IShippingRateCalculationProvider` and `IProvider` members implemented.
+- [ ] `GetShippingOptions` returns at least one option or an error, never throws.
+- [ ] Rates converted to working currency via `ICurrencyService`.
+- [ ] `IShippingMethodService.GetAllShippingMethods` used with country and store scope.
+- [ ] Output path set to `Grand.Web/Plugins/{SystemName}/`.
+- [ ] Provider registered with `AddScoped<IShippingRateCalculationProvider, ...>`.
+- [ ] `Install` saves settings and resource keys; `Uninstall` cleans them up.
+- [ ] Admin controller uses `[PermissionAuthorize(PermissionSystemName.ShippingSettings)]`.
+
+## Examples
+
+### Example 1: Fixed Rate per Method
+Pattern from `Shipping.FixedRateShipping`: load all `ShippingMethod` records, look up a per-method setting key (`"ShippingRateComputationMethod.FixedRate.Rate.ShippingMethodId{id}"`), create one `ShippingOption` per method with the stored rate, convert currency.
+
+### Example 2: Flat Rate Plugin
+Create a single `ShippingOption` with a hard-coded or settings-driven flat rate, returning it for all carts regardless of method or weight.
+
+### Example 3: API-Based Real-Time Rate
+Set `ShippingRateCalculationType = Real`. In `GetShippingOptions`, call an external carrier API, map each returned service to a `ShippingOption`, and add errors if the API is unavailable.

--- a/skills/plugins/plugin-widget/SKILL.md
+++ b/skills/plugins/plugin-widget/SKILL.md
@@ -1,0 +1,159 @@
+# Plugin — Widget Provider
+
+## Purpose
+Create, modify, and review GrandNode widget plugins that implement `IWidgetProvider` and inject rendered output into storefront zone slots.
+
+## When To Use
+Use this skill when building a new widget plugin (tracking pixel, banner, slider, chat, analytics), changing which zones a widget targets, adding a new view component, reviewing widget consent behavior, or wiring a widget to a CMS data source.
+
+## When Not To Use
+Do not use this skill for admin-only functionality with no storefront output, or for general plugin infrastructure; combine with `plugin-module` when foundational setup is needed.
+
+## Inputs Required
+- Repository root.
+- Which widget zones the widget should render in.
+- Whether the widget needs admin configuration or CMS data.
+- Whether consent (GDPR/cookie) gating is required.
+- Whether context data from the zone (e.g., product ID, category ID) is needed.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Provider Interface
+1. Implement `IWidgetProvider` from `Grand.Business.Core.Interfaces.Cms`. This extends `IProvider` requiring `ConfigurationUrl`, `SystemName`, `FriendlyName`, `Priority`, `LimitedToStores`, `LimitedToGroups`.
+2. Implement both `IWidgetProvider` members:
+
+| Member | Requirement |
+|---|---|
+| `GetWidgetZones()` | Return the list of zone names where this widget renders. Use existing zone name constants from `Defaults` or string literals matching the zones used in storefront views. |
+| `GetPublicViewComponentName(widgetZone)` | Return the view component name to invoke for the given zone. Can return different component names per zone, or the same name for all zones. |
+
+3. Resolve `FriendlyName` through `ITranslationService.GetResource(Defaults.FriendlyName)`.
+4. Resolve `Priority` from settings `DisplayOrder`.
+
+#### View Component
+5. Create a view component class with `[ViewComponent(Name = "YourComponentName")]` inheriting `ViewComponent`.
+6. Implement `InvokeAsync(string widgetZone, object additionalData = null)`:
+   - Use `widgetZone` when the component handles multiple zones differently.
+   - Cast `additionalData` to the expected zone data type when context is needed (e.g., product ID for product page zones).
+   - Return `Content("")` or `View(emptyModel)` rather than returning `null` when nothing should render.
+7. Place the view component class in the plugin's `Components/` folder.
+
+#### Views
+8. Place the default view at `Views/Shared/Components/{ViewComponentName}/Default.cshtml`.
+9. Add `_ViewImports.cshtml` under `Views/` with the plugin's namespace, common tag helpers, and `@inject LocService Loc` when localization is used:
+   ```cshtml
+   @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+   @addTagHelper *, Grand.Web.Common
+   @addTagHelper *, Grand.Web
+   @using YourPlugin.Models
+   @inject LocService Loc
+   ```
+10. Use `Microsoft.NET.Sdk.Razor` as the project SDK to enable view compilation and output.
+11. Set output path to `..\..\Web\Grand.Web\Plugins\{SystemName}\` so views are deployed to the plugin output folder.
+
+#### Consent / GDPR
+12. When the widget injects third-party tracking scripts, check user consent via `ICookiePreference.IsEnable(consentCookieName, store, customer)` before rendering the script. Return `Content("")` when consent is denied.
+13. Register the cookie consent name in plugin settings and expose it through the admin configuration page.
+
+#### Project Structure
+14. Mark all GrandNode project references `Private="false"`.
+15. Include `logo.jpg` with `CopyToOutputDirectory = Always`.
+16. Copy static assets (CSS, JS, images) owned by the plugin using `<Content CopyToOutputDirectory="Always">`.
+
+#### Manifest, Defaults, Settings
+17. Define `[assembly: PluginInfo(...)]` with `Group = "Widgets"`.
+18. Define `{Plugin}Defaults` with `ProviderSystemName`, `FriendlyName` (resource key), `ConfigurationUrl`, and zone name constants when the plugin targets specific named zones.
+19. Define `{Plugin}Settings : ISettings` with at minimum `DisplayOrder`. Add tracking IDs, container IDs, consent cookie names, or data source settings as needed.
+
+#### Startup and Install
+20. Register the provider and any supporting services:
+    ```csharp
+    services.AddScoped<IWidgetProvider, YourWidgetProvider>();
+    services.AddScoped<IYourDataService, YourDataService>();
+    ```
+21. In `Install()`: save default settings, register localization keys. Call `base.Install()` last.
+22. In `Uninstall()`: delete settings, remove resource keys. Call `base.Uninstall()` last.
+
+#### Admin Configuration
+23. Create an admin controller with `[AuthorizeAdmin]`, `[Area("Admin")]`, and `[PermissionAuthorize(PermissionSystemName.Widgets)]`.
+24. Use `IAdminStoreService.GetActiveStore()`, `LoadSetting`, `SaveSetting`, `ClearCache` for store-scoped config.
+25. For widgets with CMS-managed content (e.g., sliders), create full CRUD controllers and views under the plugin's `Areas/Admin/` folder.
+
+### Recommendations
+1. Prefer `Widgets.GoogleAnalytics` as a template for tracking-only widgets (no CMS data, single component, consent gating).
+2. Prefer `Widgets.Slider` as a template for widgets with admin-managed content and multiple zones.
+3. Prefer returning `Content("")` (empty) over rendering empty markup when no data is available.
+4. Prefer loading zone-specific context from `additionalData` rather than re-querying by URL or route.
+5. Prefer a single view component that handles multiple zones by switching on `widgetZone`, rather than creating separate components per zone.
+
+## Common Widget Zones
+
+| Zone name | Rendered in |
+|---|---|
+| `"home_page_top"` | Top of home page |
+| `"home_page_bottom"` | Bottom of home page |
+| `"category_page_top"` | Top of category listing |
+| `"product_page_top"` | Top of product detail page |
+| `"product_page_bottom"` | Bottom of product detail page |
+| `"body_end_html_tag_before"` | Before `</body>` — analytics scripts |
+| `"clean_body_end_html_tag_before"` | Before `</body>` on clean layout |
+| `"collection_page_top"` / `"brand_page_top"` | Top of collection/brand page |
+| `"order_summary_content_after"` | After order summary in checkout |
+| `"checkout_completed_top"` | Order confirmation page — for conversion tracking |
+
+Zone names are arbitrary strings agreed upon between the view and the provider. Check the target layout or view for the exact zone string used in `@await Component.InvokeAsync("Widget", new { widgetZone = "..." })`.
+
+## Key Contracts
+
+### IWidgetProvider
+```csharp
+Task<IList<string>> GetWidgetZones();
+Task<string> GetPublicViewComponentName(string widgetZone);
+```
+
+### View component invocation from storefront views
+```cshtml
+@await Component.InvokeAsync("Widget", new { widgetZone = "home_page_top" })
+```
+The core `Widget` view component discovers all active `IWidgetProvider` plugins and invokes the returned component name for each.
+
+### ICookiePreference (consent)
+```csharp
+Task<bool> IsEnable(string name, Store store, Customer customer);
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| IWidgetProvider | `src/Business/Grand.Business.Core/Interfaces/Cms/IWidgetProvider.cs` |
+| ICookiePreference | `src/Business/Grand.Business.Core/Interfaces/Common/Security/ICookiePreference.cs` |
+| Widget core component | `src/Web/Grand.Web/Components/Widget.cs` |
+| Example — tracking pixel | `src/Plugins/Widgets.GoogleAnalytics/` |
+| Example — tracking pixel 2 | `src/Plugins/Widgets.FacebookPixel/` |
+| Example — CMS slider | `src/Plugins/Widgets.Slider/` |
+
+## Validation Checklist
+- [ ] `IWidgetProvider` and `IProvider` members all implemented.
+- [ ] `GetWidgetZones()` returns the exact zone strings used in the target views.
+- [ ] `GetPublicViewComponentName` returns a name matching the `[ViewComponent(Name = "...")]` attribute.
+- [ ] View at `Views/Shared/Components/{Name}/Default.cshtml` exists.
+- [ ] `_ViewImports.cshtml` present and includes required tag helpers and namespaces.
+- [ ] Tracking widgets check consent before rendering scripts.
+- [ ] Output path set to `Grand.Web/Plugins/{SystemName}/`.
+- [ ] Provider registered with `AddScoped<IWidgetProvider, ...>`.
+- [ ] `Install` and `Uninstall` handle settings and resource keys.
+- [ ] Admin controller uses `[PermissionAuthorize(PermissionSystemName.Widgets)]`.
+
+## Examples
+
+### Example 1: Analytics Tracking Widget
+Pattern from `Widgets.GoogleAnalytics`: implement single view component, return `"body_end_html_tag_before"` zone, check consent via `ICookiePreference`, render a script tag with the tracking ID from settings, return `Content("")` when consent denied or tracking ID not configured.
+
+### Example 2: CMS Slider Widget
+Pattern from `Widgets.Slider`: implement a database-backed slider service, return home/category/brand/collection zones, render slides from the database filtered by zone and store, provide full admin CRUD for slide management.
+
+### Example 3: Context-Aware Widget
+Widget that shows related links on a product page: receive `additionalData` as a product ID in the `product_page_bottom` zone, query related data for that product, render the widget with product-specific content.

--- a/skills/project-structure/SKILL.md
+++ b/skills/project-structure/SKILL.md
@@ -1,0 +1,100 @@
+# Project Structure
+
+## Purpose
+Orient an agent in the GrandNode repository so it can find the correct layer, understand the technologies in use, and extend the project consistently.
+
+## When To Use
+Use this skill before implementing a feature, locating ownership, planning a change, adding a project file, adding a service, adding UI, adding a plugin, adding a module, adding tests, or explaining where functionality belongs.
+
+Use this skill when the task asks where something is located, how the repository is organized, what technologies are used, or how to expand the system safely.
+
+## When Not To Use
+Do not use this skill for narrow edits where the owning file and pattern are already known.
+
+Do not use this skill as a replacement for domain-specific skills such as plugin creation, admin changes, template creation, MongoDB review, or security review.
+
+## Inputs Required
+- Repository root.
+- User goal or feature description.
+- Known affected entity, workflow, plugin, module, or UI area.
+- Existing files mentioned by the user, if any.
+- Constraints for Admin, Store Owner, Vendor, Store, Customer, or API behavior.
+
+## Instructions
+
+### Mandatory Rules
+1. Read `references/repository-map.md` before making structural decisions.
+2. Identify the requested change type: domain, business service, data access, web UI, admin UI, API, plugin, module, frontend asset, test, build, or deployment.
+3. Locate the closest existing feature with the same entity or workflow.
+4. Follow the existing folder, namespace, dependency, registration, model, mapper, validator, controller, view, and test patterns.
+5. Keep domain entities in `Grand.Domain`.
+6. Keep repository and MongoDB infrastructure in `Grand.Data`.
+7. Keep cross-cutting infrastructure in `Grand.Infrastructure`.
+8. Keep business interfaces in `Grand.Business.Core` and implementations in the relevant `Grand.Business.*` project.
+9. Keep public storefront UI in `Grand.Web`.
+10. Keep main Admin UI in `Grand.Web.Admin`.
+11. Keep Store Owner UI in `Grand.Web.Store`.
+12. Keep Vendor UI in `Grand.Web.Vendor`.
+13. Keep shared admin models, validators, and mapper profiles in `Grand.Web.AdminShared`.
+14. Keep reusable web helpers and shared UI infrastructure in `Grand.Web.Common`.
+15. Keep plugins under `src/Plugins` and modules under `src/Modules`.
+16. Keep tests under `src/Tests` in the closest matching test project.
+17. Check whether the change affects Admin, Store Owner, Vendor, API, plugin, message templates, scheduled tasks, or frontend bundles.
+18. Select and apply any more specific skill required by the change.
+19. Avoid creating new architectural categories unless existing structure cannot support the change.
+20. State the selected ownership path before making broad changes.
+
+### Recommendations
+1. Prefer searching by entity name across `Domain`, `Business`, `Web`, `AdminShared`, `Plugins`, `Modules`, and `Tests`.
+2. Prefer extending existing services and interfaces before adding new ones.
+3. Prefer existing startup registration patterns over ad hoc service registration.
+4. Prefer central package management through `Directory.Packages.props`.
+5. Prefer targeted project builds and tests over full solution builds during iteration.
+6. Prefer updating README-level build instructions only when behavior visible to contributors changes.
+
+## Constraints
+- Never place plugin or module code directly in a core web project.
+- Never place web view models in domain or data projects.
+- Never place persistence logic in controllers or Razor views.
+- Never bypass shared admin models when multiple admin panels use the same contract.
+- Never add package versions directly to project files when central package management is used.
+- Never introduce Entity Framework patterns; this repository uses MongoDB-backed data access.
+- Never assume Admin, Store Owner, Vendor, API, and public storefront share the same permissions or scope.
+- Never move files across layers as a refactor unless the user explicitly requests it.
+
+## Expected Output
+Produce one of these results:
+- A repository orientation summary with the correct ownership path.
+- A feature expansion plan listing the files and layers to modify.
+- A completed change that follows the selected project structure.
+- A review finding when code was placed in the wrong layer or project.
+
+Include the selected change type, owning projects, closest existing pattern, specific files to inspect or modify, validation commands, and remaining risks.
+
+## Validation Checklist
+- [ ] The change type was identified.
+- [ ] The owning project and layer were selected.
+- [ ] The closest existing pattern was found.
+- [ ] Cross-panel, API, plugin, module, and frontend impacts were checked.
+- [ ] Domain, business, data, UI, and test responsibilities were kept separate.
+- [ ] Package and build conventions were respected.
+- [ ] More specific skills were used where required.
+- [ ] The result states what was checked and what was intentionally out of scope.
+
+## Examples
+
+### Example 1: Add Product Field
+Input: Add a field to products.
+
+Output: Inspect `Grand.Domain/Catalog`, product services in `Grand.Business.Catalog`, shared admin product models and mapper profiles in `Grand.Web.AdminShared`, Admin/Store/Vendor product controllers and views, API DTOs if exposed, MongoDB persistence behavior, localization resources, and product tests.
+
+### Example 2: Add Payment Provider
+Input: Add a new payment method.
+
+Output: Use `src/Plugins/Payments.*` as the owning area, follow payment plugin patterns, update plugin manifest, provider, settings, startup registration, configuration views, install resources, and plugin tests.
+
+### Example 3: Add Admin Setting
+Input: Add a setting visible to store owners.
+
+Output: Update the setting domain object, AdminShared settings model and mapper, Admin and Store settings controllers and views, store-scope override behavior, localization resources, and targeted tests.
+

--- a/skills/project-structure/references/repository-map.md
+++ b/skills/project-structure/references/repository-map.md
@@ -1,0 +1,306 @@
+# GrandNode Repository Map
+
+## Root
+- `GrandNode.sln`: main solution.
+- `global.json`: pinned .NET SDK behavior.
+- `Directory.Packages.props`: central NuGet package versions.
+- `src/Build`: common MSBuild props and targets.
+- `src/Tests`: test projects.
+- `src/Core`: domain, data, infrastructure, mapping, shared kernel.
+- `src/Business`: business interfaces and implementations.
+- `src/Web`: public site, admin panels, shared web libraries, frontend app.
+- `src/Plugins`: installable provider plugins and themes.
+- `src/Modules`: application modules.
+- `src/Aspire`: local orchestration and service defaults.
+
+## Technologies In Use
+- .NET and ASP.NET Core.
+- MongoDB through repository/data abstractions.
+- Redis for caching and data protection integration.
+- MediatR for commands, queries, and events.
+- FluentValidation for validators.
+- Custom mapping framework in `Grand.Mapping` with an AutoMapper-compatible profile API (`Profile`, `CreateMap`, `ForMember`). AutoMapper package is not used.
+- Razor views, partials, view components, and tag helpers.
+- Vue 3 and Vite for storefront frontend assets.
+- Bootstrap and Bootstrap Icons.
+- DotLiquid for message templates.
+- OpenAPI and Scalar in the API module.
+- Aspire and OpenTelemetry for local orchestration and observability.
+- Docker and Azure Pipelines for build and deployment workflows.
+
+## Core Projects
+
+### `src/Core/Grand.Domain`
+Use for domain entities, settings objects, enums, and domain-level contracts.
+
+Examples:
+- `Catalog`
+- `Orders`
+- `Customers`
+- `Vendors`
+- `Stores`
+- `Payments`
+- `Shipping`
+- `Tax`
+- `Permissions`
+- `Messages`
+
+Do not put UI models, persistence details, or controller behavior here.
+
+### `src/Core/Grand.Data`
+Use for repository abstractions and MongoDB/LiteDB data infrastructure.
+
+Use this area for:
+- repository contracts and implementations
+- MongoDB context behavior
+- data provider configuration
+- audit provider integration
+
+Do not put business workflow rules or UI preparation here.
+
+### `src/Core/Grand.Infrastructure`
+Use for cross-cutting runtime infrastructure.
+
+Use this area for:
+- startup abstractions
+- caching
+- plugin infrastructure
+- module infrastructure
+- endpoint provider infrastructure
+- type scanning
+- migrations infrastructure
+- model binding
+- validators infrastructure
+
+### `src/Core/Grand.Mapping`
+Use for shared mapping infrastructure and mapping support.
+
+### `src/Core/Grand.SharedKernel`
+Use for low-level shared primitives, attributes, extensions, and small cross-cutting helpers.
+
+## Business Projects
+
+### `src/Business/Grand.Business.Core`
+Use for business interfaces, commands, queries, utilities, and cross-business contracts.
+
+Put interfaces here when implementations live in a feature-specific business project.
+
+### Feature Business Projects
+Use these for implementations:
+- `Grand.Business.Authentication`
+- `Grand.Business.Catalog`
+- `Grand.Business.Checkout`
+- `Grand.Business.Cms`
+- `Grand.Business.Common`
+- `Grand.Business.Customers`
+- `Grand.Business.Marketing`
+- `Grand.Business.Messages`
+- `Grand.Business.Storage`
+
+Use the closest feature project. Register implementations in that project's `Startup/StartupApplication.cs`.
+
+## Web Projects
+
+### `src/Web/Grand.Web`
+Use for public storefront controllers, views, view models, commands, handlers, validators, components, and static web assets.
+
+Important folders:
+- `Controllers`
+- `Views`
+- `Views/Shared`
+- `Views/PdfTemplates`
+- `Components`
+- `Commands`
+- `Features`
+- `Models`
+- `Validators`
+- `wwwroot`
+- `vueapp`
+
+### `src/Web/Grand.Web.Admin`
+Use for main Admin panel controllers and views.
+
+Controllers are in:
+- `src/Web/Grand.Web.Admin/Controllers`
+
+Views are in:
+- `src/Web/Grand.Web.Admin/Areas/Admin/Views`
+
+### `src/Web/Grand.Web.Store`
+Use for Store Owner panel controllers and views.
+
+Controllers are in:
+- `src/Web/Grand.Web.Store/Controllers`
+
+Views are in:
+- `src/Web/Grand.Web.Store/Areas/Store/Views`
+
+### `src/Web/Grand.Web.Vendor`
+Use for Vendor panel controllers, views, models, services, components, and vendor-specific access behavior.
+
+Controllers are in:
+- `src/Web/Grand.Web.Vendor/Controllers`
+
+Views are in:
+- `src/Web/Grand.Web.Vendor/Areas/Vendor/Views`
+
+### `src/Web/Grand.Web.AdminShared`
+Use for shared admin models, validators, mapper profiles, extensions, and contracts used by Admin, Store Owner, and sometimes Vendor panels.
+
+Check this project before adding duplicate admin models.
+
+### `src/Web/Grand.Web.Common`
+Use for shared web infrastructure, base controllers, base components, themes, tag helpers, and common MVC helpers.
+
+### `src/Web/Grand.SharedUIResources`
+Use for shared static UI resources.
+
+## Plugins
+Plugins live under `src/Plugins`.
+
+Existing plugin categories:
+- `Authentication.*`
+- `DiscountRules.*`
+- `ExchangeRate.*`
+- `Payments.*`
+- `Shipping.*`
+- `Tax.*`
+- `Theme.*`
+- `Widgets.*`
+
+Use plugins for installable providers, integrations, widgets, payment methods, shipping methods, tax providers, authentication providers, discount rules, exchange rates, and themes.
+
+Plugin build output goes to:
+- `src/Web/Grand.Web/Plugins/{SystemName}`
+
+Use the `plugin-module` skill for plugin work.
+
+## Modules
+Modules live under `src/Modules`.
+
+Existing modules:
+- `Grand.Module.Api`
+- `Grand.Module.Installer`
+- `Grand.Module.Migration`
+- `Grand.Module.ScheduledTasks`
+
+Use modules for application-level features that are not installable provider plugins.
+
+Module build output goes to:
+- `src/Web/Grand.Web/Modules/{ModuleName}`
+
+Use the `plugin-module` skill for module structure.
+
+## API Module
+API functionality lives in:
+- `src/Modules/Grand.Module.Api`
+
+Use for:
+- REST controllers
+- DTOs
+- validators
+- command and query handlers
+- JWT
+- OpenAPI metadata
+- API mapping profiles
+
+## Installer And Migration
+Installer behavior lives in:
+- `src/Modules/Grand.Module.Installer`
+
+Migration behavior lives in:
+- `src/Modules/Grand.Module.Migration`
+
+Use installer for initial seed data. Use migration for versioned updates to existing installations.
+
+Common seeded areas:
+- permissions
+- admin sitemap
+- settings
+- message templates
+- stores
+- schedule tasks
+- localization resources
+
+## Scheduled Tasks
+Scheduled task module:
+- `src/Modules/Grand.Module.ScheduledTasks`
+
+Register tasks in:
+- `Startup/StartupApplication.cs`
+
+Use keyed scoped registration:
+- `AddKeyedScoped<IScheduleTask, TaskType>("Task name")`
+
+## Frontend Assets
+Storefront frontend source:
+- `src/Web/Grand.Web/vueapp`
+
+Committed frontend output:
+- `src/Web/Grand.Web/wwwroot/bundles`
+
+Theme CSS source:
+- `src/Web/Grand.Web/wwwroot/theme/css`
+
+Run frontend build when changing Vue source or theme CSS that affects committed bundles.
+
+## Tests
+Tests live under:
+- `src/Tests`
+
+Choose the closest test project by target ownership:
+- Business changes: `Grand.Business.*.Tests`
+- Data changes: `Grand.Data.Tests`
+- Domain changes: `Grand.Domain.Tests`
+- Infrastructure changes: `Grand.Infrastructure.Tests`
+- Mapping changes: `Grand.Mapping.Tests`
+- Module changes: `Grand.Modules.Tests` or module-specific tests
+- API changes: `Grand.Module.Api.Tests`
+- Web common changes: `Grand.Web.Common.Tests`
+- Admin changes: `Grand.Web.Admin.Tests`
+- Storefront changes: `Grand.Web.Tests`
+- Store Owner changes: `Grand.Web.Store.Tests`
+- Shared kernel changes: `Grand.SharedKernel.Tests`
+
+## Expansion Rules
+
+### Add Domain Data
+1. Add or update entity or settings class in `Grand.Domain`.
+2. Update data access behavior only if repository or MongoDB configuration requires it.
+3. Update business services and interfaces.
+4. Update UI/API models, mappers, validators, and tests.
+
+### Add Business Logic
+1. Add interface to `Grand.Business.Core` when used across projects.
+2. Add implementation to the closest `Grand.Business.*` project.
+3. Register implementation in `StartupApplication`.
+4. Add or update tests in the matching business test project.
+
+### Add Public Storefront UI
+1. Update `Grand.Web` controller, command, query, handler, model, validator, component, or view.
+2. Update localization resources.
+3. Update frontend bundles when Vue or theme CSS source changes.
+4. Add web tests when behavior changes.
+
+### Add Admin UI
+1. Use `admin-area-changes`.
+2. Update `Grand.Web.AdminShared` if shared models, validators, or mapper profiles are involved.
+3. Update Admin, Store Owner, and Vendor panels only where the role should own the workflow.
+
+### Add Plugin Or Module
+1. Use `plugin-module`.
+2. Start from the closest existing plugin or module.
+3. Keep output paths aligned with `Grand.Web/Plugins` or `Grand.Web/Modules`.
+
+### Add Message Template
+1. Use `template-creation`.
+2. Update `MessageTemplateNames` when code references the template.
+3. Update installer seed data for new installations.
+4. Add DotLiquid tokens only through `Liquid*` drops and token provider patterns.
+
+### Add Permission Or Menu Item
+1. Update permission constants and seed data using existing installer utilities.
+2. Update `StandardAdminSiteMap` when navigation is required.
+3. Enforce permission server-side in controllers or services.
+4. Check Admin, Store Owner, and Vendor differences.
+

--- a/skills/reviews/architecture-review/SKILL.md
+++ b/skills/reviews/architecture-review/SKILL.md
@@ -1,0 +1,82 @@
+# Architecture Review
+
+## Purpose
+Identify architectural risks, boundary violations, maintainability problems, and design inconsistencies in a software repository before changes are accepted.
+
+## When To Use
+Use this skill when asked to review system design, module boundaries, dependency direction, layering, extensibility, coupling, deployment structure, or long-term maintainability.
+
+Use this skill before large refactors, platform changes, shared library changes, cross-service integrations, or changes that affect public contracts.
+
+## When Not To Use
+Do not use this skill for narrow syntax fixes, formatting changes, dependency version bumps with no behavior change, or isolated test-only edits.
+
+Do not use this skill as a substitute for security, database, performance, or framework-specific review when those domains are the primary concern.
+
+## Inputs Required
+- Repository root.
+- Change set or target files to review.
+- Stated feature goal or pull request summary.
+- Existing architecture documentation, if available.
+- Build, test, and deployment configuration relevant to the change.
+
+## Instructions
+
+### Mandatory Rules
+1. Read the stated goal before inspecting implementation details.
+2. Identify the affected components, modules, services, packages, and external contracts.
+3. Map dependencies between affected areas.
+4. Check whether dependency direction follows existing repository conventions.
+5. Check whether responsibilities remain in the correct layer or module.
+6. Check whether public APIs, events, messages, schemas, or configuration contracts changed.
+7. Verify that compatibility, migration, and rollback concerns are handled when contracts change.
+8. Look for duplicated abstractions, unnecessary indirection, circular dependencies, and hidden coupling.
+9. Check whether error handling, observability, and operational behavior match existing patterns.
+10. Prioritize findings by impact and likelihood.
+11. Provide file and line references for each finding when possible.
+12. State when no architectural issues are found.
+
+### Recommendations
+1. Prefer small, reversible design changes over broad rewrites.
+2. Recommend existing repository patterns before introducing new abstractions.
+3. Suggest tests that protect architectural contracts.
+4. Separate confirmed defects from design preferences.
+5. Include open questions only when missing information affects the review outcome.
+
+## Constraints
+- Never rewrite code unless explicitly asked.
+- Never recommend a new framework, pattern, service, or dependency without tying it to a concrete problem.
+- Never ignore existing project conventions in favor of generic architecture preferences.
+- Never report stylistic preferences as architectural defects.
+- Never invent requirements, constraints, or undocumented contracts.
+
+## Expected Output
+Produce a review report with:
+- Findings ordered by severity.
+- Each finding containing impact, evidence, and a concrete recommendation.
+- Open questions or assumptions, if any.
+- A brief summary of residual risk.
+- A validation checklist result.
+
+## Validation Checklist
+- [ ] The review explains the change scope.
+- [ ] Findings are tied to concrete files, interfaces, or runtime behavior.
+- [ ] Dependency direction and layering were checked.
+- [ ] Public contracts and compatibility were checked.
+- [ ] Operational concerns were checked.
+- [ ] Recommendations preserve repository conventions.
+- [ ] No speculative issue is presented as fact.
+- [ ] The report states when no issues are found.
+
+## Examples
+
+### Example 1: Layer Boundary Violation
+Input: A web controller now directly imports a data access implementation.
+
+Output finding: The controller bypasses the application service layer, which couples request handling to persistence and makes authorization rules easier to skip. Move the persistence call behind the existing service abstraction and add a service-level test.
+
+### Example 2: Contract Change Without Migration
+Input: An event payload field is renamed and consumers are not updated.
+
+Output finding: The event contract changed without a compatibility path. Existing consumers may fail to deserialize messages. Add a versioned field, update consumers, and document the removal timeline.
+

--- a/skills/reviews/database-review/SKILL.md
+++ b/skills/reviews/database-review/SKILL.md
@@ -1,0 +1,86 @@
+# Database Review
+
+## Purpose
+Review database-related changes for correctness, data integrity, performance, migration safety, concurrency behavior, and maintainability.
+
+## When To Use
+Use this skill when reviewing schema changes, migrations, indexes, constraints, queries, stored procedures, ORM mappings, seed data, transactions, reporting queries, or data access patterns.
+
+Use this skill before deploying changes that modify persistent data shape, query behavior, data retention, or database configuration.
+
+## When Not To Use
+Do not use this skill for code changes that do not read, write, migrate, or configure persistent data.
+
+Do not use this skill as the primary review for authentication, authorization, or cryptographic storage; combine it with a security review when sensitive data is involved.
+
+## Inputs Required
+- Repository root.
+- Change set or target files to review.
+- Database engine and version, if known.
+- Migration files, schema definitions, ORM mappings, and query code.
+- Existing indexes, constraints, and relevant data volume assumptions.
+- Rollback or deployment process, if available.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify all tables, collections, views, indexes, constraints, migrations, and queries affected by the change.
+2. Check schema changes for backward compatibility with currently deployed application versions.
+3. Check migrations for lock risk, runtime duration, batching needs, transactional safety, idempotency, and rollback behavior.
+4. Check column and type changes for data loss, truncation, precision loss, nullability conflicts, default values, and timezone behavior.
+5. Check constraints for existing-data compatibility and intended enforcement.
+6. Check indexes for query support, selectivity, write overhead, uniqueness needs, and redundant overlap.
+7. Check query changes for filtering correctness, join cardinality, sort behavior, pagination stability, N+1 access, and avoidable full scans.
+8. Check transactions for atomicity, isolation assumptions, retry behavior, deadlock risk, and partial update failure.
+9. Check concurrency behavior for lost updates, duplicate creation, stale reads, and optimistic or pessimistic locking requirements.
+10. Check ORM mappings for cascade behavior, tracking behavior, lazy loading, required relationships, and migration consistency.
+11. Check seed or reference data changes for environment safety and repeatability.
+12. Prioritize findings by risk to data integrity, availability, and performance.
+13. Provide file and line references for each finding when possible.
+14. State when no database issues are found.
+
+### Recommendations
+1. Prefer expand-and-contract migrations for breaking schema changes.
+2. Prefer database-enforced integrity for invariants that must survive concurrent writers.
+3. Recommend representative data-volume testing for expensive migrations or queries.
+4. Recommend query plan inspection when performance depends on index selection.
+5. Separate confirmed defects from scalability warnings.
+
+## Constraints
+- Never assume production data is small unless explicitly documented.
+- Never recommend destructive migrations without a backup, rollout, and rollback plan.
+- Never rely only on application validation for critical data integrity.
+- Never ignore compatibility between application deployment order and migration order.
+- Never propose dropping columns, indexes, constraints, or data without proving they are unused or safely replaced.
+
+## Expected Output
+Produce a database review report with:
+- Findings ordered by severity.
+- Each finding containing data risk, operational impact, evidence, and remediation.
+- Migration and rollback concerns.
+- Performance concerns and recommended validation.
+- Open questions or assumptions, if any.
+- A validation checklist result.
+
+## Validation Checklist
+- [ ] Affected schema objects and queries were identified.
+- [ ] Migration safety and deployment order were checked.
+- [ ] Data loss and compatibility risks were checked.
+- [ ] Constraints and indexes were checked.
+- [ ] Transaction and concurrency behavior were checked.
+- [ ] ORM mappings were checked where relevant.
+- [ ] Performance validation was recommended where needed.
+- [ ] Destructive operations include safety requirements.
+
+## Examples
+
+### Example 1: Non-Nullable Column Without Default
+Input: A migration adds a required column to an existing large table without a default value.
+
+Output finding: The migration can fail on existing rows or require a long exclusive lock while backfilling. Add the column as nullable, backfill in batches, enforce not-null after validation, and define rollback behavior.
+
+### Example 2: Offset Pagination Instability
+Input: A query uses offset pagination ordered only by a non-unique timestamp.
+
+Output finding: Results can be duplicated or skipped when multiple rows share the same timestamp or new rows are inserted. Add a deterministic tie-breaker and consider keyset pagination for large result sets.
+

--- a/skills/reviews/dotnet-review/SKILL.md
+++ b/skills/reviews/dotnet-review/SKILL.md
@@ -1,0 +1,85 @@
+# .NET Review
+
+## Purpose
+Review .NET repository changes for correctness, framework consistency, maintainability, runtime safety, MongoDB-backed data access, and test coverage.
+
+## When To Use
+Use this skill when reviewing C#, F#, Visual Basic, ASP.NET Core, MongoDB repository usage, NuGet package configuration, MSBuild files, background services, middleware, dependency injection, LINQ, async code, or .NET test projects.
+
+Use this skill for changes that affect request handling, domain logic, persistence, serialization, configuration, build behavior, or package versions.
+
+## When Not To Use
+Do not use this skill for non-.NET files unless they directly affect .NET build, deployment, runtime configuration, or generated code.
+
+Do not use this skill as the primary review for database design, MongoDB index strategy, or security-sensitive changes; combine it with the relevant review skill.
+
+## Inputs Required
+- Repository root.
+- Change set or target files to review.
+- Target framework versions.
+- Solution, project, package, and build files relevant to the change.
+- Existing tests and test framework conventions.
+- Runtime configuration files relevant to the change.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify affected projects, target frameworks, package references, and build properties.
+2. Check that code follows existing repository conventions for naming, layering, dependency injection, logging, validation, and error handling.
+3. Check async code for missing awaits, sync-over-async, unobserved tasks, blocking calls, cancellation token misuse, and context leaks.
+4. Check dependency injection registrations for lifetime mismatches, duplicate registrations, missing registrations, and service locator patterns.
+5. Check nullable reference type handling when enabled.
+6. Check LINQ and collection usage for repeated enumeration, client-side evaluation risk, null handling, and avoidable materialization.
+7. Check ASP.NET Core changes for model binding, validation, filters, middleware order, status codes, routing, antiforgery behavior, and response serialization.
+8. Check MongoDB-backed repository usage for filter correctness, projection shape, pagination stability, update atomicity, transaction boundaries, concurrency handling, and avoidable N+1 access patterns.
+9. Check configuration access for missing defaults, unsafe environment assumptions, and inconsistent option binding.
+10. Check package changes for version conflicts, central package management consistency, and unnecessary dependencies.
+11. Check tests for meaningful assertions, correct isolation, deterministic behavior, and coverage of changed behavior.
+12. Run or recommend the narrowest relevant build and test commands when execution is available.
+13. Prioritize findings by runtime impact and maintainability risk.
+14. Provide file and line references for each finding when possible.
+15. State when no .NET issues are found.
+
+### Recommendations
+1. Prefer repository-established helpers, base classes, extension methods, and test utilities.
+2. Prefer explicit cancellation support for I/O, background work, and request-scoped operations.
+3. Prefer options validation for required configuration.
+4. Recommend integration tests for framework pipeline behavior.
+5. Separate correctness issues from style or modernization suggestions.
+
+## Constraints
+- Never introduce a new package recommendation when the platform or repository already provides the needed capability.
+- Never assume MongoDB query behavior without checking filters, projections, sorting, pagination, and materialization points.
+- Never ignore project-level settings such as nullable annotations, implicit usings, analyzers, or central package management.
+- Never recommend broad framework upgrades unless the change requires them.
+- Never treat generated files as source of truth when source templates or generators are present.
+
+## Expected Output
+Produce a .NET review report with:
+- Findings ordered by severity.
+- Each finding containing runtime impact, evidence, and remediation.
+- Build and test commands executed or recommended.
+- Open questions or assumptions, if any.
+- A validation checklist result.
+
+## Validation Checklist
+- [ ] Affected projects and target frameworks were identified.
+- [ ] Build and package configuration were checked.
+- [ ] Async, DI, nullable, LINQ, and configuration patterns were checked where relevant.
+- [ ] ASP.NET Core behavior was checked where relevant.
+- [ ] MongoDB-backed repository behavior was checked where relevant.
+- [ ] Tests were reviewed for changed behavior.
+- [ ] Recommendations match existing repository conventions.
+- [ ] The report states whether commands were run.
+
+## Examples
+
+### Example 1: Scoped Service Captured By Singleton
+Input: A singleton background dispatcher receives a scoped repository through constructor injection.
+
+Output finding: The singleton captures a scoped dependency, which can cause disposed context usage and cross-request state leakage. Resolve scoped services inside a created scope for each operation and add a background service test.
+
+### Example 2: Missing Await
+Input: A controller calls an asynchronous save method without awaiting it.
+
+Output finding: The response may return before persistence completes and exceptions may be unobserved. Await the save operation, pass the request cancellation token, and assert persistence in the controller test.

--- a/skills/reviews/mongodb-review/SKILL.md
+++ b/skills/reviews/mongodb-review/SKILL.md
@@ -1,0 +1,98 @@
+# MongoDB Review
+
+## Purpose
+Review MongoDB-related repository changes for query correctness, index fit, data integrity, migration safety, concurrency behavior, and production performance.
+
+## When To Use
+Use this skill when reviewing MongoDB collections, repository methods, filters, projections, sorting, pagination, indexes, aggregation pipelines, update operations, migrations, seed data, connection configuration, or MongoDB driver usage.
+
+Use this skill when a change reads, writes, transforms, migrates, imports, exports, or deletes persisted MongoDB data.
+
+## When Not To Use
+Do not use this skill for changes that do not touch MongoDB-backed persistence, repository behavior, data migrations, or data access configuration.
+
+Do not use this skill as the primary review for authentication, authorization, secrets, or business workflow correctness; combine it with the relevant review skill when those concerns are present.
+
+## Inputs Required
+- Repository root.
+- Change set or target files to review.
+- MongoDB driver version and data access abstractions.
+- Affected domain models, repository methods, migrations, and configuration files.
+- Existing indexes and expected data volume, if available.
+- Deployment and rollback process for data migrations, if available.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify every affected collection, document type, repository method, migration, and query path.
+2. Check filters for correct tenant, store, vendor, customer, language, currency, status, and soft-delete scoping when those fields apply.
+3. Check queries for missing filters, incorrect boolean logic, case-sensitivity mistakes, timezone mistakes, and null or empty value handling.
+4. Check sorting and pagination for deterministic ordering, stable page boundaries, and index support.
+5. Check projections for over-fetching, missing required fields, accidental sensitive field exposure, and shape mismatches.
+6. Check update operations for atomicity, lost-update risk, unintended full-document replacement, array update correctness, and upsert safety.
+7. Check delete operations for scope, cascade expectations, soft-delete behavior, and irreversible data loss.
+8. Check aggregation pipelines for stage order, memory risk, cardinality expansion, lookup cost, grouping correctness, and index use before blocking stages.
+9. Check indexes for query coverage, selectivity, uniqueness requirements, sort support, redundant overlap, write overhead, and migration safety.
+10. Check migrations for idempotency, batching, resumability, runtime duration, lock impact, rollback behavior, and compatibility with mixed application versions.
+11. Check transactions and multi-document workflows for atomicity requirements, retry behavior, write concern, read concern, and partial failure handling.
+12. Check repository abstractions for materialization points, repeated enumeration, N+1 access patterns, and client-side filtering after broad reads.
+13. Check configuration for connection string handling, database name selection, timeouts, retry behavior, pooling, TLS, and environment-specific settings.
+14. Prioritize findings by risk to data integrity, tenant isolation, availability, and performance.
+15. Provide file and line references for each finding when possible.
+16. State when no MongoDB issues are found.
+
+### Recommendations
+1. Prefer query filters that include all required scoping fields at the database level.
+2. Prefer atomic update operators over read-modify-write when concurrent writers can touch the same document.
+3. Prefer keyset pagination for large or frequently changing result sets.
+4. Prefer expand-and-contract data migrations for breaking document shape changes.
+5. Recommend representative data-volume testing for expensive queries, indexes, or migrations.
+6. Recommend query plan inspection when performance depends on index selection.
+7. Separate confirmed defects from scalability warnings and cleanup suggestions.
+
+## Constraints
+- Never assume production collections are small unless explicitly documented.
+- Never recommend dropping data, fields, indexes, or collections without a migration, backup, rollback, and usage check.
+- Never rely on application-side filtering for tenant, store, vendor, or permission isolation when database-side filtering is possible.
+- Never ignore deployment order between application code and data migrations.
+- Never present an index recommendation without naming the query pattern it supports.
+- Never expose real connection strings, secrets, tokens, or personal data in the output.
+
+## Expected Output
+Produce a MongoDB review report with:
+- Findings ordered by severity.
+- Each finding containing affected collection or query path, data risk, performance or availability impact, evidence, and remediation.
+- Index and migration concerns.
+- Commands or validation steps executed or recommended.
+- Open questions or assumptions, if any.
+- A validation checklist result.
+
+## Validation Checklist
+- [ ] Affected collections, models, repository methods, and migrations were identified.
+- [ ] Tenant, store, vendor, customer, and permission scoping were checked where relevant.
+- [ ] Filters, projections, sorting, and pagination were checked.
+- [ ] Update, delete, and upsert operations were checked.
+- [ ] Aggregation pipelines were checked where relevant.
+- [ ] Index fit and write overhead were checked.
+- [ ] Migration safety and deployment order were checked.
+- [ ] Concurrency and partial failure behavior were checked.
+- [ ] Configuration and connection handling were checked where relevant.
+- [ ] Findings distinguish confirmed defects from risk-based recommendations.
+
+## Examples
+
+### Example 1: Missing Store Scope
+Input: A repository method loads discount records by coupon code only.
+
+Output finding: The query does not include store scope. In a multi-store deployment, a coupon from one store can be applied in another store if codes collide. Add `StoreId` or the repository's established store filter to the MongoDB query and add a cross-store negative test.
+
+### Example 2: Unstable Pagination
+Input: A product listing sorts only by `CreatedOnUtc` and uses skip/limit pagination.
+
+Output finding: Pagination is unstable when multiple products share the same timestamp or new products are inserted between requests. Add a deterministic tie-breaker such as `_id`, ensure the compound sort has index support, and consider keyset pagination for large catalogs.
+
+### Example 3: Unsafe Read-Modify-Write
+Input: A service reads an order document, increments a counter in memory, and replaces the whole document.
+
+Output finding: Concurrent writers can lose updates because the operation replaces a stale document snapshot. Use an atomic `$inc` or a conditional update with version checking, and test concurrent updates.
+

--- a/skills/reviews/security-review/SKILL.md
+++ b/skills/reviews/security-review/SKILL.md
@@ -1,0 +1,87 @@
+# Security Review
+
+## Purpose
+Identify security vulnerabilities, unsafe defaults, authorization gaps, data exposure risks, and misuse of cryptography or secrets in a software repository.
+
+## When To Use
+Use this skill when reviewing authentication, authorization, session handling, input validation, output encoding, file handling, secrets, cryptography, dependency changes, network calls, logging, or access to sensitive data.
+
+Use this skill for changes that expose APIs, process user input, change permissions, handle payments, process personal data, or modify infrastructure configuration.
+
+## When Not To Use
+Do not use this skill for purely cosmetic UI changes, documentation-only edits, test fixture updates with no production effect, or isolated refactors that do not affect behavior or trust boundaries.
+
+Do not use this skill as a replacement for legal, privacy, or compliance review when formal certification is required.
+
+## Inputs Required
+- Repository root.
+- Change set or target files to review.
+- Threat model or trust boundaries, if available.
+- Authentication and authorization model.
+- Data classification or sensitive data definitions, if available.
+- Dependency and deployment configuration relevant to the change.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify the entry points affected by the change.
+2. Identify trust boundaries crossed by the change.
+3. Identify sensitive data read, written, logged, transmitted, or stored.
+4. Verify authentication is required where appropriate.
+5. Verify authorization checks enforce the intended resource owner, role, tenant, or permission.
+6. Check for injection risks in database queries, commands, templates, paths, URLs, headers, and serialized data.
+7. Check input validation and output encoding at all external boundaries.
+8. Check file upload, download, archive, and path handling for traversal, type confusion, overwrite, and size risks.
+9. Check secret handling for hardcoded values, unsafe storage, accidental logging, and exposure in configuration.
+10. Check cryptographic usage for approved primitives, correct randomness, safe key handling, and no custom algorithms.
+11. Check dependency changes for known vulnerable packages or unsafe transitive exposure when dependency data is available.
+12. Check error handling and logging for sensitive information disclosure.
+13. Prioritize findings by exploitability and impact.
+14. Provide file and line references for each finding when possible.
+15. State when no security issues are found.
+
+### Recommendations
+1. Prefer deny-by-default authorization.
+2. Prefer centralized validation, encoding, and policy enforcement patterns already used by the repository.
+3. Recommend tests that prove exploit paths are blocked.
+4. Separate confirmed vulnerabilities from hardening suggestions.
+5. Include severity, attack scenario, and remediation for each confirmed issue.
+
+## Constraints
+- Never provide exploit instructions beyond what is needed to prove impact and remediation.
+- Never expose real secrets, tokens, credentials, or personal data in the output.
+- Never assume a control exists without verifying it in code or configuration.
+- Never mark an issue as fixed by a caller-side control when the server-side trust boundary still accepts unsafe input.
+- Never recommend custom cryptography.
+
+## Expected Output
+Produce a security review report with:
+- Findings ordered by severity.
+- Each finding containing affected asset, attack path, impact, evidence, and remediation.
+- Hardening recommendations separated from vulnerabilities.
+- Open questions or assumptions, if any.
+- A validation checklist result.
+
+## Validation Checklist
+- [ ] Entry points were identified.
+- [ ] Trust boundaries were checked.
+- [ ] Authentication and authorization were checked.
+- [ ] Sensitive data handling was checked.
+- [ ] Injection, path, file, and serialization risks were checked.
+- [ ] Secret handling was checked.
+- [ ] Logging and error disclosure were checked.
+- [ ] Findings include concrete remediation.
+- [ ] No secrets or personal data are disclosed in the report.
+
+## Examples
+
+### Example 1: Missing Tenant Check
+Input: An endpoint loads an order by ID and returns it to any authenticated user.
+
+Output finding: The endpoint authenticates the caller but does not verify tenant or owner access for the order. A user can request another tenant's order ID. Add a tenant-scoped query or explicit authorization check and add a negative access test.
+
+### Example 2: Unsafe File Path
+Input: A download action joins a user-supplied filename with a storage directory.
+
+Output finding: The filename is not normalized or constrained to the storage root. A crafted path can read unintended files. Resolve the full path, enforce the storage root prefix, reject traversal segments, and test traversal attempts.
+

--- a/skills/scheduled-task/SKILL.md
+++ b/skills/scheduled-task/SKILL.md
@@ -1,0 +1,185 @@
+# Scheduled Task
+
+## Purpose
+Create, modify, and review GrandNode scheduled tasks including the task class, DI registration, database seed, distributed-lock behavior, error handling, and task migrations.
+
+## When To Use
+Use this skill when adding a new background task, changing an existing task's logic or interval, migrating a task name or seed entry for existing installations, or reviewing scheduled task correctness, idempotency, and multi-instance safety.
+
+## When Not To Use
+Do not use this skill for message template content or email sending logic; combine with `message-notification` when a task sends emails.
+
+Do not use this skill as the primary review for MongoDB query safety or security; combine with the relevant skill when those concerns apply.
+
+## Inputs Required
+- Repository root.
+- Task purpose and trigger description.
+- Required time interval (minutes).
+- Whether the task should be enabled by default.
+- Domain entities the task reads or writes.
+- Whether the task must respect per-store or per-language context.
+
+## Instructions
+
+### Mandatory Rules
+
+#### Task Class
+1. Implement `IScheduleTask` from `Grand.Business.Core.Interfaces.System.ScheduleTasks` with a single `Task Execute()` method.
+2. Place the task class in `src/Modules/Grand.Module.ScheduledTasks/BackgroundServices/`.
+3. Resolve all dependencies through constructor injection. `Execute()` takes no parameters and receives no `CancellationToken` from the caller.
+4. Keep `Execute()` idempotent: running it twice in a row must not corrupt data or duplicate side effects.
+5. For tasks that process a collection of items, wrap each item in its own `try-catch` block. Log the error and continue with the next item; do not let a single-item failure abort the whole run.
+6. Never call `Thread.Sleep`, `Task.Delay`, or any other wait inside `Execute()`. The runner controls the interval.
+
+#### DI Registration
+7. Register the task in `src/Modules/Grand.Module.ScheduledTasks/Startup/StartupApplication.cs` using exactly:
+   ```csharp
+   serviceCollection.AddKeyedScoped<IScheduleTask, YourTask>("Task name string");
+   ```
+8. The service key string **must exactly match** the `ScheduleTaskName` stored in the database. Any mismatch means the runner cannot resolve the task.
+
+#### Database Seed
+9. Add a `ScheduleTask` entry in `src/Modules/Grand.Module.Installer/Services/InstallDataScheduleTasks.cs` inside `InstallScheduleTasks()`:
+   ```csharp
+   new ScheduleTask {
+       ScheduleTaskName = "Task name string",   // must equal the DI key
+       Enabled = false,                          // prefer disabled by default
+       StopOnError = false,
+       TimeInterval = N                          // minutes
+   }
+   ```
+10. Prefer `Enabled = false` for new tasks so the administrator explicitly activates them. Only set `Enabled = true` for tasks that must run immediately after installation (e.g., `"Send emails"`).
+11. Leave `StopOnError = false` unless the task manages a resource that is unsafe to run after a partial failure.
+
+#### Existing Installations — Migrations
+12. Add a migration under `src/Modules/Grand.Module.Migration/Migrations/` when changing the `ScheduleTaskName`, default `TimeInterval`, or `Enabled` value for a task that already exists in production. Follow the `IMigration` interface and existing migration class patterns.
+13. In a migration that adds a new task, insert the new `ScheduleTask` only when it does not already exist (check by `ScheduleTaskName` before inserting).
+14. In a migration that removes a task, delete by `ScheduleTaskName` and remove the DI registration.
+
+#### Error Handling
+15. The runner sets `task.Enabled = false` when `StopOnError = true` and `Execute()` throws an uncaught exception. Tasks with `StopOnError = false` remain enabled and retry on the next interval.
+16. Log unexpected exceptions with `ILogger<T>`. Do not swallow them silently — the runner also logs at error level, but task-level context is valuable.
+17. For partial-failure loops, update the item's state inside a `finally` block so the next run does not re-process an item that was already attempted.
+
+#### Multi-Instance Safety
+18. The runner uses `TryClaimTaskRun()` — an atomic compare-and-set on `LastStartUtc` — to ensure only one instance executes a given task per interval window. Task classes do not need to implement their own locking.
+19. Do not cache expensive results across `Execute()` calls using instance fields. The task is registered as `AddKeyedScoped`, so a new instance is created for each execution.
+
+#### Store and Language Context
+20. When a task must operate per store, inject `IStoreService` and iterate over `GetAllStores()`. The `ScheduleTask.StoreId` field is available if the task should be restricted to a single store.
+21. When locale-sensitive output is required, inject `ILanguageService` and iterate over languages for the relevant store.
+
+### Recommendations
+1. Prefer reading a bounded batch of records (e.g., top 500) rather than loading an unbounded collection in one query.
+2. Prefer a short `TimeInterval` for operational tasks (email sending = 1 min) and a long interval for maintenance tasks (sitemap generation = 10080 min = 7 days).
+3. Prefer injecting `ILogger<T>` for all non-trivial tasks to support observability.
+4. Prefer structured log messages that include the task name and record ID when processing per-item.
+
+## Constraints
+- Never place task classes outside `src/Modules/Grand.Module.ScheduledTasks/BackgroundServices/`.
+- Never register a task with a DI key that differs from its `ScheduleTaskName` in the database.
+- Never add a seed entry without also adding a DI registration, and vice versa.
+- Never introduce locking, semaphores, or static shared state inside a task class.
+- Never call `IEmailSender` directly from a task; use `IMessageProviderService` or queue via `IQueuedEmailService` following the message-notification pattern.
+
+## Key Contracts
+
+### IScheduleTask (`src/Business/Grand.Business.Core/Interfaces/System/ScheduleTasks/IScheduleTask.cs`)
+```csharp
+public interface IScheduleTask
+{
+    Task Execute();
+}
+```
+
+### ScheduleTask entity (`src/Core/Grand.Domain/Tasks/ScheduleTask.cs`)
+```csharp
+public class ScheduleTask : BaseEntity
+{
+    public string ScheduleTaskName { get; set; }   // DI key and display name
+    public bool   Enabled          { get; set; }
+    public bool   StopOnError      { get; set; }
+    public int    TimeInterval     { get; set; }   // minutes
+    public string StoreId          { get; set; }   // empty = all stores
+    public DateTime? LastStartUtc       { get; set; }
+    public DateTime? LastSuccessUtc     { get; set; }
+    public DateTime? LastNonSuccessEndUtc { get; set; }
+    public string LeasedByInstance { get; set; }   // multi-instance lock holder
+}
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| IScheduleTask interface | `src/Business/Grand.Business.Core/Interfaces/System/ScheduleTasks/IScheduleTask.cs` |
+| Task classes | `src/Modules/Grand.Module.ScheduledTasks/BackgroundServices/` |
+| DI registration | `src/Modules/Grand.Module.ScheduledTasks/Startup/StartupApplication.cs` |
+| ScheduleTask entity | `src/Core/Grand.Domain/Tasks/ScheduleTask.cs` |
+| Installer seed | `src/Modules/Grand.Module.Installer/Services/InstallDataScheduleTasks.cs` |
+| Task runner (BackgroundService) | `src/Web/Grand.Web.Common/Infrastructure/BackgroundServiceTask.cs` |
+| Task handler startup | `src/Web/Grand.Web.Common/Startup/TaskHandler.cs` |
+| IScheduleTaskService | `src/Business/Grand.Business.Core/Interfaces/System/ScheduleTasks/IScheduleTaskService.cs` |
+| Migration example | `src/Modules/Grand.Module.Migration/Migrations/2.1/MigrationScheduleTasks.cs` |
+| Tests — ScheduleTaskService | `src/Tests/Grand.Modules.Tests/Services/BackgroundService/ScheduleTaskServiceTests.cs` |
+| Tests — BackgroundServiceTask | `src/Tests/Grand.Web.Common.Tests/Infrastructure/BackgroundServiceTaskTests.cs` |
+
+## Existing Task Inventory
+
+| Class | DI key / ScheduleTaskName | Default interval | Default enabled |
+|---|---|---|---|
+| `QueuedMessagesSendScheduleTask` | `"Send emails"` | 1 min | true |
+| `DeleteGuestsScheduleTask` | `"Delete guests"` | 1440 min | true |
+| `UpdateExchangeRateScheduleTask` | `"Update currency exchange rates"` | 1440 min | true |
+| `ClearCacheScheduleTask` | `"Clear cache"` | 120 min | false |
+| `GenerateSitemapXmlTask` | `"Generate sitemap XML file"` | 10080 min | false |
+| `EndAuctionsTask` | `"End of the auctions"` | 60 min | false |
+| `CancelOrderScheduledTask` | `"Cancel unpaid and pending orders"` | 1440 min | false |
+
+## Expected Output
+Produce one of these results:
+- A new task class, DI registration, installer seed, and (when needed) migration.
+- An updated task class with matching DI key, seed, and migration for existing installations.
+- A review report listing task correctness, idempotency, or registration issues.
+
+Include changed files, DI key, seed values, migration status, and remaining risks.
+
+## Validation Checklist
+- [ ] Task class implements `IScheduleTask` and lives in `BackgroundServices/`.
+- [ ] `Execute()` is idempotent and does not depend on execution order.
+- [ ] Per-item loops use individual `try-catch` blocks.
+- [ ] DI key in `AddKeyedScoped` exactly matches the `ScheduleTaskName` seed value.
+- [ ] Installer seed entry added with appropriate `Enabled` and `TimeInterval`.
+- [ ] Migration added for tasks that affect existing installations.
+- [ ] No static shared state or cross-call caching inside the task class.
+- [ ] `ILogger<T>` used for error and diagnostic output.
+- [ ] Tests cover `Execute()` happy path and error-per-item behavior where applicable.
+
+## Examples
+
+### Example 1: Simple Maintenance Task
+Input: Add a task that deletes expired product reservations every 60 minutes.
+
+Output:
+1. Create `DeleteExpiredReservationsTask : IScheduleTask` in `BackgroundServices/`.
+2. Inject `IProductReservationService` and `ILogger<DeleteExpiredReservationsTask>`.
+3. In `Execute()`: query expired reservations, delete each inside a `try-catch`, log errors and continue.
+4. Register: `AddKeyedScoped<IScheduleTask, DeleteExpiredReservationsTask>("Delete expired reservations")`.
+5. Seed: `new ScheduleTask { ScheduleTaskName = "Delete expired reservations", Enabled = false, StopOnError = false, TimeInterval = 60 }`.
+
+### Example 2: Per-Store Task
+Input: Add a task that recalculates price tiers per store daily.
+
+Output:
+1. Create `RecalculatePriceTiersTask : IScheduleTask`.
+2. Inject `IStoreService` and `IPricingService`.
+3. In `Execute()`: call `_storeService.GetAllStores()`, loop each store, call `_pricingService.RecalculateTiers(store.Id)` wrapped in per-store `try-catch`.
+4. Register and seed with `TimeInterval = 1440`.
+
+### Example 3: Renaming a Task in Migration
+Input: The task `"Recalculate price tiers"` needs to be renamed to `"Recalculate product pricing"`.
+
+Output:
+1. Update the DI key in `StartupApplication.cs` to `"Recalculate product pricing"`.
+2. Add a migration class implementing `IMigration` that finds the `ScheduleTask` by the old `ScheduleTaskName` and updates it to the new name.
+3. If no existing task is found, insert a new seed entry so the task exists on installations that never had the old name.

--- a/skills/settings-and-localization/SKILL.md
+++ b/skills/settings-and-localization/SKILL.md
@@ -1,0 +1,184 @@
+# Settings and Localization
+
+## Purpose
+Create, modify, and review GrandNode settings classes, setting persistence, store-scoped overrides, localization resources, translation resource lifecycle, and localized domain and admin models.
+
+## When To Use
+Use this skill when adding or changing a settings class, loading or saving settings per store, reading or writing localization resources, adding translation keys for a plugin or module, seeding default settings or resources in the installer, building localized admin models, or working with `ITranslationService`, `ISettingService`, `IPluginTranslateResource`, or `ILanguageService`.
+
+## When Not To Use
+Do not use this skill for pure UI work without settings or localization changes; combine it with `template-creation` or `admin-area-changes` when UI is involved.
+
+Do not use this skill as the primary review for MongoDB query safety or security; combine it with the relevant skill when those concerns apply.
+
+## Inputs Required
+- Repository root.
+- Target feature, plugin, or module name.
+- Whether settings are global or per-store.
+- Which admin panels expose the settings (Admin, Store Owner, Vendor, plugin config page).
+- Required localization resource keys and their text.
+- Whether domain entities carry per-language values (`ITranslationEntity` / `Locales`).
+
+## Instructions
+
+### Mandatory Rules
+
+#### Settings
+1. Define every settings class in `src/Core/Grand.Domain` and implement the marker interface `Grand.Domain.Configuration.ISettings`.
+2. Keep settings as plain properties with no business logic. Store primitive types, enums, and simple value types.
+3. Load settings with `ISettingService.LoadSetting<T>(storeId)`. Pass an empty string to load the global fallback; pass the active store ID for per-store overrides.
+4. Obtain the active store ID from `IAdminStoreService.GetActiveStore()` in admin, store, and plugin controllers.
+5. Save settings with `ISettingService.SaveSetting<T>(settings, storeId)`. Call `await settingService.ClearCache()` immediately after.
+6. Delete all settings for a type with `ISettingService.DeleteSetting<T>()` in plugin `Uninstall`.
+7. Seed default settings in `src/Modules/Grand.Module.Installer/Services/InstallDataSettings.cs` using `SaveSetting` without a store ID.
+8. Map between settings and admin models using static extension methods in `src/Web/Grand.Web.AdminShared/Extensions/Mapping/Settings/`, following the `ToModel()` / `ToEntity(model, destination)` pattern backed by `MapTo`.
+9. Register mapper profiles for settings models in `Grand.Web.AdminShared` when the model is shared across panels.
+
+#### Localization
+10. Identify resources by a lowercase dot-separated key, for example `plugins.payment.cashondelivery.additionalfee`.
+11. Use `IPluginTranslateResource.AddOrUpdatePluginTranslateResource(name, value, area)` in plugin `Install` to register all resource keys.
+12. Use `IPluginTranslateResource.DeletePluginTranslationResource(name)` in plugin `Uninstall` for every key added during install.
+13. Assign the correct `TranslationResourceArea` enum value when adding resources:
+    - `Common` (0) — shared across all areas.
+    - `Admin` (1) — admin panel only.
+    - `Front` (2) — public storefront.
+    - `Plugin` (3) — plugin-owned resources.
+    - `Vendor` (5) — vendor panel.
+14. Seed default resources for core features in `src/Modules/Grand.Module.Installer/Services/InstallDataLocaleResources.cs` via `src/Web/Grand.Web/App_Data/Resources/DefaultLanguage.xml`.
+15. Access resources in controllers and services by injecting `ITranslationService` and calling `GetResource(key)` or `GetResource(key, languageId, defaultValue)`.
+16. Access resources in Razor views through the `Loc` indexer: `@Loc["key"]`. Do not call `ITranslationService` directly from views.
+17. Translate enum values using `IEnumTranslationService` with keys formatted as `Enums.{TypeName}.{ValueName}`.
+
+#### Localized Domain Entities
+18. Implement `ITranslationEntity` on domain entities that require per-language field values. This adds a `IList<TranslationEntity> Locales` collection where each entry carries `LanguageId`, `LocaleKey`, and `LocaleValue`.
+19. Implement `ILocalizedModel<TLocalizedModel>` on admin models for entities with localized fields. Each inner model must implement `ILocalizedModelLocal` (has a `LanguageId` property).
+
+### Recommendations
+1. Prefer `LoadSetting<T>(storeId)` over individual key lookups for settings objects with multiple properties.
+2. Prefer a single `SaveSetting<T>` call that persists the whole settings object rather than saving individual keys.
+3. Prefer store-scoped settings only when the feature must behave differently across stores.
+4. Prefer adding all resource keys in a single `Install` method block so they are easy to match with `Uninstall` deletions.
+5. Prefer using `Admin.Configuration.Updated` and `Admin.Plugins.Saved` as generic success messages rather than inventing new keys.
+6. Prefer placing plugin-specific settings classes inside the plugin project, not in `Grand.Domain`.
+
+## Constraints
+- Never place a settings class outside `Grand.Domain` for core features (plugin settings are the exception and stay in the plugin project).
+- Never load settings without passing a store ID when the feature supports per-store configuration.
+- Never skip `ClearCache()` after saving settings.
+- Never leave resource keys in `Install` that are not removed in `Uninstall`.
+- Never hardcode display text in controllers or views when a resource key is available.
+- Never call `ITranslationService` directly from Razor views; use `Loc[...]` instead.
+- Never add `TranslationResource` documents directly to the database without going through `ITranslationService` or `IPluginTranslateResource`.
+
+## Key Contracts
+
+### ISettingService (`src/Business/Grand.Business.Core/Interfaces/Common/Configuration/ISettingService.cs`)
+```csharp
+Task<T>     LoadSetting<T>(string storeId = "") where T : ISettings, new();
+Task        SaveSetting<T>(T settings, string storeId = "") where T : ISettings, new();
+Task        DeleteSetting<T>() where T : ISettings, new();
+Task        ClearCache();
+Task<T>     GetSettingByKey<T>(string key, T defaultValue = default, string storeId = "");
+Task        SetSetting<T>(string key, T value, string storeId = "");
+IList<Setting> GetAllSettings();
+```
+
+### ITranslationService (`src/Business/Grand.Business.Core/Interfaces/Common/Localization/ITranslationService.cs`)
+```csharp
+string GetResource(string name);
+string GetResource(string name, string languageId, string defaultValue = "", bool returnEmptyIfNotFound = false);
+Task InsertTranslateResource(TranslationResource resource);
+Task UpdateTranslateResource(TranslationResource resource);
+Task DeleteTranslateResource(TranslationResource resource);
+Task<TranslationResource> GetTranslateResourceByName(string name, string languageId);
+```
+
+### IPluginTranslateResource (`src/Business/Grand.Business.Core/Interfaces/Common/Localization/IPluginTranslateResource.cs`)
+```csharp
+Task AddOrUpdatePluginTranslateResource(string name, string value,
+    TranslationResourceArea area = TranslationResourceArea.Common, string languageCulture = null);
+Task DeletePluginTranslationResource(string name);
+```
+
+### IAdminStoreService (`src/Web/Grand.Web.Common/Helpers/AdminStoreService.cs`)
+```csharp
+Task<string> GetActiveStore();  // returns storeId or "" if single-store
+```
+
+## File Locations
+
+| Concern | Path |
+|---|---|
+| Settings domain classes | `src/Core/Grand.Domain/{Area}/{Feature}Settings.cs` |
+| ISettings marker | `src/Core/Grand.Domain/Configuration/ISettings.cs` |
+| ISettingService interface | `src/Business/Grand.Business.Core/Interfaces/Common/Configuration/ISettingService.cs` |
+| SettingService implementation | `src/Business/Grand.Business.Common/Services/Configuration/SettingService.cs` |
+| Settings admin models (shared) | `src/Web/Grand.Web.AdminShared/Models/Settings/` |
+| Settings mapping extensions | `src/Web/Grand.Web.AdminShared/Extensions/Mapping/Settings/` |
+| ITranslationService interface | `src/Business/Grand.Business.Core/Interfaces/Common/Localization/ITranslationService.cs` |
+| IPluginTranslateResource interface | `src/Business/Grand.Business.Core/Interfaces/Common/Localization/IPluginTranslateResource.cs` |
+| ILanguageService interface | `src/Business/Grand.Business.Core/Interfaces/Common/Localization/ILanguageService.cs` |
+| TranslationResource entity | `src/Core/Grand.Domain/Localization/TranslationResource.cs` |
+| TranslationResourceArea enum | `src/Core/Grand.Domain/Localization/TranslationResourceArea.cs` |
+| ITranslationEntity interface | `src/Core/Grand.Domain/Localization/ITranslationEntity.cs` |
+| LocService (view localizer) | `src/Web/Grand.Web.Common/Localization/LocService.cs` |
+| ILocalizedModel interface | `src/Web/Grand.Web.Common/Models/ILocalizedModel.cs` |
+| Default resource XML | `src/Web/Grand.Web/App_Data/Resources/DefaultLanguage.xml` |
+| Installer — settings seed | `src/Modules/Grand.Module.Installer/Services/InstallDataSettings.cs` |
+| Installer — resource seed | `src/Modules/Grand.Module.Installer/Services/InstallDataLocaleResources.cs` |
+| IAdminStoreService | `src/Web/Grand.Web.Common/Helpers/AdminStoreService.cs` |
+| SettingService tests | `src/Tests/Grand.Business.Common.Tests/Services/Configuration/SettingServiceTests.cs` |
+| TranslationService tests | `src/Tests/Grand.Business.Common.Tests/Services/Localization/TranslationServiceTests.cs` |
+
+## Expected Output
+Produce one of these results:
+- A new or modified settings class, mapping extension, admin model, and controller flow.
+- A new or modified set of localization resource keys with matching install and uninstall handling.
+- A review report listing settings or localization issues by severity.
+
+Include changed files, store-scope behavior, resource area classification, validation commands, and remaining risks.
+
+## Validation Checklist
+- [ ] Settings class implements `ISettings` and lives in the correct project.
+- [ ] `LoadSetting` and `SaveSetting` pass the correct store ID.
+- [ ] `ClearCache` is called after every `SaveSetting`.
+- [ ] `DeleteSetting<T>` is called in plugin `Uninstall`.
+- [ ] Every resource key added in `Install` is removed in `Uninstall`.
+- [ ] Resource area is set correctly (`TranslationResourceArea`).
+- [ ] Controllers use `ITranslationService.GetResource(key)` for display messages.
+- [ ] Views use `@Loc["key"]` and do not call `ITranslationService` directly.
+- [ ] Entities that need per-language values implement `ITranslationEntity`.
+- [ ] Admin models that expose localized fields implement `ILocalizedModel<T>`.
+- [ ] Settings mapping extensions follow the `ToModel()` / `ToEntity(model, destination)` pattern.
+- [ ] Tests or build commands were run or reported as not run.
+
+## Examples
+
+### Example 1: Plugin Settings with Store Scope
+Input: Add configurable additional fee to a payment plugin.
+
+Output:
+1. Add `AdditionalFee` property to `XPaymentSettings : ISettings` in the plugin project.
+2. In `Configure` (GET): call `_adminStoreService.GetActiveStore()`, then `_settingService.LoadSetting<XPaymentSettings>(storeScope)`, map to model.
+3. In `Configure` (POST): reload settings, update property, call `SaveSetting(settings, storeScope)`, then `ClearCache()`, then `Success(translationService.GetResource("Admin.Plugins.Saved"))`.
+4. In `Install`: call `SaveSetting(new XPaymentSettings { AdditionalFee = 0 })` and `AddOrUpdatePluginTranslateResource("Plugins.Payment.X.AdditionalFee", "Additional fee", TranslationResourceArea.Plugin)`.
+5. In `Uninstall`: call `DeleteSetting<XPaymentSettings>()` and `DeletePluginTranslationResource("Plugins.Payment.X.AdditionalFee")`.
+
+### Example 2: Core Settings Field
+Input: Add a new catalog setting that controls whether product reviews require approval.
+
+Output:
+1. Add `ProductReviewsMustBeApproved` property to `CatalogSettings` in `src/Core/Grand.Domain/Catalog/CatalogSettings.cs`.
+2. Add matching property to `CatalogSettingsModel` in `src/Web/Grand.Web.AdminShared/Models/Settings/CatalogSettingsModel.cs`.
+3. Update `CatalogSettingsMappingExtensions` to include the property in `ToModel()` and `ToEntity()`.
+4. Update the Admin and Store Owner settings views and controllers to read and write the field.
+5. Add a resource key `admin.configuration.settings.catalog.productreviewsmustbeapproved` to `DefaultLanguage.xml`.
+
+### Example 3: Localized Domain Entity Field
+Input: Add a per-language description to a custom entity.
+
+Output:
+1. Implement `ITranslationEntity` on the domain entity to get `IList<TranslationEntity> Locales`.
+2. In the admin model, implement `ILocalizedModel<TLocalizedModel>` where the inner model has `LanguageId` and `Description`.
+3. In the admin view, render a localization tab using the existing localized tab pattern.
+4. In the controller save action, persist each locale entry back to `entity.Locales`.

--- a/skills/settings-and-localization/SKILL.md
+++ b/skills/settings-and-localization/SKILL.md
@@ -24,7 +24,7 @@ Do not use this skill as the primary review for MongoDB query safety or security
 ### Mandatory Rules
 
 #### Settings
-1. Define every settings class in `src/Core/Grand.Domain` and implement the marker interface `Grand.Domain.Configuration.ISettings`.
+1. Define core settings classes in `src/Core/Grand.Domain` and implement the marker interface `Grand.Domain.Configuration.ISettings` (plugin settings classes stay in the owning plugin project).
 2. Keep settings as plain properties with no business logic. Store primitive types, enums, and simple value types.
 3. Load settings with `ISettingService.LoadSetting<T>(storeId)`. Pass an empty string to load the global fallback; pass the active store ID for per-store overrides.
 4. Obtain the active store ID from `IAdminStoreService.GetActiveStore()` in admin, store, and plugin controllers.

--- a/skills/template-creation/SKILL.md
+++ b/skills/template-creation/SKILL.md
@@ -1,0 +1,109 @@
+# Template Creation
+
+## Purpose
+Create, modify, and review GrandNode templates consistently across Razor views, partials, view components, plugin views, theme overrides, Vue-in-Razor templates, PDF templates, and DotLiquid message templates.
+
+## When To Use
+Use this skill when asked to create or change templates, views, layouts, partials, components, admin forms, store or vendor screens, theme overrides, plugin UI, PDF views, email or notification message templates, Liquid tokens, or template seed data.
+
+Use this skill when a change affects `.cshtml`, message template bodies, template names, DotLiquid drops, view component output, `_ViewImports.cshtml`, `_ViewStart.cshtml`, theme view paths, or template rendering behavior.
+
+## When Not To Use
+Do not use this skill for backend-only service changes, repository changes, migrations, plugin creation without UI, or API-only changes.
+
+Do not use this skill as the primary review for payment correctness, security, MongoDB queries, or plugin architecture; combine it with the relevant skill when those concerns are present.
+
+## Inputs Required
+- Repository root.
+- Template type to create or modify.
+- Target area: public storefront, admin, store area, vendor area, plugin, module, theme, PDF, or message template.
+- Existing closest template to use as a pattern.
+- Model type, view component, controller action, message template name, or token source.
+- Required localization keys, permissions, store scope, and customer or vendor scope.
+- Required assets, scripts, styles, and generated bundle requirements.
+
+## Instructions
+
+### Mandatory Rules
+1. Identify the template type before editing.
+2. Read `references/template-types.md` before creating a new template or changing an unfamiliar template type.
+3. Locate the closest existing template in the same area and follow its folder, naming, model, layout, localization, tag helper, JavaScript, and CSS conventions.
+4. Keep templates in the owning project or plugin; do not place plugin-owned views directly in `Grand.Web`.
+5. Use the existing view location convention for the target area.
+6. Use strongly typed models when the surrounding templates use `@model`.
+7. Use existing localization access patterns such as `Loc[...]`, `@Loc[...]`, `LocalizedService.GetResource(...)`, or plugin translation resources according to the target area.
+8. Use existing tag helpers and helpers for admin or store forms.
+9. Preserve antiforgery behavior for forms and AJAX calls.
+10. Preserve permission checks, store scope, vendor scope, customer group scope, language scope, and currency scope when the template exposes scoped data.
+11. Use partials for repeated markup only when the same structure is reused or already follows local partial patterns.
+12. Use view components when the UI requires independent data loading or existing component zones.
+13. Keep JavaScript close to existing patterns for the same area; do not introduce a new framework for one template.
+14. Keep theme overrides aligned with the base view model and route assumptions.
+15. Escape user-controlled content by default.
+16. Use `Html.Raw` or `v-html` only for content that is already sanitized, trusted, or intentionally HTML-formatted by the domain.
+17. For message templates, use only tokens exposed by the relevant DotLiquid drops or `MessageTokenProvider`.
+18. For message template seed data, update template names consistently with `MessageTemplateNames` and message-sending code.
+19. For plugin templates, ensure the plugin project copies views and assets through the plugin build output pattern.
+20. For Vue-in-Razor templates, preserve escaped Razor/Vue syntax and component registration JSON.
+21. For frontend source changes under `vueapp` or theme CSS that affect committed bundles, run the frontend build or report that it was not run.
+22. Run the narrowest relevant build or test command when execution is available.
+23. State when visual verification was not performed.
+
+### Recommendations
+1. Prefer modifying the smallest existing template that owns the UI.
+2. Prefer theme overrides over changing base storefront templates when the change is theme-specific.
+3. Prefer plugin views over core views when the UI belongs to a plugin.
+4. Prefer existing Bootstrap, Kendo, admin tag helper, and GrandNode component patterns.
+5. Prefer localized text over hardcoded display text.
+6. Prefer accessible labels, alt text, button text, and validation messages.
+7. Prefer deterministic IDs for dynamic form controls and grid elements.
+8. Prefer tests for view models, validators, message token generation, and component selection when markup behavior depends on backend logic.
+
+## Constraints
+- Never create templates without first identifying the owning area and closest existing pattern.
+- Never duplicate large views when a partial, component, or theme override is the intended extension point.
+- Never bypass authorization or scope checks in UI by hiding controls only on the client side.
+- Never expose secrets, tokens, private customer data, or cross-store data in templates.
+- Never use raw HTML output for user input unless the source is explicitly trusted or sanitized.
+- Never add unversioned package dependencies or frontend frameworks for a template-only change.
+- Never edit committed generated bundles without also identifying the source change that produced them.
+- Never change shared layouts for a single-page need unless the change is intentionally global.
+
+## Expected Output
+Produce one of these results:
+- A new or modified template set that follows GrandNode conventions.
+- A review report with template findings ordered by severity.
+- A creation plan when required ownership or model information is missing.
+
+Include changed files, selected template type, closest template used, validation commands, visual verification status, and remaining risks.
+
+## Validation Checklist
+- [ ] The template type and owning area were identified.
+- [ ] The closest existing pattern was followed.
+- [ ] Folder path, filename, model, layout, and imports are consistent.
+- [ ] Localization was used for display text.
+- [ ] Forms and AJAX preserve validation and antiforgery behavior.
+- [ ] Permission, store, vendor, customer group, language, and currency scope were checked where relevant.
+- [ ] User-controlled content is escaped unless intentionally trusted.
+- [ ] Plugin, module, and theme templates remain in their owning locations.
+- [ ] Message templates use valid DotLiquid tokens.
+- [ ] Frontend source and generated bundles are consistent when required.
+- [ ] Build, tests, or visual verification were run or explicitly reported as not run.
+
+## Examples
+
+### Example 1: Admin Configuration Partial
+Input: Add a settings section to a plugin admin configuration page.
+
+Output: Update the plugin's `Areas/Admin/Views/{Controller}/Configure.cshtml` or add a partial next to it, use existing admin tag helpers, keep plugin localization resources in install and uninstall logic, preserve antiforgery behavior, and build the plugin project.
+
+### Example 2: Storefront Theme Override
+Input: Change the product card layout only for the Modern theme.
+
+Output: Modify the matching view under `src/Plugins/Theme.Modern/Views/Modern`, preserve the base `ProductOverviewModel`, keep route and cart action attributes intact, and visually verify product listing behavior.
+
+### Example 3: Message Template
+Input: Add an email sent when a customer receives a new loyalty points reward.
+
+Output: Add a message template name, seed the default template with DotLiquid tokens exposed by the appropriate drop, ensure sending code uses the same name, add missing token generation if needed, and test template rendering.
+

--- a/skills/template-creation/references/template-types.md
+++ b/skills/template-creation/references/template-types.md
@@ -1,0 +1,141 @@
+# GrandNode Template Types
+
+## Public Storefront Razor Views
+Use for customer-facing pages under:
+- `src/Web/Grand.Web/Views`
+- `src/Web/Grand.Web/Views/Shared`
+- `src/Web/Grand.Web/Views/Shared/Partials`
+- `src/Web/Grand.Web/Views/Shared/Components`
+
+Follow existing storefront patterns:
+- Use `@model` where nearby views use strongly typed models.
+- Use `Loc[...]` or `@Loc[...]` for localized text.
+- Use route names such as `Url.RouteUrl(...)` when nearby templates use named routes.
+- Preserve `data-cart-action`, product IDs, quick view URLs, wishlist, compare, and add-to-cart attributes.
+- Preserve image `alt`, `title`, `loading`, and priority behavior.
+- Keep widget zones through `Component.InvokeAsync("Widget", ...)` where they already exist.
+
+## Admin Views
+Use for admin pages under:
+- `src/Web/Grand.Web.Admin/Areas/Admin/Views`
+- `src/Web/Grand.Web.AdminShared`
+- plugin `Areas/Admin/Views`
+
+Follow existing admin patterns:
+- Use admin tag helpers for labels, inputs, validation, cards, tabs, and grids.
+- Use existing Kendo grid and AJAX conventions.
+- Call `addAntiForgeryToken(data)` for AJAX mutations when nearby views do.
+- Preserve permission assumptions from controllers and surrounding templates.
+- Keep partial names like `CreateOrUpdate.TabInfo.cshtml`, `CreateOrUpdate.cshtml`, and popup views when nearby views use them.
+
+## Store Area Views
+Use for store management pages under:
+- `src/Web/Grand.Web.Store/Areas/Store/Views`
+
+Follow existing store-area patterns:
+- Keep store-specific permissions and scope visible in forms and grids.
+- Reuse partial names and tab structure from nearby entities.
+- Preserve store-scoped service behavior by not adding client-only filtering.
+
+## Vendor Area Views
+Use for vendor pages under:
+- `src/Web/Grand.Web.Vendor/Areas/Vendor/Views`
+
+Follow existing vendor patterns:
+- Preserve vendor-specific layout and navigation partials.
+- Do not expose admin-only actions.
+- Keep vendor data filtered by vendor-owned records.
+- Use vendor components under `Views/Shared/Components` when the UI is reusable.
+
+## Plugin Views
+Use for plugin-owned UI under:
+- `src/Plugins/{SystemName}/Views`
+- `src/Plugins/{SystemName}/Areas/Admin/Views`
+- `src/Plugins/{SystemName}/Areas/Store/Views`
+
+Follow existing plugin patterns:
+- Add `_ViewImports.cshtml` where the plugin area requires tag helpers or namespaces.
+- Use `BaseAdminPluginController` or the existing plugin controller base for admin views.
+- Keep plugin configuration views under the plugin folder.
+- Ensure the plugin project uses Razor support when views are present.
+- Ensure plugin project output copies views and assets into `src/Web/Grand.Web/Plugins/{SystemName}`.
+- Add or update plugin localization resources during install and uninstall.
+
+## Theme Views
+Use for theme-specific storefront overrides under:
+- `src/Plugins/Theme.Modern/Views/Modern`
+
+Follow existing theme patterns:
+- Keep `_ViewStart.cshtml` and `_ViewImports.cshtml` behavior intact.
+- Match base storefront model types.
+- Override only the views needed by the theme.
+- Keep theme assets under the theme plugin `Content` folder.
+- Preserve shared component view paths such as `Views/Modern/Shared/Components/{Component}/Default.cshtml`.
+
+## View Components
+Use when markup needs independently loaded data or existing component extension points.
+
+Follow existing component patterns:
+- Component class lives near the owning web or plugin project.
+- Default view path is `Views/Shared/Components/{ComponentName}/Default.cshtml` or the plugin equivalent.
+- Use view components for widgets, navigation blocks, product blocks, footer, menus, and externally supplied provider UI.
+- Keep component names aligned with provider methods such as `GetPublicViewComponentName`.
+
+## Razor Partials
+Use for reusable fragments under `Partials` folders.
+
+Follow existing partial patterns:
+- Name private layout fragments with a leading underscore when nearby views do.
+- Name entity edit tabs as `CreateOrUpdate.Tab{Name}.cshtml`.
+- Pass explicit models to `<partial name="..." model="..."/>`.
+- Avoid hidden dependencies on parent `ViewData` unless nearby partials use the same convention.
+
+## Vue-In-Razor Templates
+Use for in-page Vue component templates embedded in `.cshtml`.
+
+Follow existing patterns:
+- Use `<script type="text/html" id="...">` for template markup.
+- Use `<script type="application/json" data-grand-vm="inDomComponents">` for component registration.
+- Escape Razor/Vue collisions correctly, including `@@click` when Razor would parse `@click`.
+- Preserve Vue props, component names, and model shape.
+- Keep generated bundle requirements in sync with `src/Web/Grand.Web/vueapp`.
+
+## PDF Templates
+Use for PDF views under:
+- `src/Web/Grand.Web/Views/PdfTemplates`
+
+Follow existing PDF patterns:
+- Keep markup simple and deterministic.
+- Avoid interactive JavaScript.
+- Use inline or existing PDF-compatible styling.
+- Preserve order, shipment, address, tax, and currency formatting.
+
+## DotLiquid Message Templates
+Use for email and notification templates stored as `MessageTemplate` data.
+
+Relevant files:
+- `src/Modules/Grand.Module.Installer/Services/InstallDataMessageTemplates.cs`
+- `src/Business/Grand.Business.Messages/Services/MessageTemplateNames.cs`
+- `src/Business/Grand.Business.Messages/Services/MessageTokenProvider.cs`
+- `src/Business/Grand.Business.Core/Utilities/Messages/DotLiquidDrops`
+
+Follow existing message patterns:
+- Use names like `OrderPlaced.CustomerNotification` or `Service.ContactUs`.
+- Use `{{Token.Property}}` for values.
+- Use `{% if ... %}` and `{% for ... %}` for conditions and loops.
+- Use only tokens exposed by `Liquid*` drop classes.
+- Add a constant in `MessageTemplateNames` when sending code refers to the template.
+- Add seed data in installer when a template must exist on new installations.
+- Preserve `IsActive`, `EmailAccountId`, store limitations, and localized template behavior.
+- Avoid including sensitive data that the recipient should not receive.
+
+## Frontend Source Templates
+Use for Vue and theme asset source under:
+- `src/Web/Grand.Web/vueapp`
+- `src/Web/Grand.Web/wwwroot/theme/css`
+
+Follow existing frontend patterns:
+- Run `npm run build` from `src/Web/Grand.Web/vueapp` when source changes require regenerated committed bundles.
+- Commit regenerated files under `src/Web/Grand.Web/wwwroot/bundles` when required by the build output.
+- Run `npm run lint` when JavaScript or Vue source changes are significant.
+


### PR DESCRIPTION
## Add AI agent skill library (skills)

Adds a structured set of skill documents under skills that provide domain-specific guidance to AI coding agents working in this repository. Each skill is a focused reference that an agent reads before generating or reviewing code in the corresponding area.

### Structure

```
skills/
  reviews/          architecture, security, dotnet, database, mongodb
  plugins/          plugin-module, shipping, payment, widget, discount-rules
  best-practices/   async, mongodb, performance, security, architecture, tests, dotnet
  settings-and-localization/
  message-notification/
  scheduled-task/
  permission-navigation/
  frontend-bundle-workflow/
  admin-area-changes/
  project-structure/
  template-creation/
```

### What each group covers

**`reviews/`** — checklists for code review across architecture, security, C#/.NET, database, and MongoDB layers.

**`plugins/`** — implementation contracts for each provider type: `IShippingRateCalculationProvider`, `IPaymentProvider`, `IWidgetProvider`, `IDiscountProvider`, and the general plugin module scaffold.

**`best-practices/`** — "how to write" guides grounded in actual codebase patterns:
- `async` — `async Task`, `CancellationToken`, `Task.WhenAll`, no `.Result`/`.Wait()`
- `mongodb` — `IRepository<T>` usage, partial updates, `PagedList`
- `performance` — `ICacheBase`, `CacheKey` constants, `IHttpClientFactory`, pagination
- `security` — permission checks, FluentValidation, guard clauses, output encoding
- `architecture` — DI lifetimes, MediatR commands/queries, domain events
- `tests` — MSTest + Moq, Arrange/Act/Assert, validator and controller test setup
- `dotnet` — C# idioms: records, result objects, `using` declarations, nullable types

**Feature-specific skills** cover settings/localization (`ISettingService`, `ITranslationService`), message notifications (DotLiquid, `IMessageProviderService`), scheduled tasks (`IScheduleTask`, keyed DI), permission/navigation (`StandardPermission`, `AdminSiteMap`), and the Vue/Vite frontend build workflow.

AGENTS.md is updated with routing entries for all new skills.

Created 1 todo