### PR TITLE
Fix blocking S3 calls, unawaited cache notifications and startup provider

### DIFF
--- a/src/Business/Grand.Business.Storage/Services/AmazonPictureService.cs
+++ b/src/Business/Grand.Business.Storage/Services/AmazonPictureService.cs
@@ -185,9 +185,9 @@ public class AmazonPictureService : PictureService
     /// </summary>
     /// <param name="thumbFileName">Thumb file name</param>
     /// <param name="binary">Picture binary</param>
-    protected override Task SaveThumb(string thumbFileName, byte[] binary)
+    protected override async Task SaveThumb(string thumbFileName, byte[] binary)
     {
-        CheckBucketExists().Wait();
+        await CheckBucketExists();
 
         using (Stream stream = new MemoryStream(binary))
         {
@@ -197,11 +197,10 @@ public class AmazonPictureService : PictureService
                 Key = thumbFileName,
                 StorageClass = S3StorageClass.Standard
             };
-            _s3Client.PutObjectAsync(putObjectRequest).Wait();
+            await _s3Client.PutObjectAsync(putObjectRequest);
         }
 
-        _s3Client.MakeObjectPublicAsync(_bucketName, thumbFileName, true).Wait();
-        return Task.CompletedTask;
+        await _s3Client.MakeObjectPublicAsync(_bucketName, thumbFileName, true);
     }
 
     /// <summary>

--- a/src/Core/Grand.Infrastructure/Caching/MemoryCacheBase.cs
+++ b/src/Core/Grand.Infrastructure/Caching/MemoryCacheBase.cs
@@ -110,25 +110,21 @@ public class MemoryCacheBase : ICacheBase
         }
     }
 
-    public virtual Task RemoveAsync(string key, bool publisher = true)
+    public virtual async Task RemoveAsync(string key, bool publisher = true)
     {
         _cache.Remove(key);
 
         if (publisher)
-            _mediator.Publish(new EntityCacheEvent(key, CacheEvent.RemoveKey));
-
-        return Task.CompletedTask;
+            await _mediator.Publish(new EntityCacheEvent(key, CacheEvent.RemoveKey));
     }
 
-    public virtual Task RemoveByPrefix(string prefix, bool publisher = true)
+    public virtual async Task RemoveByPrefix(string prefix, bool publisher = true)
     {
         var entriesToRemove = CacheEntries.Where(x => x.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
         foreach (var cacheEntries in entriesToRemove) _cache.Remove(cacheEntries.Key);
 
         if (publisher)
-            _mediator.Publish(new EntityCacheEvent(prefix, CacheEvent.RemovePrefix));
-
-        return Task.CompletedTask;
+            await _mediator.Publish(new EntityCacheEvent(prefix, CacheEvent.RemovePrefix));
     }
 
     public virtual Task Clear(bool publisher = true)
@@ -137,12 +133,11 @@ public class MemoryCacheBase : ICacheBase
         foreach (var cacheEntry in CacheEntries.Keys.ToList())
             _cache.Remove(cacheEntry);
 
-        //cancel
-        _resetCacheToken.Cancel();
-        //dispose
-        _resetCacheToken.Dispose();
-
-        _resetCacheToken = new CancellationTokenSource();
+        //swap first, so a concurrent Clear cannot cancel or dispose a token another
+        //thread has already handed to GetMemoryCacheEntryOptions
+        var previousToken = Interlocked.Exchange(ref _resetCacheToken, new CancellationTokenSource());
+        previousToken.Cancel();
+        previousToken.Dispose();
 
         return Task.CompletedTask;
     }

--- a/src/Core/Grand.Infrastructure/Caching/MemoryCacheBase.cs
+++ b/src/Core/Grand.Infrastructure/Caching/MemoryCacheBase.cs
@@ -133,11 +133,13 @@ public class MemoryCacheBase : ICacheBase
         foreach (var cacheEntry in CacheEntries.Keys.ToList())
             _cache.Remove(cacheEntry);
 
