### PR TITLE
Remove unused Grand.Targets.props

### DIFF
--- a/src/Build/Grand.Targets.props
+++ b/src/Build/Grand.Targets.props
@@ -1,3 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-</Project>


### PR DESCRIPTION
Type: **bugfix**

## Issue
`src/Build/Grand.Targets.props` has been an empty `<Project></Project>` since 2022
and nothing imports it - no `.csproj`, `.props`, `.targets` or `.sln` in the
repository references it. It reads like shared build configuration and is not.

Found while working through the repository hygiene items in the architecture
roadmap.

## Solution
Delete the file.

`src/Build/Grand.Common.props` is untouched - that one *is* imported by projects
and holds the shared `TargetFramework`, product version and the
`SetSourceRevisionId` / `SetRepositoryBranch` targets.

## Breaking changes
None. The file is empty and has no importers.

## Testing
1. `grep -r "Grand.Targets" --include=*.csproj --include=*.props --include=*.targets --include=*.sln .`
   returns nothing.
2. `dotnet build ./GrandNode.sln` - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)