### PR TITLE
Run deploy pipeline tests in the configuration it actually builds

### DIFF
--- a/.github/workflows/grandnode.yml
+++ b/.github/workflows/grandnode.yml
@@ -32,9 +32,12 @@ jobs:
     - name: Restore
       run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
     - name: Build sln
-      run: dotnet build "GrandNode.sln"
+      run: dotnet build "GrandNode.sln" --configuration ${{ env.CONFIGURATION }}
     - name: Unit tests
-      run: ./.github/scripts/run-tests.sh Debug
+      # The job-level CONFIGURATION env var is picked up by MSBuild as the Configuration
+      # property, so "Build sln" above produces Release regardless of the missing
+      # --configuration flag. The tests must look in the same place.
+      run: ./.github/scripts/run-tests.sh ${{ env.CONFIGURATION }}
     - name: Build
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore -p:SourceRevisionId=${{ github.sha }} -p:GitBranch=${{ github.ref_name }}
     - name: Publish


### PR DESCRIPTION
Type: **bugfix**

## Issue
`Build and deploy .NET Core app to Linux WebApp grandnode` fails on every push to
`develop`, so nothing has deployed since the shared test script landed in #759.
Example: [run 31268755721](https://github.com/grandnode/grandnode2/actions/runs/31268755721/job/93133194319).

All 21 test projects are reported as failed, each in well under a second:

```
Test run for .../src/Tests/Grand.SharedKernel.Tests/bin/Debug/net10.0/Grand.SharedKernel.Tests.dll
The argument .../bin/Debug/net10.0/Grand.SharedKernel.Tests.dll is invalid.
```

No test actually ran. The `Build sln` step produced **`bin/Release`** (visible at
line 345 of the same log), while `run-tests.sh` was told `Debug` and runs with
`--no-build`, so it pointed vstest at Debug assemblies that were never built.

The build step looks like it produces Debug - it has no `--configuration` flag. It
does not. The job declares `CONFIGURATION: Release` at the `env` level for the later
publish and deploy steps, and MSBuild reads environment variables as properties, so
`Configuration` resolves to `Release`.

Confirming it locally:

```
$ CONFIGURATION=Release dotnet build src/Tests/Grand.SharedKernel.Tests/Grand.SharedKernel.Tests.csproj
$ ls src/Tests/Grand.SharedKernel.Tests/bin/Release/net10.0/Grand.SharedKernel.Tests.dll
```

The same script invoked as `run-tests.sh Release` from `aspnetcore.yml` passes on the
identical commit ([run 31268755713](https://github.com/grandnode/grandnode2/actions/runs/31268755713)),
which is what isolates this to the configuration mismatch rather than the script or
the tests.

## Solution
- The `Unit tests` step uses `${{ env.CONFIGURATION }}` instead of the hard-coded
  `Debug`, so it looks where the build actually wrote.
- The `Build sln` step states `--configuration ${{ env.CONFIGURATION }}` explicitly.
  This changes nothing about what it produces; it stops the configuration being
  decided invisibly by an environment variable, which is what made the mismatch hard
  to see in the first place.
- A comment records why the coupling exists, so the next person does not "fix" the
  test step back to Debug.

## Breaking changes
None. Tests now run in Release in this workflow, which is the configuration the job
builds, publishes and deploys.

## Testing
1. Merge and push to `develop`; the `Unit tests` step should report
   `All 21 test projects passed.` and the job should proceed to Publish and Deploy.
2. Locally, `CONFIGURATION=Release dotnet build <any test csproj>` writes to
   `bin/Release/net10.0/` despite no `--configuration` flag, which is the mechanism
   behind the failure.
3. `./.github/scripts/run-tests.sh Release` after a Release build of the solution
   runs all 21 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)