-        //swap first, so a concurrent Clear cannot cancel or dispose a token another
-        //thread has already handed to GetMemoryCacheEntryOptions
-        var previousToken = Interlocked.Exchange(ref _resetCacheToken, new CancellationTokenSource());
-        previousToken.Cancel();
-        previousToken.Dispose();
+        //cancel, but do not dispose: a writer that already read this source is still handing it to
+        //MemoryCache, which registers an eviction callback on it while storing the entry, and that
+        //registration throws ObjectDisposedException on a disposed source. Cancelling releases the
+        //registrations, and the source has no timer and no WaitHandle, so it is simply collected
+        _resetCacheToken.Cancel();
+
+        _resetCacheToken = new CancellationTokenSource();
 
         return Task.CompletedTask;
     }

--- a/src/Core/Grand.Infrastructure/StartupBase.cs
+++ b/src/Core/Grand.Infrastructure/StartupBase.cs
@@ -231,7 +231,8 @@ public static class StartupBase
     /// </summary>
     /// <param name="services">Collection of service descriptors</param>
     /// <param name="configuration">Configuration root of the application</param>
-    public static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    public static void ConfigureServices(IServiceCollection services, IConfiguration configuration,
+        IWebHostEnvironment hostingEnvironment)
     {
         services.AddFeatureManagement();
 
@@ -239,26 +240,21 @@ public static class StartupBase
         var typeSearcher = new TypeSearcher();
         services.AddSingleton<ITypeSearcher>(typeSearcher);
 
-        var provider = services.BuildServiceProvider();
-        var hostingEnvironment = provider.GetRequiredService<IWebHostEnvironment>();
-
         //register application
         var mvcBuilder = RegisterApplication(services, configuration, hostingEnvironment, typeSearcher);
 
-        //register extensions 
+        //register extensions
         RegisterExtensions(mvcBuilder, configuration, hostingEnvironment);
 
-        var startupConfigurations = typeSearcher.ClassesOfType<IStartupApplication>();
-
-        //Register startup
-        var instancesBefore = startupConfigurations
+        //instantiate once - the same instances serve both configuration passes
+        var startupInstances = typeSearcher.ClassesOfType<IStartupApplication>()
             .Where(PluginExtensions.OnlyInstalledPlugins)
             .Select(startup => (IStartupApplication)Activator.CreateInstance(startup))
-            .Where(startup => startup!.BeforeConfigure)
-            .OrderBy(startup => startup.Priority);
+            .OrderBy(startup => startup!.Priority)
+            .ToList();
 
         //configure services
-        foreach (var instance in instancesBefore)
+        foreach (var instance in startupInstances.Where(startup => startup.BeforeConfigure))
             instance.ConfigureServices(services, configuration);
 
         //register mapper configurations
@@ -273,15 +269,8 @@ public static class StartupBase
         //add mediator
         AddMediator(services, typeSearcher);
 
-        //Register startup
-        var instancesAfter = startupConfigurations
-            .Where(PluginExtensions.OnlyInstalledPlugins)
-            .Select(startup => (IStartupApplication)Activator.CreateInstance(startup))
-            .Where(startup => !startup!.BeforeConfigure)
-            .OrderBy(startup => startup.Priority);
-
         //configure services
-        foreach (var instance in instancesAfter)
+        foreach (var instance in startupInstances.Where(startup => !startup.BeforeConfigure))
             instance.ConfigureServices(services, configuration);
 
         //Execute startup interface

--- a/src/Modules/Grand.Module.Migration/Startup/StartupApplication.cs
+++ b/src/Modules/Grand.Module.Migration/Startup/StartupApplication.cs
@@ -22,11 +22,15 @@ public class StartupApplication : IStartupApplication
         if (!DataSettingsManager.DatabaseIsInstalled())
             return;
         var featureManager = application.Services.GetRequiredService<IFeatureManager>();
-        if (featureManager.IsEnabledAsync("Grand.Module.Migration").Result)
-        {
-            var migrationProcess = application.Services.GetRequiredService<IMigrationProcess>();
-            migrationProcess.RunMigrationProcess();
-        }
+        //Configure is synchronous, so the startup path has to block here
+        if (!featureManager.IsEnabledAsync("Grand.Module.Migration").GetAwaiter().GetResult())
+            return;
+
+        //IMigrationProcess is scoped - resolving it from the root provider fails scope validation
+        //and otherwise roots the repository graph for the lifetime of the process
+        using var scope = application.Services.CreateScope();
+        var migrationProcess = scope.ServiceProvider.GetRequiredService<IMigrationProcess>();
+        migrationProcess.RunMigrationProcess();
     }
 
     public int Priority => 100;

