### PR TITLE
Fix the dead plugin version gate and stop leaking host assemblies into plugin folders

### DIFF
--- a/.ai/prompts/create-plugin.md
+++ b/.ai/prompts/create-plugin.md
@@ -41,7 +41,7 @@ Scaffold a new installable GrandNode plugin end to end, with the correct project
 
 1. `SystemName` in `Manifest.cs` must equal the value in `{Feature}Defaults` and the output folder name.
 2. `Group` must be one of the existing group names in `.ai/knowledge/plugin-types.md`.
-3. All GrandNode project references must be `Private="false"`.
+3. Import `src/Build/Grand.Plugin.props` for the shared host references; do not repeat them in the plugin. Anything referenced beyond that set must be `Private="false"`.
 4. Use `Microsoft.NET.Sdk.Razor` when the plugin contains `.cshtml` files, `Microsoft.NET.Sdk` otherwise.
 5. `Install()` saves default settings and adds localization resources, then calls `base.Install()` last.
 6. `Uninstall()` deletes settings and removes localization resources, then calls `base.Uninstall()` last.

--- a/.ai/standards/dependencies.md
+++ b/.ai/standards/dependencies.md
@@ -50,7 +50,8 @@ Do not override `TargetFramework` or `LangVersion` in an individual project.
 
 ## Project references
 
-- Reference GrandNode projects with `<Private>false</Private>` in plugins and modules — the host already loads those assemblies.
+- Plugins import `src/Build/Grand.Plugin.props`, which carries the host projects every plugin compiles against, each already `Private="false"`. Do not restate that list in a plugin — a new core project goes in the props file, so it reaches all plugins at once.
+- Reference GrandNode projects with `<Private>false</Private>` in modules, and in a plugin for anything beyond the shared set — the host already loads those assemblies. `Private="false"` does not carry to a reference's own dependencies, so each project has to be named.
 - Use `<ExcludeAssets>all</ExcludeAssets>` (plugins referencing `Grand.Web` / `Grand.Web.Common`) or `<ExcludeAssets>runtime</ExcludeAssets>` (modules) following the nearest existing project of the same kind.
 - Never reference a plugin from core, business, or web projects. Dependencies point inward only.
 

