### PR TITLE
Fix database version stamp running before its own migrations

### DIFF
--- a/src/Core/Grand.Infrastructure/Migrations/IMigrationVersionStamp.cs
+++ b/src/Core/Grand.Infrastructure/Migrations/IMigrationVersionStamp.cs
@@ -1,0 +1,12 @@
+namespace Grand.Infrastructure.Migrations;
+
+/// <summary>
+///     Marks the migration that records a database version as reached.
+/// </summary>
+/// <remarks>
+///     A version stamp must be the last migration to run for its <see cref="IBaseMigration.Version" />, and it must only
+///     run when every other migration of that version succeeded. <see cref="MigrationManager.GetCurrentMigrations" />
+///     filters by version, so a version recorded before its own migrations completed makes them unreachable forever —
+///     they compare equal to the installed version and are never selected again.
+/// </remarks>
+public interface IMigrationVersionStamp : IMigration;

--- a/src/Core/Grand.Infrastructure/Migrations/MigrationManager.cs
+++ b/src/Core/Grand.Infrastructure/Migrations/MigrationManager.cs
@@ -33,7 +33,10 @@ public class MigrationManager
     {
         return GetAllMigrations()
             .Where(x => x.Version.CompareTo(installedVersion) > 0)
-            .OrderBy(mg => mg.Version.ToString())
+            //DbVersion, not its string form - "2.10" sorts before "2.2" as text
+            .OrderBy(mg => mg.Version)
+            //the version stamp closes its version, whatever priority it declares
+            .ThenBy(mg => mg is IMigrationVersionStamp ? 1 : 0)
             .ThenBy(mg => mg.Priority)
             .ToList();
     }

--- a/src/Modules/Grand.Module.Migration/Migrations/1.1/MigrationUpgradeDbVersion_11.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/1.1/MigrationUpgradeDbVersion_11.cs
@@ -1,35 +1,10 @@
-﻿using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._1._1;
 
-public class MigrationUpgradeDbVersion_11 : IMigration
+public class MigrationUpgradeDbVersion_11 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(1, 1);
 
-    public DbVersion Version => new(1, 1);
-
-    public Guid Identity => new("6BDB7093-4C31-4D78-9604-58188DF728D3");
-
-    public string Name => "Upgrade version of the database to 1.1";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("6BDB7093-4C31-4D78-9604-58188DF728D3");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/2.0/MigrationUpgradeDbVersion_20.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.0/MigrationUpgradeDbVersion_20.cs
@@ -1,35 +1,10 @@
-﻿using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._2._0;
 
-public class MigrationUpgradeDbVersion_20 : IMigration
+public class MigrationUpgradeDbVersion_20 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(2, 0);
 
-    public DbVersion Version => new(2, 0);
-
-    public Guid Identity => new("AEC3CF1F-4443-474A-B932-4F91D08C8F61");
-
-    public string Name => "Upgrade version of the database to 2.0";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("AEC3CF1F-4443-474A-B932-4F91D08C8F61");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/2.1/MigrationUpgradeDbVersion_21.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.1/MigrationUpgradeDbVersion_21.cs
@@ -1,35 +1,10 @@
-﻿using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._2._1;
 
-public class MigrationUpgradeDbVersion_21 : IMigration
+public class MigrationUpgradeDbVersion_21 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(2, 1);
 
-    public DbVersion Version => new(2, 1);
-
-    public Guid Identity => new("EA674DAA-66B2-4F21-9C68-008ACE752FBD");
-
-    public string Name => "Upgrade version of the database to 2.1";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("EA674DAA-66B2-4F21-9C68-008ACE752FBD");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/2.2/MigrationUpgradeDbVersion_22.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.2/MigrationUpgradeDbVersion_22.cs
@@ -1,35 +1,10 @@
-﻿using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._2._2;
 
-public class MigrationUpgradeDbVersion_22 : IMigration
+public class MigrationUpgradeDbVersion_22 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(2, 2);
 
