### PR TITLE
Run the whole test suite on pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,9 @@
 * text=auto
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 
+# Shell scripts run on the Linux CI runners - CRLF makes the shebang unusable
+*.sh text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Runs every test project under src/Tests, one project at a time.
+#
+# Discovering the projects instead of listing them keeps CI honest: a new test project
+# is picked up automatically rather than silently never running.
+#
+# Running them one at a time is deliberate. The suites share process-wide static state
+# (DataSettingsManager.Instance, PluginPaths.Instance, AutoMapperConfig), so a single
+# whole-solution `dotnet test` makes Customers, Marketing and Messages fail depending on
+# the order they happen to execute in. Until that state is removed, per-project runs are
+# what gives a trustworthy signal.
+#
+# Usage: run-tests.sh [configuration] [extra dotnet test args...]
+#   run-tests.sh Release
+#   run-tests.sh Debug --collect:"XPlat Code Coverage"
+#
+# Every project is run even if an earlier one fails, so a single CI run reports all of
+# the broken suites rather than only the first.
+
+set -uo pipefail
+
+configuration="${1:-Release}"
+[ $# -gt 0 ] && shift
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+mapfile -t projects < <(find src/Tests -name '*.csproj' | sort)
+
+if [ ${#projects[@]} -eq 0 ]; then
+    echo "No test projects found under src/Tests" >&2
+    exit 1
+fi
+
+echo "Running ${#projects[@]} test projects in $configuration"
+
+failed=()
+
+for project in "${projects[@]}"; do
+    name="$(basename "$project" .csproj)"
+    echo "::group::$name"
+    if ! dotnet test "$project" --configuration "$configuration" --no-build --nologo "$@"; then
+        failed+=("$name")
+    fi
+    echo "::endgroup::"
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    printf 'FAILED: %s\n' "${failed[@]}" >&2
+    echo "::error::Failing test projects: ${failed[*]}"
+    exit 1
+fi
+
+echo "All ${#projects[@]} test projects passed."

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -1,12 +1,16 @@
 name: ASP.NET Core CI
 
-on: [push]
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    branches: [ develop, main ]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core
@@ -14,46 +18,19 @@ jobs:
       with:
         dotnet-version: 10.0.x
     - name: Install .NET Aspire workload
-      run: dotnet workload install aspire        
+      run: dotnet workload install aspire
     - name: Restore
       run: dotnet restore ./GrandNode.sln
     - name: Build with dotnet
       run: dotnet build ./GrandNode.sln --configuration Release
     - name: Start Docker for Mongodb
       run: docker run -d -p 27017:27017 mongo
-    - name: Grand.Business.Authentication Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Authentication.Tests/Grand.Business.Authentication.Tests.csproj
-    - name: Grand.Business.Catalog Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Catalog.Tests/Grand.Business.Catalog.Tests.csproj
-    - name: Grand.Business.Checkout Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Checkout.Tests/Grand.Business.Checkout.Tests.csproj
-    - name: Grand.Business.Cms Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Cms.Tests/Grand.Business.Cms.Tests.csproj
-    - name: Grand.Business.Common Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Common.Tests/Grand.Business.Common.Tests.csproj
-    - name: Grand.Business.Customers Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Customers.Tests/Grand.Business.Customers.Tests.csproj
-    - name: Grand.Business.Marketing Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Marketing.Tests/Grand.Business.Marketing.Tests.csproj
-    - name: Grand.Business.Messages Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Messages.Tests/Grand.Business.Messages.Tests.csproj
-    - name: Grand.Business.Storage Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Storage.Tests/Grand.Business.Storage.Tests.csproj
-    - name: Grand.Business.System Unit Tests
-      run: dotnet test ./src/Tests/Grand.Modules.Tests/Grand.Modules.Tests.csproj
-    - name: Grand.Business.Data Unit Tests
-      run: dotnet test ./src/Tests/Grand.Data.Tests/Grand.Data.Tests.csproj
-    - name: Grand.Domain.Domain.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Domain.Tests/Grand.Domain.Tests.csproj
-    - name: Grand.Infrastructure.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Infrastructure.Tests/Grand.Infrastructure.Tests.csproj
-    - name: Grand.SharedKernel.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.SharedKernel.Tests/Grand.SharedKernel.Tests.csproj
-    - name: Grand.Mapping.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Mapping.Tests/Grand.Mapping.Tests.csproj
-    - name: Grand.Web.Common.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Web.Common.Tests/Grand.Web.Common.Tests.csproj
-    - name: Grand.Web.Admin.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Web.Admin.Tests/Grand.Web.Admin.Tests.csproj
-    - name: Grand.Web.Store.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Web.Store.Tests/Grand.Web.Store.Tests.csproj
+    - name: Wait for MongoDB to be ready
+      run: |
+        for i in {1..30}; do
+          nc -z localhost 27017 && echo "MongoDB is up" && exit 0
+          sleep 2
+        done
+        echo "MongoDB did not become ready" && exit 1
+    - name: Unit tests
+      run: ./.github/scripts/run-tests.sh Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,5 +50,5 @@ jobs:
         run: |
           ./.sonar/scanner/dotnet-sonarscanner begin /k:"grandnode_grandnode2" /o:"grandnode" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
           dotnet build ./GrandNode.sln
-          dotnet test ./GrandNode.sln --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          ./.github/scripts/run-tests.sh Debug --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/grandnode.yml
+++ b/.github/workflows/grandnode.yml
@@ -2,13 +2,13 @@ name: Build and deploy .NET Core app to Linux WebApp grandnode
 on:
   push:
     branches: [ "develop" ]
-  
+
 env:
   AZURE_WEBAPP_NAME: grandnode-dev
   AZURE_WEBAPP_PACKAGE_PATH: src/Web/Grand.Web/publish
   AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
   CONFIGURATION: Release
-  WORKING_DIRECTORY: src/Web/Grand.Web  
+  WORKING_DIRECTORY: src/Web/Grand.Web
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -18,48 +18,25 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
-    - name: Create mongoDB Docker container      
+    - name: Create mongoDB Docker container
       run: sudo docker run -d -p 27017:27017 mongo:latest
+    - name: Wait for MongoDB to be ready
+      run: |
+        for i in {1..30}; do
+          nc -z localhost 27017 && echo "MongoDB is up" && exit 0
+          sleep 2
+        done
+        echo "MongoDB did not become ready" && exit 1
     - name: Install .NET Aspire workload
-      run: dotnet workload install aspire        
+      run: dotnet workload install aspire
     - name: Restore
       run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
     - name: Build sln
       run: dotnet build "GrandNode.sln"
+    - name: Unit tests
+      run: ./.github/scripts/run-tests.sh Debug
     - name: Build
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore -p:SourceRevisionId=${{ github.sha }} -p:GitBranch=${{ github.ref_name }}
-    - name: Grand.Business.Authentication Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Authentication.Tests/Grand.Business.Authentication.Tests.csproj
-    - name: Grand.Business.Catalog Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Catalog.Tests/Grand.Business.Catalog.Tests.csproj
-    - name: Grand.Business.Checkout Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Checkout.Tests/Grand.Business.Checkout.Tests.csproj
-    - name: Grand.Business.Cms Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Cms.Tests/Grand.Business.Cms.Tests.csproj
-    - name: Grand.Business.Common Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Common.Tests/Grand.Business.Common.Tests.csproj
-    - name: Grand.Business.Customers Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Customers.Tests/Grand.Business.Customers.Tests.csproj
-    - name: Grand.Business.Marketing Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Marketing.Tests/Grand.Business.Marketing.Tests.csproj
-    - name: Grand.Business.Messages Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Messages.Tests/Grand.Business.Messages.Tests.csproj
-    - name: Grand.Business.Storage Unit Tests
-      run: dotnet test ./src/Tests/Grand.Business.Storage.Tests/Grand.Business.Storage.Tests.csproj
-    - name: Grand.Business.System Unit Tests
-      run: dotnet test ./src/Tests/Grand.Modules.Tests/Grand.Modules.Tests.csproj
-    - name: Grand.Business.Data Unit Tests
-      run: dotnet test ./src/Tests/Grand.Data.Tests/Grand.Data.Tests.csproj
-    - name: Grand.Domain.Domain.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Domain.Tests/Grand.Domain.Tests.csproj
-    - name: Grand.Infrastructure.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Infrastructure.Tests/Grand.Infrastructure.Tests.csproj
-    - name: Grand.SharedKernel.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.SharedKernel.Tests/Grand.SharedKernel.Tests.csproj
-    - name: Grand.Web.Common.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Web.Common.Tests/Grand.Web.Common.Tests.csproj
-    - name: Grand.Web.Admin.Tests Unit Tests
-      run: dotnet test ./src/Tests/Grand.Web.Admin.Tests/Grand.Web.Admin.Tests.csproj
     - name: Publish
       run: dotnet publish "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-build --output "${{ env.AZURE_WEBAPP_PACKAGE_PATH }}" -p:SourceRevisionId=${{ github.sha }} -p:GitBranch=${{ github.ref_name }}
     - name: Deploy to Azure WebApp


### PR DESCRIPTION
Type: **bugfix**

## Issue

No issue was open; this came out of an audit of CI.

**Pull requests were not running the test workflow.** `aspnetcore.yml` was declared `on: [push]`
with no `pull_request` trigger, so the 18 test steps it defines never ran for a PR. The only test
execution a PR actually got was inside `build.yml` (SonarQube), and that used:

```
dotnet test ./GrandNode.sln --no-build --collect:"XPlat Code Coverage" ...
```

A single whole-solution run executes the assemblies in parallel, which is the mode where
`Grand.Business.Customers`, `Grand.Business.Marketing` and `Grand.Business.Messages` fail depending
on the order they happen to run in — the suites share process-wide static state through
`DataSettingsManager.Instance`, `PluginPaths.Instance` and `AutoMapperConfig`. So the one signal a
PR did get was the unreliable one.

**The project list was hand-maintained in two workflows and had already drifted.** Against the 21
projects under `src/Tests`:

- `aspnetcore.yml` was missing `Grand.Mediator.Tests`, `Grand.Module.Api.Tests` and `Grand.Web.Tests`
- `grandnode.yml` was missing those three plus `Grand.Mapping.Tests` and `Grand.Web.Store.Tests`

`Grand.Web.Tests` and `Grand.Mediator.Tests` have never run in CI. Adding a test project did not
make it execute anywhere.

## Solution

`.github/scripts/run-tests.sh` discovers every `*.csproj` under `src/Tests` and runs them one
project at a time:

- **Discovered, not listed** — a new test project runs automatically, so the drift cannot come back.
- **Sequential** — this is what the 18 hand-written steps were really doing. Keeping it explicit,
  with the reason in a comment, means nobody "optimises" it back into one parallel run. The proper
  fix is removing the static state; until then this is what gives a trustworthy signal.
- **Does not stop at the first failure** — one CI run reports every failing project.

All three workflows call it. `aspnetcore.yml` gains a `pull_request` trigger, and its `push` trigger
is narrowed from every branch to `develop` and `main` so a branch with an open PR is not built
twice. Both Mongo-dependent workflows now wait for the container to accept connections instead of
racing it.

`*.sh text eol=lf` is added to `.gitattributes` — a shell script checked out with CRLF makes the
shebang unusable on the Linux runners.

## Breaking changes

None to the product. One CI behaviour change worth stating: pushing a feature branch no longer
triggers `aspnetcore.yml` on its own; the branch is verified through its pull request. This is what
removes the duplicate run.

## Testing

Run from the repository root.

1. `dotnet build ./GrandNode.sln` then `./.github/scripts/run-tests.sh Debug` — all 21 projects run
   sequentially and pass. Verified locally: 1759 tests, 5 pre-existing skips, no failures.
2. Confirm every project is picked up: the script prints `Running 21 test projects in Debug` and
   ends with `All 21 test projects passed.` Compare against
   `find src/Tests -name '*.csproj' | wc -l`.
3. Confirm the failure path collects rather than aborts:
   `./.github/scripts/run-tests.sh NoSuchConfig`. Verified locally — exit code 1, all 21 projects
   attempted, and a single `::error::Failing test projects:` line naming all of them.
4. Confirm this PR itself triggers `ASP.NET Core CI`. Before this change it would not have, which
   is the whole point — the check appearing on this PR is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