--- a/src/Tests/Grand.Infrastructure.Tests/Caching/MemoryCacheBaseTests.cs
+++ b/src/Tests/Grand.Infrastructure.Tests/Caching/MemoryCacheBaseTests.cs
@@ -161,4 +161,45 @@ public class MemoryCacheBaseTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => _service.RemoveByPrefix("key"));
     }
+
+    /// <summary>
+    ///     Guards against disposing the reset token in <see cref="MemoryCacheBase.Clear" />.
+    /// </summary>
+    /// <remarks>
+    ///     A writer reads the token source, then MemoryCache registers an eviction callback on it while
+    ///     storing the entry. Disposing the previous source in Clear makes that registration throw
+    ///     ObjectDisposedException, and swapping the field first only narrows the window rather than
+    ///     closing it. The assertion only fires on an exception actually raised by the race, so this
+    ///     cannot fail spuriously - it can only miss.
+    /// </remarks>
+    [TestMethod]
+    [Timeout(60000)]
+    [DoNotParallelize]
+    public void Clear_WhileEntriesAreBeingWritten_DoesNotThrow()
+    {
+        Exception captured = null;
+        var stopWriting = false;
+
+        var writer = Task.Run(async () =>
+        {
+            var i = 0;
+            while (!stopWriting)
+                try
+                {
+                    await _service.SetAsync($"race-{i++}", () => Task.FromResult("value"));
+                }
+                catch (Exception ex)
+                {
+                    captured ??= ex;
+                    return;
+                }
+        });
+
+        for (var i = 0; i < 5000 && captured == null; i++) _service.Clear(false).GetAwaiter().GetResult();
+
+        stopWriting = true;
+        writer.Wait(TimeSpan.FromSeconds(5));
+
+        Assert.IsNull(captured, $"Clear raced a concurrent write: {captured}");
+    }
 }

--- a/src/Tests/Grand.Infrastructure.Tests/Caching/MemoryCacheBaseTests.cs
+++ b/src/Tests/Grand.Infrastructure.Tests/Caching/MemoryCacheBaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using Grand.Infrastructure.Caching;
 using Grand.Infrastructure.Configuration;
+using Grand.Infrastructure.Events;
 using Grand.Mediator;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,5 +139,26 @@ public class MemoryCacheBaseTests
         var cacheResult = _memoryCache.Get(key);
         Assert.IsNotNull(cacheResult);
         Assert.AreEqual(cacheEntry, cacheResult);
+    }
+
+    [TestMethod]
+    public async Task RemoveAsync_AwaitsTheNotification()
+    {
+        _mediatorMock
+            .Setup(x => x.Publish(It.IsAny<EntityCacheEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("handler failed"));
+
+        //a fire-and-forget Publish would swallow this
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.RemoveAsync("key"));
+    }
+
+    [TestMethod]
+    public async Task RemoveByPrefix_AwaitsTheNotification()
+    {
+        _mediatorMock
+            .Setup(x => x.Publish(It.IsAny<EntityCacheEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("handler failed"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.RemoveByPrefix("key"));
     }
 }

--- a/src/Web/Grand.Web.Admin/Program.cs
+++ b/src/Web/Grand.Web.Admin/Program.cs
@@ -15,7 +15,7 @@ builder.Host.UseDefaultServiceProvider((_, options) =>
 });
 
 //add services
