### PR TITLE
fix(plugins): validate antiforgery token on admin POST actions

### DIFF
--- a/src/Plugins/Authentication.Facebook/Areas/Admin/Controllers/FacebookAuthenticationSettingsController.cs
+++ b/src/Plugins/Authentication.Facebook/Areas/Admin/Controllers/FacebookAuthenticationSettingsController.cs
@@ -61,6 +61,7 @@ public class FacebookAuthenticationSettingsController : BasePluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         if (!await _permissionService.Authorize(StandardPermission.ManageExternalAuthenticationMethods))

--- a/src/Plugins/Authentication.Google/Areas/Admin/Controllers/GoogleAuthenticationSettingsController.cs
+++ b/src/Plugins/Authentication.Google/Areas/Admin/Controllers/GoogleAuthenticationSettingsController.cs
@@ -58,6 +58,7 @@ public class GoogleAuthenticationSettingsController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         if (!await _permissionService.Authorize(StandardPermission.ManageExternalAuthenticationMethods))

--- a/src/Plugins/Payments.BrainTree/Areas/Admin/Controllers/PaymentBrainTreeController.cs
+++ b/src/Plugins/Payments.BrainTree/Areas/Admin/Controllers/PaymentBrainTreeController.cs
@@ -54,6 +54,7 @@ public class PaymentBrainTreeController : BasePaymentController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         if (!ModelState.IsValid)

--- a/src/Plugins/Payments.CashOnDelivery/Areas/Admin/Controllers/PaymentCashOnDeliveryController.cs
+++ b/src/Plugins/Payments.CashOnDelivery/Areas/Admin/Controllers/PaymentCashOnDeliveryController.cs
@@ -51,6 +51,7 @@ public class PaymentCashOnDeliveryController : BasePaymentController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         if (!ModelState.IsValid)

--- a/src/Plugins/Payments.StripeCheckout/Areas/Admin/Controllers/StripeCheckoutController.cs
+++ b/src/Plugins/Payments.StripeCheckout/Areas/Admin/Controllers/StripeCheckoutController.cs
@@ -55,6 +55,7 @@ public class StripeCheckoutController : BasePaymentController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         if (!await _permissionService.Authorize(StandardPermission.ManagePaymentMethods))

