### PR TITLE
Align Aspire on 13.4.6 and net10.0

### DIFF
--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -17,8 +17,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
-    - name: Install .NET Aspire workload
-      run: dotnet workload install aspire
     - name: Restore
       run: dotnet restore ./GrandNode.sln
     - name: Build with dotnet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-      - name: Install .NET Aspire workload
-        run: dotnet workload install aspire
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/grandnode.yml
+++ b/.github/workflows/grandnode.yml
@@ -27,8 +27,6 @@ jobs:
           sleep 2
         done
         echo "MongoDB did not become ready" && exit 1
-    - name: Install .NET Aspire workload
-      run: dotnet workload install aspire
     - name: Restore
       run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
     - name: Build sln

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,11 +73,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
-    <PackageVersion Include="Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)" Version="9.0.0" />
-    <PackageVersion Include="Aspire.Hosting.Orchestration.$(NETCoreSdkRuntimeIdentifier)" Version="9.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageVersion Update="Aspire.Dashboard.Sdk.win-x64" Version="13.4.6" />
-    <PackageVersion Update="Aspire.Hosting.Orchestration.win-x64" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Orchestration.$(NETCoreSdkRuntimeIdentifier)" Version="13.4.6" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,13 +53,6 @@ steps:
   inputs:
     version: '10.0.x'
 
-- task: Bash@3
-  displayName: Install .NET Aspire workload
-  inputs:
-    targetType: 'inline'
-    script: |
-      dotnet workload install aspire
-
 # Replaced NuGet tasks with dotnet CLI commands to fix Ubuntu 24.04 compatibility
 - task: DotNetCoreCLI@2
   displayName: 'dotnet restore'

--- a/src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
+++ b/src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	<Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsAspireHost>true</IsAspireHost>

--- a/src/Aspire/Aspire.ServiceDefaults/Aspire.ServiceDefaults.csproj
+++ b/src/Aspire/Aspire.ServiceDefaults/Aspire.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsAspireSharedProject>true</IsAspireSharedProject>


### PR DESCRIPTION
Type: **bugfix**

## Issue
Aspire was pinned at three different versions at once:

| Where | Version |
|---|---|
| `Directory.Packages.props` - `Aspire.Hosting.*` | 13.4.6 |
| `Aspire.AppHost.csproj` - `Aspire.AppHost.Sdk` | 9.0.0 |
| `Directory.Packages.props` - `Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)` and `Aspire.Hosting.Orchestration.$(...)` | 9.0.0 |
| same two, `Update` for `win-x64` only | 13.4.6 |

The `win-x64` override hid the problem on Windows developer machines. Everywhere
else - including every CI runner - the dashboard and orchestration resolved 9.0.0
next to hosting at 13.4.6.

Reproduce:

```
dotnet restore src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj --force \
  -p:NETCoreSdkRuntimeIdentifier=linux-x64
```

Before this change that resolves `Aspire.Dashboard.Sdk.linux-x64/9.0.0`; after it,
`13.4.6`.

Separately, `src/Aspire/*` targeted `net9.0` while the rest of the solution is
`net10.0`, and all four web hosts reference `Aspire.ServiceDefaults`.

## Solution
- `Aspire.AppHost.Sdk` 9.0.0 -> 13.4.6.
- `Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)` and
  `Aspire.Hosting.Orchestration.$(...)` 9.0.0 -> 13.4.6.
- Dropped the `win-x64` `Update` block - it no longer differs from the generic entry.
- `Aspire.AppHost` and `Aspire.ServiceDefaults` net9.0 -> net10.0.
- Removed `dotnet workload install aspire` from all four CI definitions. Aspire has
  been SDK-based since 9.2; the solution builds with no aspire workload installed
  (`dotnet workload list` empty).

The API surface in play is small - `DistributedApplication.CreateBuilder`,
`AddMongoDB`, `AddRedis`, `WithLifetime`, `ContainerLifetime.Persistent` in a
12-line `Program.cs`, plus 95 lines of `ServiceDefaults/Extensions.cs` - and is
unchanged between 9.x and 13.x.

## Breaking changes
None to application behaviour.

Anyone building the AppHost needs the .NET 10 SDK, which the rest of the solution
already required. Non-Windows builds now get Aspire 13.4.6 components instead of
9.0.0 - that is the fix, but it is a change in what those builds produce.

## Testing
1. `dotnet restore src/Aspire/Aspire.AppHost/Aspire.AppHost.csproj --force -p:NETCoreSdkRuntimeIdentifier=linux-x64`
   then check `obj/project.assets.json` - `Aspire.Dashboard.Sdk.linux-x64/13.4.6` and
   `Aspire.Hosting.Orchestration.linux-x64/13.4.6`.
2. `dotnet build ./GrandNode.sln` - clean, 0 errors.
3. `dotnet workload list` shows no aspire workload, confirming the CI step is
   unnecessary.
4. Manual: run `Aspire.AppHost` and confirm the dashboard starts and both the
   MongoDB and Redis containers come up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)