-StartupBase.ConfigureServices(builder.Services, builder.Configuration);
+StartupBase.ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
 
 builder.ConfigureApplicationSettings();
 

--- a/src/Web/Grand.Web.Store/Program.cs
+++ b/src/Web/Grand.Web.Store/Program.cs
@@ -15,7 +15,7 @@ builder.Host.UseDefaultServiceProvider((_, options) =>
 });
 
 //add services
-StartupBase.ConfigureServices(builder.Services, builder.Configuration);
+StartupBase.ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
 
 builder.ConfigureApplicationSettings();
 

--- a/src/Web/Grand.Web.Vendor/Program.cs
+++ b/src/Web/Grand.Web.Vendor/Program.cs
@@ -15,7 +15,7 @@ builder.Host.UseDefaultServiceProvider((_, options) =>
 });
 
 //add services
-StartupBase.ConfigureServices(builder.Services, builder.Configuration);
+StartupBase.ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
 
 builder.ConfigureApplicationSettings();
 

--- a/src/Web/Grand.Web/Program.cs
+++ b/src/Web/Grand.Web/Program.cs
@@ -16,7 +16,7 @@ builder.Host.UseDefaultServiceProvider((_, options) =>
 });
 
 //add services
-StartupBase.ConfigureServices(builder.Services, builder.Configuration);
+StartupBase.ConfigureServices(builder.Services, builder.Configuration, builder.Environment);
 
 builder.ConfigureApplicationSettings();
 


### PR DESCRIPTION
Type: **bugfix**

## Issue

No issues were open for these; they came out of an audit of async and startup code. Three
independent defects, one commit each (plus a follow-up correcting one of them — see below).

**1. `AmazonPictureService.SaveThumb` blocked three times on S3 I/O.**
`CheckBucketExists().Wait()`, `PutObjectAsync(...).Wait()` and `MakeObjectPublicAsync(...).Wait()`,
all from the thread serving the request. Thumbnail generation runs on catalogue and product pages,
so on an S3-backed installation these tie up thread pool threads for the length of a round trip.
This is the case `.ai/constraints.md` prohibits — blocking in service code, not in a startup path.

**2. `MemoryCacheBase` mishandled cache invalidation in two ways.**

`RemoveAsync` and `RemoveByPrefix` called `_mediator.Publish` without awaiting it and returned
`Task.CompletedTask`. A failing handler surfaced as an unobserved task exception on the finalizer
thread; a slow one raced the caller, so an invalidation could still be in flight when the next read
hit the cache. These were the only two unawaited `Publish` calls in the solution.

`Clear()` **disposed** `_resetCacheToken`. A writer reads the token source, and `MemoryCache` then
registers an eviction callback on it while storing the entry — that registration throws
`ObjectDisposedException` on a disposed source.

Reproduced with a stress test: `Clear` running against concurrent `SetAsync` throws
`ObjectDisposedException` within roughly 120ms.

**3. `StartupBase.ConfigureServices` built a throwaway service provider.**
`services.BuildServiceProvider()` (ASP0000) purely to resolve `IWebHostEnvironment` — a second,
never-disposed container with its own singleton graph. The same method also instantiated every
`IStartupApplication` twice, once per configuration pass. Separately,
`Grand.Module.Migration.Startup.StartupApplication` resolved the scoped `IMigrationProcess` from the
root provider.

## Solution

- `SaveThumb` is now `async Task` and awaits the three S3 calls. The base
  `PictureService.SaveThumb` already returns `Task` and every caller awaits it, so nothing else
  changes.
- `RemoveAsync` and `RemoveByPrefix` await the notification.
- `Clear()` cancels the token but no longer disposes it. The source is left to the garbage
  collector: `Cancel` releases the registrations, and it has no timer and no `WaitHandle`, so
  nothing needs releasing eagerly. Against `develop` this is a single removed line.
- `ConfigureServices` takes `IWebHostEnvironment`; all four hosts already have `builder.Environment`.
  Startup types are instantiated once and the list filtered per pass.