--- a/src/Plugins/Shipping.FixedRateShipping/Areas/Admin/Controllers/ShippingFixedRateController.cs
+++ b/src/Plugins/Shipping.FixedRateShipping/Areas/Admin/Controllers/ShippingFixedRateController.cs
@@ -34,6 +34,7 @@ public class ShippingFixedRateController : BaseShippingController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(DataSourceRequest command)
     {
         if (!await _permissionService.Authorize(StandardPermission.ManageShippingSettings))

--- a/src/Plugins/Shipping.ShippingPoint/Areas/Admin/Controllers/ShippingPointController.cs
+++ b/src/Plugins/Shipping.ShippingPoint/Areas/Admin/Controllers/ShippingPointController.cs
@@ -42,6 +42,7 @@ public class ShippingPointController : BaseShippingController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> List(DataSourceRequest command)
     {
         var shippingPoints = await _shippingPointService.GetAllStoreShippingPoint("",
@@ -90,6 +91,7 @@ public class ShippingPointController : BaseShippingController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Create(ShippingPointModel model)
     {
         if (ModelState.IsValid)
@@ -115,6 +117,7 @@ public class ShippingPointController : BaseShippingController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Edit(ShippingPointModel model)
     {
         if (ModelState.IsValid)
@@ -133,6 +136,7 @@ public class ShippingPointController : BaseShippingController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Delete(string id)
     {
         var model = await _shippingPointService.GetStoreShippingPointById(id);

--- a/src/Plugins/Tax.FixedRate/Areas/Admin/Controllers/TaxFixedRateController.cs
+++ b/src/Plugins/Tax.FixedRate/Areas/Admin/Controllers/TaxFixedRateController.cs
@@ -28,6 +28,7 @@ public class TaxFixedRateController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(DataSourceRequest command)
     {
         var taxRateModels = new List<FixedTaxRateModel>();
@@ -46,6 +47,7 @@ public class TaxFixedRateController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> TaxRateUpdate(FixedTaxRateModel model)
     {
         var taxCategoryId = model.TaxCategoryId;

--- a/src/Plugins/Widgets.FacebookPixel/Areas/Admin/Controllers/WidgetsFacebookPixelController.cs
+++ b/src/Plugins/Widgets.FacebookPixel/Areas/Admin/Controllers/WidgetsFacebookPixelController.cs
@@ -48,6 +48,7 @@ public class WidgetsFacebookPixelController : BaseAdminPluginController
 
     [HttpPost]
     [AuthorizeAdmin]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         //load settings for a chosen store scope

--- a/src/Plugins/Widgets.GoogleAnalytics/Areas/Admin/Controllers/WidgetsGoogleAnalyticsController.cs
+++ b/src/Plugins/Widgets.GoogleAnalytics/Areas/Admin/Controllers/WidgetsGoogleAnalyticsController.cs
@@ -48,6 +48,7 @@ public class WidgetsGoogleAnalyticsController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Configure(ConfigurationModel model)
     {
         //load settings for a chosen store scope

--- a/src/Plugins/Widgets.Slider/Areas/Admin/Controllers/WidgetsSliderController.cs
+++ b/src/Plugins/Widgets.Slider/Areas/Admin/Controllers/WidgetsSliderController.cs
@@ -54,6 +54,7 @@ public class WidgetsSliderController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public IActionResult Configure(ConfigurationModel model)
     {
         _sliderWidgetSettings.DisplayOrder = model.DisplayOrder;
@@ -65,6 +66,7 @@ public class WidgetsSliderController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> List(DataSourceRequest command)
     {
         var sliders = await _sliderService.GetPictureSliders();
@@ -95,6 +97,7 @@ public class WidgetsSliderController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     [ArgumentNameFilter(KeyName = "save-continue", Argument = "continueEditing")]
     public async Task<IActionResult> Create(SlideModel model, bool continueEditing)
     {
@@ -133,6 +136,7 @@ public class WidgetsSliderController : BaseAdminPluginController
     }
 
     [HttpPost]
+    [AutoValidateAntiforgeryToken]
     [ArgumentNameFilter(KeyName = "save-continue", Argument = "continueEditing")]
     public async Task<IActionResult> Edit(SlideModel model, bool continueEditing)
     {
@@ -154,6 +158,8 @@ public class WidgetsSliderController : BaseAdminPluginController
         return View(model);
     }
 
+    [HttpPost]
+    [AutoValidateAntiforgeryToken]
     public async Task<IActionResult> Delete(string id)
     {
         var pictureSlider = await _sliderService.GetById(id);

--- a/src/Plugins/Widgets.Slider/Areas/Admin/Views/WidgetsSlider/Configure.cshtml
+++ b/src/Plugins/Widgets.Slider/Areas/Admin/Views/WidgetsSlider/Configure.cshtml
@@ -39,12 +39,14 @@
                     read: {
                         url: "@Html.Raw(Url.Action("List", "WidgetsSlider"))",
                         type: "POST",
-                        dataType: "json"
+                        dataType: "json",
+                        data: addAntiForgeryToken
                     },
                     destroy: {
                         url: "@Html.Raw(Url.Action("Delete", "WidgetsSlider"))",
                         type: "POST",
                         dataType: "json",
+                        data: addAntiForgeryToken
                     }
                 },
                 schema: {

--- a/src/Plugins/Widgets.Slider/Areas/Admin/Views/WidgetsSlider/_Settings.cshtml
+++ b/src/Plugins/Widgets.Slider/Areas/Admin/Views/WidgetsSlider/_Settings.cshtml
@@ -4,6 +4,7 @@
 @inject SliderWidgetSettings setting
 
 <form method="post" id="widget-settings-form">
+    @Html.AntiForgeryToken()
     <div class="panel-group">
         <div class="panel panel-default">
             <div class="panel-body">
@@ -37,7 +38,6 @@
                         $('#savegeneralsettings').click(function () {
 
                             var postData = $(this.form).serialize();
-                            addAntiForgeryToken(postData);
 
                             $.ajax({
                                 cache: false,


### PR DESCRIPTION
## Problem

Plugin admin controllers derive from `BasePluginController` / `BaseAdminPluginController`. Neither carries `[AutoValidateAntiforgeryToken]`, unlike `BaseAdminController:13`, `BaseStoreController:8` and `BaseVendorController:8`, which apply it at class level.

Their POST endpoints therefore accepted cross-site form submissions while the browser was authenticated by the admin cookie. CodeQL has been reporting these as `cs/web/missing-token-validation` (21 open alerts on `develop`); they are genuine, not false positives.

## Change

`[AutoValidateAntiforgeryToken]` added per action, matching the existing convention in `Shipping.ByWeight` and `Tax.CountryStateZip` (attribute on the action, not the base class).

Covered: Widgets.Slider, Widgets.GoogleAnalytics, Widgets.FacebookPixel, Tax.FixedRate, Shipping.ShippingPoint, Shipping.FixedRateShipping, Payments.StripeCheckout (admin), Payments.CashOnDelivery, Payments.BrainTree, Authentication.Google, Authentication.Facebook.

## View audit

`_AdminLayout.cshtml:48` renders `@Html.AntiForgeryToken()` globally and `admin.common.js:105` provides `addAntiForgeryToken(data)` for Kendo grids. Every affected view was checked against that:

- Tax.FixedRate, Shipping.FixedRateShipping, Shipping.ShippingPoint — already send `data: addAntiForgeryToken`.
- The seven `Configure` screens — use `<form asp-action>`, so the tag helper injects the token.
- **Widgets.Slider — did not.** Two real defects fixed:
  1. `Configure.cshtml` grid `read`/`destroy` sent no token at all.
  2. `_Settings.cshtml` called `addAntiForgeryToken(postData)` on the *string* returned by `serialize()`. Assigning a property to a string primitive is a no-op and the return value was discarded, so the token was never sent. The form now renders its own `@Html.AntiForgeryToken()` and `serialize()` picks it up; the dead call is removed.

## Also in scope

`WidgetsSliderController.Delete` performed a delete over GET. CodeQL does not flag it (the rule only inspects POST/PUT/DELETE). The grid already calls it with `type: "POST"`, so it is now `[HttpPost]` only.

## Deliberately untouched

- `Payments.StripeCheckout/Controllers/PaymentStripeCheckoutController.cs:42` — storefront callback from Stripe; antiforgery would break it.
- `Grand.Module.Installer/Controllers/InstallController.cs:203`
- `Grand.Web.AdminShared/Controllers/BaseLoginController.cs:142`

The 36 `Grand.Module.Api` alerts for the same rule are false positives (JWT bearer via `BaseApiController:10`, no ambient cookie credentials) and are being dismissed separately.

## Validation

All 11 plugin projects built individually — `Build succeeded`, no new warnings.

Not exercised in a browser. Worth clicking through before merge, especially Widgets.Slider (grid + settings save) and Shipping.ShippingPoint (Create/Edit popups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)