--- a/.ai/templates/plugin/base-plugin.md
+++ b/.ai/templates/plugin/base-plugin.md
@@ -13,6 +13,7 @@ Placeholders: `{SystemName}` = `{Group}.{Name}`, `{Feature}` = type-name prefix.
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -29,31 +30,6 @@ Placeholders: `{SystemName}` = `{Group}.{Name}`, `{Feature}` = type-name prefix.
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Update="logo.jpg">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
@@ -61,7 +37,11 @@ Placeholders: `{SystemName}` = `{Group}.{Name}`, `{Feature}` = type-name prefix.
 </Project>
 ```
 
-Use `Microsoft.NET.Sdk` and drop the Razor properties when the plugin ships no `.cshtml`. Trim project references down to what the plugin actually uses.
+Use `Microsoft.NET.Sdk` and drop the Razor properties when the plugin ships no `.cshtml`.
+
+`Grand.Plugin.props` brings in the host projects every plugin compiles against — `Grand.SharedKernel`, `Grand.Domain`, `Grand.Data`, `Grand.Mapping`, `Grand.Mediator`, `Grand.Infrastructure`, `Grand.Business.Core` and `Grand.Web.Common` — each with `Private=false` so nothing is copied into the plugin folder. Do not restate them in the plugin: they were duplicated across all 16 plugins until `Grand.Mediator` was added to the solution, added to none of them, and copied into every plugin's output. Add a new core project to `src/Build/Grand.Plugin.props`, not here.
+
+The unused references cost nothing at runtime, so there is no need to trim the list. A plugin needing something beyond that set — a NuGet package, or `Grand.Web` as `Theme.Modern` does — declares it in its own `ItemGroup`.
 
 ## 2. `Manifest.cs`
 

--- a/src/Build/Grand.Plugin.props
+++ b/src/Build/Grand.Plugin.props
@@ -1,0 +1,35 @@
+<Project>
+
+    <!--
+        The host assemblies every plugin compiles against.
+
+        Private=false keeps them out of the plugin's output folder: the plugin is loaded
+        into the host's AssemblyLoadContext, which already has them, and a second copy of
+        a host assembly beside a plugin is a hazard - if that copy is ever the one loaded,
+        its types are not the host's types and DI resolution fails in ways that are hard
+        to trace.
+
+        Private=false does not carry to a reference's own dependencies, which is why each
+        project is listed rather than relying on the transitive graph. Keeping the list in
+        one file is the point: it used to be duplicated across every plugin, so a new core
+        project was added to some and forgotten in others - Grand.Mediator shipped that way
+        and was copied into all 16 plugin folders.
+
+        Add a new core project here, not in the individual plugins.
+
+        Paths are anchored to this file so a plugin can sit at any depth.
+    -->
+
+    <ItemGroup>
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Domain\Grand.Domain.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Data\Grand.Data.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mapping\Grand.Mapping.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mediator\Grand.Mediator.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Core\Grand.Business.Core.csproj" Private="false" />
+        <!-- ExcludeAssets=all: referenced for its views and tag helpers, nothing is linked from it -->
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Web\Grand.Web.Common\Grand.Web.Common.csproj" Private="false" ExcludeAssets="all" />
+    </ItemGroup>
+
+</Project>

--- a/src/Build/Grand.Plugin.props
+++ b/src/Build/Grand.Plugin.props
@@ -1,6 +1,21 @@
 <Project>
 
     <!--
+        A plugin is a library, and the SDK does not copy NuGet assemblies into a library's
+        output - it expects the runtime to resolve them from deps.json, which does not happen
+        for an assembly side-loaded from a plugin folder. So the plugin's own packages have to
+        be copied, and CopyLocalLockFileAssemblies does that.
+
+        On its own it would also copy the host's entire package graph - 62 assemblies for a
+        plugin that needs one. ExcludeAssets=runtime on each host reference is what prevents
+        that: the plugin still compiles against the project, but nothing from its runtime
+        closure is copied. The same pairing is what the projects in src/Modules use.
+    -->
+    <PropertyGroup>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    </PropertyGroup>
+
+    <!--
         The host assemblies every plugin compiles against.
 
         Private=false keeps them out of the plugin's output folder: the plugin is loaded
@@ -21,13 +36,13 @@
     -->
 
     <ItemGroup>
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Domain\Grand.Domain.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Data\Grand.Data.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mapping\Grand.Mapping.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mediator\Grand.Mediator.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj" Private="false" />
-        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Core\Grand.Business.Core.csproj" Private="false" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Domain\Grand.Domain.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Data\Grand.Data.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mapping\Grand.Mapping.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Mediator\Grand.Mediator.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj" Private="false" ExcludeAssets="runtime" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Core\Grand.Business.Core.csproj" Private="false" ExcludeAssets="runtime" />
         <!-- ExcludeAssets=all: referenced for its views and tag helpers, nothing is linked from it -->
         <ProjectReference Include="$(MSBuildThisFileDirectory)..\Web\Grand.Web.Common\Grand.Web.Common.csproj" Private="false" ExcludeAssets="all" />
     </ItemGroup>

--- a/src/Core/Grand.Infrastructure/Plugins/PluginInfoAttribute.cs
+++ b/src/Core/Grand.Infrastructure/Plugins/PluginInfoAttribute.cs
@@ -1,22 +1,18 @@
-﻿using System.Reflection;
-
-namespace Grand.Infrastructure.Plugins;
+﻿namespace Grand.Infrastructure.Plugins;
 
 [AttributeUsage(AttributeTargets.Assembly)]
 public class PluginInfoAttribute : Attribute
 {
-    public PluginInfoAttribute()
-    {
-        var assembly = Assembly.GetExecutingAssembly();
-        var fullVersion = assembly.GetName().Version;
-        SupportedVersion = $"{fullVersion?.Major}.{fullVersion?.Minor}";
-    }
-
     public string Group { get; set; } = string.Empty;
     public string FriendlyName { get; set; } = string.Empty;
     public string SystemName { get; set; } = string.Empty;
     public string Author { get; set; } = string.Empty;
 
+    /// <summary>
+    ///     The GrandNode version this plugin supports, as "Major.Minor". Left unset by convention -
+    ///     it is then resolved from the assembly's Grand.Infrastructure reference by
+    ///     <see cref="PluginVersionResolver" />.
+    /// </summary>
     public string SupportedVersion { get; set; }
 
     public string Version { get; set; }

--- a/src/Core/Grand.Infrastructure/Plugins/PluginManager.cs
+++ b/src/Core/Grand.Infrastructure/Plugins/PluginManager.cs
@@ -254,7 +254,7 @@ public static class PluginManager
             Group = pluginInfo.Group,
             SystemName = pluginInfo.SystemName,
             Version = pluginInfo.Version,
-            SupportedVersion = pluginInfo.SupportedVersion,
+            SupportedVersion = PluginVersionResolver.ResolveSupportedVersion(assembly, pluginInfo.SupportedVersion),
             Author = pluginInfo.Author,
             PluginFileName = plug.Name,
             OriginalAssemblyFile = pluginFile,

--- a/src/Core/Grand.Infrastructure/Plugins/PluginVersionResolver.cs
+++ b/src/Core/Grand.Infrastructure/Plugins/PluginVersionResolver.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+
+namespace Grand.Infrastructure.Plugins;
+
+/// <summary>
+///     Resolves which GrandNode version a plugin assembly was built against.
+/// </summary>
+public static class PluginVersionResolver
+{
+    private const string CoreAssemblyName = "Grand.Infrastructure";
+
+    /// <summary>
+    ///     Returns the GrandNode version the plugin supports, as "Major.Minor".
+    /// </summary>
+    /// <param name="pluginAssembly">The plugin assembly the info attribute was read from</param>
+    /// <param name="declaredVersion">The version declared on <see cref="PluginInfoAttribute" />, if any</param>
+    /// <returns>
+    ///     The declared version when the plugin states one, otherwise the version of the
+    ///     <see cref="CoreAssemblyName" /> reference it was compiled against. Null when neither is available -
+    ///     such a plugin cannot be matched against <see cref="GrandVersion.SupportedPluginVersion" /> and is
+    ///     therefore treated as incompatible.
+    /// </returns>
+    public static string ResolveSupportedVersion(Assembly pluginAssembly, string declaredVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(declaredVersion))
+            return declaredVersion.Trim();
+
+        var coreReference = pluginAssembly?.GetReferencedAssemblies()
+            .FirstOrDefault(x => string.Equals(x.Name, CoreAssemblyName, StringComparison.OrdinalIgnoreCase));
+
+        return coreReference?.Version == null
+            ? null
+            : $"{coreReference.Version.Major}.{coreReference.Version.Minor}";
+    }
+}

--- a/src/Modules/Grand.Module.Api/Grand.Module.Api.csproj
+++ b/src/Modules/Grand.Module.Api/Grand.Module.Api.csproj
@@ -16,6 +16,10 @@
 			<Private>False</Private>
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</ProjectReference>
+		<ProjectReference Include="..\..\Core\Grand.Mediator\Grand.Mediator.csproj">
+			<Private>False</Private>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</ProjectReference>
 		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
             <Private>False</Private>
 			<ExcludeAssets>runtime</ExcludeAssets>

--- a/src/Modules/Grand.Module.Installer/Grand.Module.Installer.csproj
+++ b/src/Modules/Grand.Module.Installer/Grand.Module.Installer.csproj
@@ -24,6 +24,9 @@
 		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
 			<Private>False</Private>
 		</ProjectReference>
+		<ProjectReference Include="..\..\Core\Grand.Mediator\Grand.Mediator.csproj">
+			<Private>False</Private>
+		</ProjectReference>
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Modules/Grand.Module.Migration/Grand.Module.Migration.csproj
+++ b/src/Modules/Grand.Module.Migration/Grand.Module.Migration.csproj
@@ -20,6 +20,9 @@
 		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
 			<Private>False</Private>
 		</ProjectReference>
+		<ProjectReference Include="..\..\Core\Grand.Mediator\Grand.Mediator.csproj">
+			<Private>False</Private>
+		</ProjectReference>
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Modules/Grand.Module.ScheduledTasks/Grand.Module.ScheduledTasks.csproj
+++ b/src/Modules/Grand.Module.ScheduledTasks/Grand.Module.ScheduledTasks.csproj
@@ -13,6 +13,10 @@
             <Private>False</Private>
             <ExcludeAssets>runtime</ExcludeAssets>
         </ProjectReference>
+        <ProjectReference Include="..\..\Core\Grand.Mediator\Grand.Mediator.csproj">
+            <Private>False</Private>
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </ProjectReference>
         <ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
             <Private>False</Private>
             <ExcludeAssets>runtime</ExcludeAssets>

--- a/src/Plugins/Authentication.Facebook/Authentication.Facebook.csproj
+++ b/src/Plugins/Authentication.Facebook/Authentication.Facebook.csproj
@@ -20,12 +20,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" />
   </ItemGroup>
   
-  <Target Name="CopyFile" AfterTargets="AfterBuild">
-    <ItemGroup>
-      <CopyFiles Include="$(NuGetPackageRoot)\microsoft.aspnetcore.authentication.facebook\10.0.10\lib\net10.0\*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Authentication.Facebook\" />
-  </Target>
   
   
   <ItemGroup>

--- a/src/Plugins/Authentication.Facebook/Authentication.Facebook.csproj
+++ b/src/Plugins/Authentication.Facebook/Authentication.Facebook.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <Import Project="..\..\Build\Grand.Common.props" />
+  <Import Project="..\..\Build\Grand.Plugin.props" />
   <PropertyGroup>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 	<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -26,30 +27,6 @@
     <Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Authentication.Facebook\" />
   </Target>
   
-  <ItemGroup>
-    <ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-	  <Private>false</Private>
-	</ProjectReference>
-	<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-      <Private>false</Private>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-      <Private>false</Private>
-      <ExcludeAssets>all</ExcludeAssets>
-    </ProjectReference>
-	<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-	   <Private>false</Private>
-	</ProjectReference>
-  </ItemGroup>
   
   <ItemGroup>
     <None Update="Assets\facebookstyles.css">

--- a/src/Plugins/Authentication.Google/Authentication.Google.csproj
+++ b/src/Plugins/Authentication.Google/Authentication.Google.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -25,30 +26,6 @@
 		<Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Authentication.Google\" />
 	</Target>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="Assets\googlestyles.css">

--- a/src/Plugins/Authentication.Google/Authentication.Google.csproj
+++ b/src/Plugins/Authentication.Google/Authentication.Google.csproj
@@ -19,12 +19,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
 	</ItemGroup>
 
-	<Target Name="CopyFile" AfterTargets="AfterBuild">
-		<ItemGroup>
-			<CopyFiles Include="$(NuGetPackageRoot)\microsoft.aspnetcore.authentication.google\10.0.10\lib\net10.0\*.dll" />
-		</ItemGroup>
-		<Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Authentication.Google\" />
-	</Target>
 
 
 	<ItemGroup>

--- a/src/Plugins/DiscountRules.Standard/DiscountRules.Standard.csproj
+++ b/src/Plugins/DiscountRules.Standard/DiscountRules.Standard.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-	</ItemGroup>
 	<ItemGroup>
 		<None Update="logo.jpg">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Plugins/ExchangeRate.McExchange/ExchangeRate.McExchange.csproj
+++ b/src/Plugins/ExchangeRate.McExchange/ExchangeRate.McExchange.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
 		<OutputPath>..\..\Web\Grand.Web\Plugins\ExchangeRate.McExchange\</OutputPath>
@@ -11,30 +12,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Payments.BrainTree/Payments.BrainTree.csproj
+++ b/src/Plugins/Payments.BrainTree/Payments.BrainTree.csproj
@@ -21,13 +21,6 @@
 		<PackageReference Include="System.Xml.XPath.XmlDocument" />
 	</ItemGroup>
 
-	<Target Name="CopyFile" AfterTargets="AfterBuild">
-		<ItemGroup>
-			<CopyFiles Include="$(NuGetPackageRoot)\braintree\5.39.0\lib\netstandard2.0\*.*" />
-			<CopyFiles Include="$(NuGetPackageRoot)\system.xml.xpath.xmldocument\4.7.0\lib\netstandard2.0\*.*" />
-		</ItemGroup>
-		<Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Payments.BrainTree\" />
-	</Target>
 
 
 	<ItemGroup>

--- a/src/Plugins/Payments.BrainTree/Payments.BrainTree.csproj
+++ b/src/Plugins/Payments.BrainTree/Payments.BrainTree.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -28,30 +29,6 @@
 		<Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Payments.BrainTree\" />
 	</Target>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Payments.CashOnDelivery/Payments.CashOnDelivery.csproj
+++ b/src/Plugins/Payments.CashOnDelivery/Payments.CashOnDelivery.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Payments.StripeCheckout/Payments.StripeCheckout.csproj
+++ b/src/Plugins/Payments.StripeCheckout/Payments.StripeCheckout.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
     <Import Project="..\..\Build\Grand.Common.props" />
+    <Import Project="..\..\Build\Grand.Plugin.props" />
     <PropertyGroup>
         <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -27,30 +28,6 @@
         <Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Payments.StripeCheckout\" />
     </Target>
     
-    <ItemGroup>
-        <ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-            <Private>false</Private>
-        </ProjectReference>
-        <ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-            <Private>false</Private>
-        </ProjectReference>
-        <ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-            <Private>false</Private>
-        </ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-            <Private>false</Private>
-        </ProjectReference>
-        <ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-            <Private>false</Private>
-        </ProjectReference>
-        <ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-            <Private>false</Private>
-            <ExcludeAssets>all</ExcludeAssets>
-        </ProjectReference>
-    </ItemGroup>
 
     <ItemGroup>
         <None Update="logo.jpg">

--- a/src/Plugins/Payments.StripeCheckout/Payments.StripeCheckout.csproj
+++ b/src/Plugins/Payments.StripeCheckout/Payments.StripeCheckout.csproj
@@ -20,13 +20,6 @@
 		<PackageReference Include="Stripe.net" />
     </ItemGroup>
 
-    <Target Name="CopyFile" AfterTargets="AfterBuild">
-        <ItemGroup>
-            <CopyFiles Include="$(NuGetPackageRoot)\stripe.net\51.1.0\lib\net9.0\*.*" />			
-			<CopyFiles Include="$(NuGetPackageRoot)\newtonsoft.json\13.0.3\lib\net6.0\*.dll" />
-		</ItemGroup>
-        <Copy SourceFiles="@(CopyFiles)" DestinationFolder="..\..\Web\Grand.Web\Plugins\Payments.StripeCheckout\" />
-    </Target>
     
 
     <ItemGroup>

--- a/src/Plugins/Shipping.ByWeight/Shipping.ByWeight.csproj
+++ b/src/Plugins/Shipping.ByWeight/Shipping.ByWeight.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Shipping.FixedRateShipping/Shipping.FixedRateShipping.csproj
+++ b/src/Plugins/Shipping.FixedRateShipping/Shipping.FixedRateShipping.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Shipping.ShippingPoint/Shipping.ShippingPoint.csproj
+++ b/src/Plugins/Shipping.ShippingPoint/Shipping.ShippingPoint.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Tax.CountryStateZip/Tax.CountryStateZip.csproj
+++ b/src/Plugins/Tax.CountryStateZip/Tax.CountryStateZip.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Tax.FixedRate/Tax.FixedRate.csproj
+++ b/src/Plugins/Tax.FixedRate/Tax.FixedRate.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Theme.Modern/Theme.Modern.csproj
+++ b/src/Plugins/Theme.Modern/Theme.Modern.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -16,28 +17,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
 		<ProjectReference Include="..\..\Web\Grand.Web\Grand.Web.csproj">
 			<Private>false</Private>
 			<ExcludeAssets>all</ExcludeAssets>

--- a/src/Plugins/Widgets.FacebookPixel/Widgets.FacebookPixel.csproj
+++ b/src/Plugins/Widgets.FacebookPixel/Widgets.FacebookPixel.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Widgets.GoogleAnalytics/Widgets.GoogleAnalytics.csproj
+++ b/src/Plugins/Widgets.GoogleAnalytics/Widgets.GoogleAnalytics.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 
 	<ItemGroup>
 		<None Update="logo.jpg">

--- a/src/Plugins/Widgets.Slider/Widgets.Slider.csproj
+++ b/src/Plugins/Widgets.Slider/Widgets.Slider.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Plugin.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
@@ -15,30 +16,6 @@
 		<OutDir>$(OutputPath)</OutDir>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\Core\Grand.Data\Grand.Data.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Business\Grand.Business.Core\Grand.Business.Core.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Domain\Grand.Domain.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Mapping\Grand.Mapping.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj">
-			<Private>false</Private>
-		</ProjectReference>
-		<ProjectReference Include="..\..\Web\Grand.Web.Common\Grand.Web.Common.csproj">
-			<Private>false</Private>
-			<ExcludeAssets>all</ExcludeAssets>
-		</ProjectReference>
-	</ItemGroup>
 	<ItemGroup>
 		<None Update="Assets\**\*.*">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Tests/Grand.Infrastructure.Tests/Plugins/PluginVersionResolverTests.cs
+++ b/src/Tests/Grand.Infrastructure.Tests/Plugins/PluginVersionResolverTests.cs
@@ -1,0 +1,79 @@
+using Grand.Infrastructure.Plugins;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+
+namespace Grand.Infrastructure.Tests.Plugins;
+
+[TestClass]
+public class PluginVersionResolverTests
+{
+    /// <summary>
+    ///     Stands in for a plugin assembly: it is compiled against the same Grand.Infrastructure
+    ///     as any real plugin, so its reference version is the one a plugin would carry.
+    /// </summary>
+    private static readonly Assembly PluginLikeAssembly = typeof(PluginVersionResolverTests).Assembly;
+
+    [TestMethod]
+    public void ResolveSupportedVersion_AssemblyBuiltAgainstCurrentCore_MatchesSupportedPluginVersion()
+    {
+        var result = PluginVersionResolver.ResolveSupportedVersion(PluginLikeAssembly, null);
+
+        Assert.AreEqual(GrandVersion.SupportedPluginVersion, result);
+    }
+
+    [TestMethod]
+    public void ResolveSupportedVersion_DeclaredVersion_WinsOverAssemblyReference()
+    {
+        var result = PluginVersionResolver.ResolveSupportedVersion(PluginLikeAssembly, "1.0");
+
+        Assert.AreEqual("1.0", result);
+        Assert.AreNotEqual(GrandVersion.SupportedPluginVersion, result,
+            "A plugin declaring an old version must stay distinguishable from the current one - " +
+            "this is the comparison the compatibility gate relies on.");
+    }
+
+    [TestMethod]
+    public void ResolveSupportedVersion_DeclaredVersionIsWhitespace_FallsBackToAssemblyReference()
+    {
+        var result = PluginVersionResolver.ResolveSupportedVersion(PluginLikeAssembly, "   ");
+
+        Assert.AreEqual(GrandVersion.SupportedPluginVersion, result);
+    }
+
+    [TestMethod]
+    public void ResolveSupportedVersion_DeclaredVersionIsPadded_IsTrimmed()
+    {
+        var result = PluginVersionResolver.ResolveSupportedVersion(PluginLikeAssembly, " 2.3 ");
+
+        Assert.AreEqual("2.3", result);
+    }
+
+    [TestMethod]
+    public void ResolveSupportedVersion_AssemblyWithoutCoreReference_ReturnsNull()
+    {
+        //System.Private.CoreLib does not reference Grand.Infrastructure
+        var result = PluginVersionResolver.ResolveSupportedVersion(typeof(object).Assembly, null);
+
+        Assert.IsNull(result,
+            "A plugin that cannot be tied to a core version must not be reported as compatible.");
+    }
+
+    [TestMethod]
+    public void ResolveSupportedVersion_NoAssembly_ReturnsNull()
+    {
+        var result = PluginVersionResolver.ResolveSupportedVersion(null, null);
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void PluginInfoAttribute_DoesNotSelfAssignSupportedVersion()
+    {
+        //The attribute used to compute SupportedVersion in its constructor from
+        //Assembly.GetExecutingAssembly() - always Grand.Infrastructure, never the plugin -
+        //which made every plugin compare equal to GrandVersion.SupportedPluginVersion.
+        var attribute = new PluginInfoAttribute();
+
+        Assert.IsNull(attribute.SupportedVersion);
+    }
+}


### PR DESCRIPTION
Type: **bugfix**

Three defects in how the host and its plugins relate to each other. All were invisible: one made a safety check pass unconditionally, one quietly copied a host assembly into every plugin folder, and one shipped some plugins without their own dependencies.

## Issue

### 1. The plugin compatibility gate could never reject anything

`PluginInfoAttribute` computed `SupportedVersion` in its constructor:

```csharp
var assembly = Assembly.GetExecutingAssembly();
SupportedVersion = $"{fullVersion?.Major}.{fullVersion?.Minor}";
```

`GetExecutingAssembly()` returns the assembly holding the *executing code*. That constructor is compiled into `Grand.Infrastructure`, so it returned Grand.Infrastructure's version no matter whose DLL was being inspected — even though the attribute is read off the plugin in `PluginManager.PreparePluginInfo`:

```csharp
var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(plug.FullName);
var pluginInfo = assembly.GetCustomAttribute<PluginInfoAttribute>();  // ctor runs in the host
```

`GrandVersion.SupportedPluginVersion` is derived from that same assembly, so both sides of every comparison were equal by construction. Three gates were dead code:

- `PluginManager.Load` — the `Incompatible plugin` branch
- `PluginController.Install` — "You can't install unsupported version of plugin"
- `PluginController.UploadPlugin`

A plugin built against 1.0 loaded and installed exactly like one built against 2.4, then failed later with `TypeLoadException` or `MissingMethodException` from plugin code instead of one clean log line. The admin upload screen showed the running installation's version in the "supported version" column rather than the uploaded file's.

No `Manifest.cs` sets `SupportedVersion` explicitly, so there was no way to work around it.

### 2. `Grand.Mediator.dll` was copied into all 16 plugin folders

Plugins name each core project with `Private=false`, so the host's assemblies are compiled against but not copied. `Grand.Mediator` arrived with the MediatR replacement (#753) and was added to none of the 16 lists, so it came in transitively — `Private=false` does not carry to a reference's own dependencies — and MSBuild copied it.

`Grand.Mediator.dll` and its `.pdb` sat in every plugin folder, and in all four module folders for the same reason. It was the only Grand assembly leaking; the other seven were correctly excluded.

Plugins load into the default `AssemblyLoadContext`, so a duplicate of a host assembly next to a plugin is a hazard rather than dead weight: if the plugin's copy is ever the one loaded, `IRequestHandler<T>` from it is not the same type as the host's and handler resolution fails in ways that are hard to trace.

The reference list had been duplicated 16 times, which is why one addition to the solution could be missed everywhere at once.

### 3. Plugins hand-copied their NuGet assemblies, and got it wrong

Four plugins reached into the NuGet cache with a hand-written target:

```xml
<CopyFiles Include="$(NuGetPackageRoot)\stripe.net\51.1.0\lib\net9.0\*.*" />
```

Six such lines, each pinning a package version and a target framework that `Directory.Packages.props` also controls. Bumping a package there leaves the plugin shipping the old assembly, or nothing once that cache folder no longer exists, and the build does not complain.

A hand-written list also cannot follow a dependency graph. `Payments.StripeCheckout` shipped `Stripe.net` and `Newtonsoft.Json` but not `System.Configuration.ConfigurationManager`, `System.Diagnostics.EventLog` or `System.Security.Cryptography.ProtectedData`, which `Stripe.net` needs. `Payments.BrainTree` never copied Braintree's `Newtonsoft.Json`.

The copies were needed because a plugin is a library, and the SDK does not copy NuGet assemblies into a library's output — it leaves the runtime to resolve them through `deps.json`, which does not happen for an assembly side-loaded from a plugin folder.

## Solution

**Version gate.** `SupportedVersion` becomes a plain optional property. `PluginVersionResolver` derives it from the plugin assembly's own `Grand.Infrastructure` reference when the plugin does not declare one — the compiler records that version in the plugin's metadata, so it is the honest answer to "what was this built against". A plugin that cannot be tied to a core version resolves to `null` and is treated as incompatible instead of silently accepted. No `Manifest.cs` changes; a plugin may still declare `SupportedVersion` itself.

**Reference list.** New `src/Build/Grand.Plugin.props` holds the eight shared host references once. Plugins import it next to `Grand.Common.props` and drop their own copies, so adding a core project is one edit instead of sixteen that are easy to miss. Paths use `$(MSBuildThisFileDirectory)` so a plugin can sit at any depth. `Theme.Modern` keeps its own `Grand.Web` reference — it is the only plugin with one, and referencing the host project is a separate problem. The four modules keep their individual lists but get the missing `Grand.Mediator` entry.

**Package assemblies.** The props file sets `CopyLocalLockFileAssemblies`, paired with `ExcludeAssets=runtime` on each host reference. The pairing is the point: on its own the switch copies the host's entire package graph, 62 assemblies for a plugin that needs one. This is the combination the projects in `src/Modules` already use. Each plugin now gets exactly its own closure and the four `CopyFile` targets are gone, so versions come only from `Directory.Packages.props`.

**Docs.** The base-plugin template spelled out the same reference list — and was itself already missing `Grand.Mediator` — so it would have reintroduced the duplication. Updated together with the create-plugin prompt and the dependencies standard.

## Breaking changes

Plugins compiled against an older GrandNode are now correctly reported as incompatible instead of loading. That is the gate working, but it is a visible change for anyone who was relying on the broken behaviour.

Nothing changes for the bundled plugins. All 16 built assemblies were read directly from their metadata: each carries a `Grand.Infrastructure` reference at 2.4, so each resolves to `"2.4"` and loads exactly as before. Stripe and BrainTree now ship *more* than they did, not less.

## Testing

1. `dotnet test ./src/Tests/Grand.Infrastructure.Tests/Grand.Infrastructure.Tests.csproj` — 94 pass, including 7 new `PluginVersionResolverTests`. `Grand.Module.Api.Tests` — 20 pass.
2. `PluginInfoAttribute_DoesNotSelfAssignSupportedVersion` fails on the previous code — the old constructor always assigned a value. That is the regression proof.
3. Delete every folder under `src/Web/Grand.Web/Plugins/` except `bin`, and every folder under `src/Web/Grand.Web/Modules/`, then `dotnet build ./GrandNode.sln`. Deleting first matters: `OutputPath` is a fixed folder the build never prunes, so stale copies survive an ordinary rebuild and hide the result.
4. After that rebuild, no `Grand.*.dll` in any of the 16 plugin folders or 4 module folders, and each plugin holds only its own packages:

   ```
   Authentication.Facebook  Microsoft.AspNetCore.Authentication.Facebook.dll
   Authentication.Google    Microsoft.AspNetCore.Authentication.Google.dll
   Payments.BrainTree       Braintree, Newtonsoft.Json, System.Xml.XPath.XmlDocument
   Payments.StripeCheckout  Stripe.net, Newtonsoft.Json + 3 transitive
   the other twelve         nothing but their own assembly
   ```

5. Manual: admin panel → Configuration → Plugins. Every bundled plugin still lists as compatible and installs. Exercise the paths that need the copied packages — sign in with Facebook and with Google, and run a Stripe and a BrainTree payment — since those are what a missing assembly would break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