- The migration startup runs in its own scope. Its feature flag check still blocks, because
  `Configure` is synchronous, but `GetAwaiter().GetResult()` rethrows the original exception instead
  of wrapping it in an `AggregateException`.
- Three regression tests in `Grand.Infrastructure.Tests`.

**A correction worth reading before reviewing commit by commit.** The first attempt at the `Clear()`
race swapped the token with `Interlocked.Exchange` before cancelling and disposing, and the commit
message claimed that closed the window. It does not: a thread that read the field before the swap
still holds the source being disposed, so the stress test throws on that version exactly as it does
on `develop`. The follow-up commit removes the `Dispose` call, which is the actual fix, and drops
the `Exchange` as well — with `Dispose` gone it only guarded against two concurrent `Clear` calls
orphaning a token, which is a different and much milder problem, out of scope here.

Deliberately left alone, with reasons:

- `MemoryCacheBase.Get<T>` uses `semaphore.Wait()`. That blocks on a semaphore, not on a `Task`, and
  the method is a synchronous `ICacheBase` member — removing it means changing the interface.
- `MigrationProductRating` uses `GetAwaiter().GetResult()` and `IStartupApplication.Configure`
  blocks. Both are startup paths with synchronous contracts, which `.ai/constraints.md` explicitly
  does not treat as precedent.
- `AzurePictureService.SaveThumb` calls synchronous Azure SDK methods. That is a different problem
  from blocking on a `Task` and would widen this change.

## Breaking changes

**One.** `StartupBase.ConfigureServices` gains a third parameter:

```csharp
ConfigureServices(IServiceCollection services, IConfiguration configuration)
ConfigureServices(IServiceCollection services, IConfiguration configuration, IWebHostEnvironment hostingEnvironment)
```

All four in-repo hosts are updated. A custom host with its own `Program.cs` must pass
`builder.Environment`. It is a compile error, not a silent change. An overload was considered, but
keeping the old one means keeping the `BuildServiceProvider` call it exists to remove.

`ICacheBase` is unchanged — `RemoveAsync` and `RemoveByPrefix` already returned `Task`, and
`RedisMessageCacheManager` overrides both with matching signatures.

## Testing

1. `dotnet build ./GrandNode.sln` — succeeds.
2. `dotnet test ./src/Tests/Grand.Infrastructure.Tests/Grand.Infrastructure.Tests.csproj` — 87/87 pass.
3. `dotnet test ./src/Tests/Grand.Modules.Tests/Grand.Modules.Tests.csproj` — 18/18 pass.
4. `dotnet test ./src/Tests/Grand.Business.Storage.Tests/Grand.Business.Storage.Tests.csproj` — 51 pass, 2 pre-existing skips.
5. To confirm the notification tests guard the defect, temporarily restore the fire-and-forget body
   of `MemoryCacheBase.RemoveAsync` and re-run step 2. `RemoveAsync_AwaitsTheNotification` fails
   while `RemoveByPrefix_AwaitsTheNotification` still passes. Revert.
6. To confirm the race test guards the defect, temporarily add `_resetCacheToken.Dispose();` back
   into `Clear()` and re-run step 2. `Clear_WhileEntriesAreBeingWritten_DoesNotThrow` fails with
   `ObjectDisposedException: The CancellationTokenSource has been disposed.` Revert.
   The test only asserts on an exception the race actually raised, so it cannot fail spuriously — it
   can only miss.
7. Start each of the four hosts and confirm they boot and serve a page — this change touches every
   `Program.cs` and the shared composition root.
8. On an installation upgrading from an older database version, confirm migrations still run at
   startup; the migration process now executes inside its own DI scope.
9. S3 path, if you have a bucket configured: set the Amazon storage provider, upload a product
   picture and load the product page so a thumbnail is generated. It should be created and served
   as before.

Steps 7 to 9 have not been run here — they need running hosts, an upgradable database and an S3
bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
