### PR TITLE
Clean up redundant ImageSharp references, document the elFinder HTTP pin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="AWSSDK.Core" Version="4.0.100.9" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.101.5" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SkiaSharp" Version="4.150.1" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.150.1" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />

--- a/src/Business/Grand.Business.Common/Grand.Business.Common.csproj
+++ b/src/Business/Grand.Business.Common/Grand.Business.Common.csproj
@@ -2,7 +2,6 @@
   <Import Project="..\..\Build\Grand.Common.props" />
   <ItemGroup>
   	<PackageReference Include="ExcelMapper" />  	
-	<PackageReference Include="SixLabors.ImageSharp" />
 	<PackageReference Include="Scryber.Core" />
     <PackageReference Include="Scryber.Core.OpenType" />
     <PackageReference Include="System.Security.Cryptography.Xml" />   

--- a/src/Web/Grand.Web.Admin/Grand.Web.Admin.csproj
+++ b/src/Web/Grand.Web.Admin/Grand.Web.Admin.csproj
@@ -19,7 +19,6 @@
 		<PackageReference Include="elFinder.Net.AspNetCore" />
 		<PackageReference Include="elFinder.Net.Core" />
 		<PackageReference Include="elFinder.Net.Drivers.FileSystem" />		
-		<PackageReference Include="SixLabors.ImageSharp" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Aspire\Aspire.ServiceDefaults\Aspire.ServiceDefaults.csproj" />

--- a/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
+++ b/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
@@ -13,6 +13,9 @@
 		<PackageReference Include="elFinder.Net.AspNetCore" />
 		<PackageReference Include="elFinder.Net.Core" />
 		<PackageReference Include="elFinder.Net.Drivers.FileSystem" />
+		<!-- Not used in code. elFinder.Net.* 1.5.0 drags in the ASP.NET Core 2.1.x graph, and its
+		     Microsoft.AspNetCore.Http 2.1.1 has a known high severity advisory (GHSA-hxrm-9w7p-39cc).
+		     This reference lifts it to a patched 2.x. Remove only together with elFinder. -->
 		<PackageReference Include="Microsoft.AspNetCore.Http" />
 		<PackageReference Include="SixLabors.ImageSharp" />
 	</ItemGroup>

--- a/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
+++ b/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
@@ -17,6 +17,5 @@
 		     Microsoft.AspNetCore.Http 2.1.1 has a known high severity advisory (GHSA-hxrm-9w7p-39cc).
 		     This reference lifts it to a patched 2.x. Remove only together with elFinder. -->
 		<PackageReference Include="Microsoft.AspNetCore.Http" />
-		<PackageReference Include="SixLabors.ImageSharp" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Type: **bugfix**

## Issue
Two package references in the admin projects looked like leftovers. Verifying them
before removal showed they meant opposite things.

**`Microsoft.AspNetCore.Http` 2.3.11 in `Grand.Web.AdminShared`** reads as a stray
ASP.NET Core 2.x package on net10.0. It is not. `elFinder.Net.*` 1.5.0 pulls in the
whole ASP.NET Core 2.1.x graph, including `Microsoft.AspNetCore.Http` **2.1.1**,
which carries GHSA-hxrm-9w7p-39cc (high severity). The direct reference is a
deliberate lift to a patched 2.x. Removing it makes restore emit NU1903.

**`SixLabors.ImageSharp`** appeared to be a second graphics stack alongside
SkiaSharp, referenced directly by three projects. There is no `SixLabors`
identifier in any `.cs` file in the solution; the only graphics code is
`Grand.Business.Storage/Services/PictureService.cs`, which uses SkiaSharp.
`dotnet nuget why` shows ImageSharp arriving through `Scryber.Core` 9.5.0 and
`elFinder.Net.Core` 1.5.0, both already asking for 3.1.12 - so all three direct
references were pins to a version the graph produces on its own.

## Solution
- Keep the `Microsoft.AspNetCore.Http` reference, with a comment in the `.csproj`
  recording the advisory it lifts and that it should only be removed together with
  elFinder.
- Drop the three direct `SixLabors.ImageSharp` references and the now-unreferenced
  `PackageVersion` entry.

## Breaking changes
None. ImageSharp still resolves at 3.1.12 through Scryber and elFinder, so nothing
changes in the build output.

Note that ImageSharp therefore still ships in the artifacts, so the Six Labors
Split License question is unaffected by this PR - it needs one of those two
dependencies replaced, which is a separate decision.

## Testing
1. `dotnet restore ./GrandNode.sln --force` - no NU1903, no errors.
2. `dotnet list src/Web/Grand.Web.Admin package --include-transitive | grep -i sixlabors`
   still reports `SixLabors.ImageSharp 3.1.12`.
3. `dotnet build ./GrandNode.sln` - clean.
4. `dotnet test ./src/Tests/Grand.Web.Admin.Tests/Grand.Web.Admin.Tests.csproj` (51 pass)
   and `./src/Tests/Grand.Business.Common.Tests/Grand.Business.Common.Tests.csproj`
   (126 pass, 2 skipped).
5. Manual: in the admin panel open the elFinder file manager, upload an image and
   confirm the thumbnail renders; generate an order PDF to exercise Scryber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)