-    public DbVersion Version => new(2, 2);
-
-    public Guid Identity => new("9B9FD138-7E67-44AA-913B-273F3D5B5DE9");
-
-    public string Name => "Upgrade version of the database to 2.2";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("9B9FD138-7E67-44AA-913B-273F3D5B5DE9");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/2.3/MigrationUpgradeDbVersion_23.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.3/MigrationUpgradeDbVersion_23.cs
@@ -1,36 +1,10 @@
-﻿using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._2._3;
 
-public class MigrationUpgradeDbVersion_23 : IMigration
+public class MigrationUpgradeDbVersion_23 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(2, 3);
 
-    public DbVersion Version => new(2, 3);
-
-    public Guid Identity => new("689E5BFA-7229-41A5-AF48-07CB58C0D608");
-
-    public string Name => "Upgrade version of the database to 2.3";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.InstalledVersion = $"{GrandVersion.SupportedDBVersion}";
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("689E5BFA-7229-41A5-AF48-07CB58C0D608");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/2.4/MigrationUpgradeDbVersion_24.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.4/MigrationUpgradeDbVersion_24.cs
@@ -1,35 +1,10 @@
-using Grand.Data;
-using Grand.Domain.Common;
-using Grand.Infrastructure;
 using Grand.Infrastructure.Migrations;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Grand.Module.Migration.Migrations._2._4;
 
-public class MigrationUpgradeDbVersion_24 : IMigration
+public class MigrationUpgradeDbVersion_24 : MigrationUpgradeDbVersionBase
 {
-    public int Priority => 0;
+    public override DbVersion Version => new(2, 4);
 
-    public DbVersion Version => new(2, 4);
-
-    public Guid Identity => new("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
-
-    public string Name => "Upgrade version of the database to 2.4";
-
-    /// <summary>
-    ///     Upgrade process
-    /// </summary>
-    /// <param name="serviceProvider"></param>
-    /// <returns></returns>
-    public bool UpgradeProcess(IServiceProvider serviceProvider)
-    {
-        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
-
-        var dbversion = repository.Table.FirstOrDefault();
-        dbversion!.InstalledVersion = $"{GrandVersion.SupportedDBVersion}";
-        dbversion!.DataBaseVersion = $"{GrandVersion.SupportedDBVersion}";
-        repository.Update(dbversion);
-
-        return true;
-    }
+    public override Guid Identity => new("A1B2C3D4-E5F6-7890-ABCD-EF1234567890");
 }

--- a/src/Modules/Grand.Module.Migration/Migrations/MigrationProcess.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/MigrationProcess.cs
@@ -57,14 +57,45 @@ public class MigrationProcess : IMigrationProcess
     {
         var migrationsDb = GetMigrationDb();
         var version = _repositoryVersion.Table.FirstOrDefault();
-        if(version == null)
+        if (version == null)
             return;
-        var majorVersion = string.IsNullOrEmpty(version?.InstalledVersion) ? int.Parse(version?.DataBaseVersion.Split('.')[0]!) : int.Parse(version?.InstalledVersion.Split('.')[0]!);
-        var minorVersion = string.IsNullOrEmpty(version?.InstalledVersion) ? int.Parse(version?.DataBaseVersion.Split('.')[1]!) : int.Parse(version?.InstalledVersion.Split('.')[1]!);
+
+        var installedVersion = ParseDbVersion(string.IsNullOrEmpty(version.InstalledVersion)
+            ? version.DataBaseVersion
+            : version.InstalledVersion);
+
+        if (installedVersion == null)
+        {
+            _logger.LogError("Cannot read the installed database version - migration process skipped");
+            return;
+        }
+
         var migrationManager = new MigrationManager();
-        foreach (var item in migrationManager.GetCurrentMigrations(new DbVersion(majorVersion, minorVersion)))
-            if (migrationsDb.FirstOrDefault(x => x.Identity == item.Identity) == null)
-                RunProcess(item);
+        foreach (var item in migrationManager.GetCurrentMigrations(installedVersion))
+        {
+            if (migrationsDb.Any(x => x.Identity == item.Identity))
+                continue;
+
+            if (RunProcess(item).Success) continue;
+
+            //stop before the version stamp of this version runs - recording a version whose
+            //migrations did not all succeed puts them below the installed version, and
+            //GetCurrentMigrations never selects them again
+            _logger.LogError("Migration process stopped at {MigrationName} ({Version}) - it will be retried on the next start",
+                item.Name, item.Version);
+            return;
+        }
+    }
+
+    private static DbVersion? ParseDbVersion(string? version)
+    {
+        var parts = version?.Split('.');
+        if (parts is not { Length: >= 2 })
+            return null;
+
+        return int.TryParse(parts[0], out var major) && int.TryParse(parts[1], out var minor)
+            ? new DbVersion(major, minor)
+            : null;
     }
 
     private MigrationResult RunProcessInternal(IMigration migration)

--- a/src/Modules/Grand.Module.Migration/Migrations/MigrationUpgradeDbVersionBase.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/MigrationUpgradeDbVersionBase.cs
@@ -1,0 +1,45 @@
+using Grand.Data;
+using Grand.Domain.Common;
+using Grand.Infrastructure.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Grand.Module.Migration.Migrations;
+
+/// <summary>
+///     Records <see cref="Version" /> as the version the database has reached.
+/// </summary>
+/// <remarks>
+///     Runs last within its version - see <see cref="IMigrationVersionStamp" />.
+/// </remarks>
+public abstract class MigrationUpgradeDbVersionBase : IMigrationVersionStamp
+{
+    public int Priority => 0;
+
+    public abstract DbVersion Version { get; }
+
+    public abstract Guid Identity { get; }
+
+    public string Name => $"Upgrade version of the database to {Version}";
+
+    /// <summary>
+    ///     Upgrade process
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <returns></returns>
+    public bool UpgradeProcess(IServiceProvider serviceProvider)
+    {
+        var repository = serviceProvider.GetRequiredService<IRepository<GrandNodeVersion>>();
+
+        var dbversion = repository.Table.FirstOrDefault();
+        if (dbversion == null)
+            return false;
+
+        //stamp the version this migration closes, not the version the build supports - stamping
+        //the latest supported version here makes every migration in between unreachable
+        dbversion.InstalledVersion = Version.ToString();
+        dbversion.DataBaseVersion = Version.ToString();
+        repository.Update(dbversion);
+
+        return true;
+    }
+}

--- a/src/Tests/Grand.Modules.Tests/Services/Migrations/MigrationManagerTests.cs
+++ b/src/Tests/Grand.Modules.Tests/Services/Migrations/MigrationManagerTests.cs
@@ -1,16 +1,37 @@
-﻿using Grand.Infrastructure.Migrations;
+using Grand.Data;
+using Grand.Domain.Common;
+using Grand.Infrastructure.Migrations;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Grand.Modules.Tests.Services.Migrations;
 
 [TestClass]
 public class MigrationManagerTests
 {
+    /// <summary>
+    ///     MigrationManager scans loaded assemblies, and a project reference alone does not load one.
+    ///     Holding the assembly in a field keeps it loaded before the first scan.
+    /// </summary>
+    private static readonly System.Reflection.Assembly MigrationsAssembly =
+        typeof(Grand.Module.Migration.Migrations.MigrationUpgradeDbVersionBase).Assembly;
+
     private MigrationManager _migrationManager;
+
+    /// <summary>
+    ///     Every migration that ships, from the oldest supported database version upwards.
+    /// </summary>
+    private IList<IMigration> AllShippedMigrations =>
+        _migrationManager.GetCurrentMigrations(new DbVersion(1, 0))
+            //test fixtures in this assembly also implement IMigration - keep them out
+            .Where(x => x.GetType().Assembly == MigrationsAssembly)
+            .ToList();
 
     [TestInitialize]
     public void Init()
     {
+        Assert.IsNotNull(MigrationsAssembly);
         _migrationManager = new MigrationManager();
     }
 
@@ -19,5 +40,67 @@ public class MigrationManagerTests
     {
         var migrations = _migrationManager.GetCurrentMigrations(new DbVersion(2, 2));
         Assert.IsNotEmpty(migrations);
+    }
+
+    [TestMethod]
+    public void GetCurrentMigrations_OrderedByAscendingVersion()
+    {
+        var migrations = AllShippedMigrations;
+
+        for (var i = 1; i < migrations.Count; i++)
+            Assert.IsTrue(migrations[i].Version.CompareTo(migrations[i - 1].Version) >= 0,
+                $"{migrations[i].Name} ({migrations[i].Version}) runs after {migrations[i - 1].Name} ({migrations[i - 1].Version})");
+    }
+
+    [TestMethod]
+    public void GetCurrentMigrations_VersionStampIsLastWithinItsVersion()
+    {
+        var migrations = AllShippedMigrations;
+
+        foreach (var group in migrations.GroupBy(x => x.Version.ToString()))
+        {
+            var stamp = group.OfType<IMigrationVersionStamp>().SingleOrDefault();
+            if (stamp == null) continue;
+
+            Assert.AreSame(stamp, group.Last(),
+                $"The version stamp for {group.Key} must run last, otherwise the remaining migrations of that version are skipped permanently");
+        }
+    }
+
+    [TestMethod]
+    public void AllMigrations_HaveUniqueIdentity()
+    {
+        var duplicates = AllShippedMigrations
+            .GroupBy(x => x.Identity)
+            .Where(x => x.Count() > 1)
+            .Select(x => x.Key)
+            .ToList();
+
+        Assert.IsEmpty(duplicates, $"Duplicated migration identity: {string.Join(", ", duplicates)}");
+    }
+
+    [TestMethod]
+    public void VersionStamp_RecordsItsOwnVersion()
+    {
+        var stamps = AllShippedMigrations.OfType<IMigrationVersionStamp>().ToList();
+        Assert.IsNotEmpty(stamps);
+
+        foreach (var stamp in stamps)
+        {
+            var dbVersion = new GrandNodeVersion { DataBaseVersion = "1.0", InstalledVersion = "1.0" };
+
+            var repository = new Mock<IRepository<GrandNodeVersion>>();
+            repository.Setup(x => x.Table).Returns(new List<GrandNodeVersion> { dbVersion }.AsQueryable());
+
+            var services = new ServiceCollection();
+            services.AddSingleton(repository.Object);
+
+            Assert.IsTrue(stamp.UpgradeProcess(services.BuildServiceProvider()), $"{stamp.Name} failed");
+
+            Assert.AreEqual(stamp.Version.ToString(), dbVersion.DataBaseVersion,
+                $"{stamp.Name} must record its own version, not the version the build supports");
+            Assert.AreEqual(stamp.Version.ToString(), dbVersion.InstalledVersion,
+                $"{stamp.Name} must record its own version in InstalledVersion too - the migration process reads it first");
+        }
     }
 }


### PR DESCRIPTION
Type: **bugfix**

## Issue

No issue was open for this; it came out of an audit of the migration runner.

`MigrationManager.GetCurrentMigrations` selects migrations with
`Version.CompareTo(installedVersion) > 0`. A version recorded in `GrandNodeVersion` before that
version's own migrations have run therefore puts them *at* the installed version, and they are
never selected again. The `MigrationDb.Identity` bookkeeping does not rescue this, because the
version filter is applied first.

Three defects combined to make that happen:

1. **Every `MigrationUpgradeDbVersion_XX` recorded `GrandVersion.SupportedDBVersion`, not its own
   version.** Upgrading a 1.0 installation stamped `2.4` as soon as `MigrationUpgradeDbVersion_11`
   ran.
2. **The stamp had no guaranteed position within its version.** All six stamps declare
   `Priority => 0`; in 1.1, 2.0, 2.1 and 2.2 the data migrations declare `0` as well, so the order
   came down to assembly scan order. In 2.4 the stamp (`Priority => 0`) was guaranteed to run
   *before* `MigrationUpdateAdminSiteMap` (1) and `MigrationUpdateStandardPermissionNames` (2).
3. **1.1 through 2.2 set only `DataBaseVersion`**, while `RunMigrationProcess` reads
   `InstalledVersion` first when it is non-empty.

Separately, `MigrationProcess` logged a failed migration and carried on to the next one — including
the version stamp — and `version.DataBaseVersion.Split('.')[1]` threw on a version string without a
second segment.

**Reproduction:** take an installation on 1.0, start the app, and kill the process after
`MigrationUpgradeDbVersion_11` commits. `GrandNodeVersion` now reads `2.4`. On the next start no
migration from 1.1 through 2.4 is selected, so permissions, sitemap entries and resource strings
from those versions are missing permanently.

## Solution

- `IMigrationVersionStamp` — a marker interface. `MigrationManager` orders migrations carrying it
  last within their version, whatever `Priority` they declare, so the ordering guarantee no longer
  depends on hand-assigned integers staying consistent across six folders.
- Ordering now sorts on `DbVersion` (which already implements `IComparable<DbVersion>`) instead of
  `Version.ToString()`. The string form sorts `"2.10"` before `"2.2"`.
- `MigrationUpgradeDbVersionBase` records the migration's **own** `Version`, in both
  `InstalledVersion` and `DataBaseVersion`. The six stamp classes are reduced to `Version` and
  `Identity`. **All `Identity` GUIDs are unchanged** — they are persisted identities, and altering
  one would re-run the migration on every existing installation.
- `RunMigrationProcess` stops at the first failed migration rather than continuing to the stamp, so
  a version is only recorded once everything below it succeeded and the run is retried on the next
  start. Version parsing no longer throws on a malformed version string.
- Five regression tests in `Grand.Modules.Tests`.

Note for reviewers: `MigrationManager` scans *loaded* assemblies, and a project reference alone does
not load one. The existing `GetCurrentMigrations_Exists` test was therefore asserting against a
local test fixture rather than the shipped migrations. The new tests hold the migration assembly in
a static field so the scan sees it.

## Breaking changes

None to any public contract. `IMigrationVersionStamp` is additive, and no `Identity`, migration
`Name`, or `Version` changed.

Two intentional behaviour changes:

- Each version stamp now records its own version instead of the latest supported one. On a run that
  completes, the end state is identical to before (the last stamp still writes the current version);
  it differs only when a run is interrupted, which is the point of the fix.
- A failed migration now aborts the run instead of letting later migrations proceed on top of it.

This does not retroactively repair an installation already left with a version it never truly
reached; such an installation still needs its `GrandNodeVersion` corrected by hand.

## Testing

1. `dotnet build ./GrandNode.sln` — succeeds.
2. `dotnet test ./src/Tests/Grand.Modules.Tests/Grand.Modules.Tests.csproj` — 22/22 pass.
3. `dotnet test ./src/Tests/Grand.Infrastructure.Tests/Grand.Infrastructure.Tests.csproj` — 84/84 pass.
4. To confirm the tests actually guard the defect, temporarily change
   `MigrationUpgradeDbVersionBase.UpgradeProcess` back to writing
   `GrandVersion.SupportedDBVersion` and re-run step 2. `VersionStamp_RecordsItsOwnVersion` fails
   with `expected: "1.1", actual: "2.4"`. Revert.
5. Upgrade path on a real database: restore a dump from an older version (or set
   `GrandNodeVersion.InstalledVersion` and `DataBaseVersion` to `2.3`), start the app, and confirm
   the `MigrationDb` collection gains one row per 2.4 migration and `GrandNodeVersion` ends at
   `2.4`.
6. Interruption path: with the database at `2.3`, put a breakpoint or a thrown exception in
   `MigrationUpdateStandardPermissionNames`, start the app, and confirm `GrandNodeVersion` still
   reads `2.3` — before this change it would already read `2.4` and the remaining 2.4 migrations
   would never run again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
