### PR TITLE
Validate antiforgery on the admin file manager and fix picture URLs from subfolders

### DIFF
--- a/src/Tests/Grand.Web.Admin.Tests/Security/AntiforgeryOptOutTests.cs
+++ b/src/Tests/Grand.Web.Admin.Tests/Security/AntiforgeryOptOutTests.cs
@@ -1,0 +1,35 @@
+using Grand.Web.Admin.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace Grand.Web.Admin.Tests.Security;
+
+[TestClass]
+public class AntiforgeryOptOutTests
+{
+    /// <summary>
+    ///     BaseAdminController carries [AutoValidateAntiforgeryToken]; a single [IgnoreAntiforgeryToken]
+    ///     opens the action to CSRF from an authenticated administrator's browser. The panel has no
+    ///     endpoint that needs the opt-out - every caller already sends the token, either as the
+    ///     __RequestVerificationToken field or as the X-CSRF-TOKEN header.
+    /// </summary>
+    [TestMethod]
+    public void AdminControllers_DoNotOptOutOfAntiforgery()
+    {
+        var offenders = (from controller in typeof(BaseAdminController).Assembly.GetTypes()
+                where typeof(ControllerBase).IsAssignableFrom(controller) && !controller.IsAbstract
+                from action in controller.GetMethods(BindingFlags.Public | BindingFlags.Instance |
+                                                     BindingFlags.DeclaredOnly)
+                where !action.IsSpecialName &&
+                      (action.IsDefined(typeof(IgnoreAntiforgeryTokenAttribute), true) ||
+                       controller.IsDefined(typeof(IgnoreAntiforgeryTokenAttribute), true))
+                select $"{controller.Name}.{action.Name}")
+            .Distinct()
+            .ToList();
+
+        Assert.AreEqual(0, offenders.Count,
+            $"Antiforgery validation is disabled on: {string.Join(", ", offenders)}");
+    }
+}

--- a/src/Tests/Grand.Web.Admin.Tests/Services/BaseInfoResponseConverterTests.cs
+++ b/src/Tests/Grand.Web.Admin.Tests/Services/BaseInfoResponseConverterTests.cs
@@ -1,0 +1,63 @@
+using elFinder.Net.Core.Models.FileInfo;
+using Grand.Web.AdminShared.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace Grand.Web.Admin.Tests.Services;
+
+/// <summary>
+///     OpenResponse.cwd is declared as BaseInfoResponse, so these tests serialize through that same
+///     declared type - the condition under which the properties go missing.
+/// </summary>
+[TestClass]
+public class BaseInfoResponseConverterTests
+{
+    private JsonSerializerOptions _options;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _options = new JsonSerializerOptions();
+        _options.Converters.Add(new BaseInfoResponseConverter());
+    }
+
+    /// <summary>
+    ///     Losing phash costs the browser the link from the current directory to its parent - and with
+    ///     it every file URL below the volume root, because elFinder builds those by walking that chain.
+    /// </summary>
+    [TestMethod]
+    public void Directory_KeepsTheParentHashOfItsRuntimeType()
+    {
+        BaseInfoResponse cwd = new DirectoryInfoResponse {
+            name = "test", hash = "v1_XHRlc3Q", phash = "v1_", volumeid = "v1_", mime = "directory"
+        };
+
+        var json = JsonSerializer.Serialize(cwd, _options);
+
+        StringAssert.Contains(json, "\"phash\":\"v1_\"");
+        StringAssert.Contains(json, "\"volumeid\":\"v1_\"");
+    }
+
+    [TestMethod]
+    public void Root_KeepsTheRootMarkerOfItsRuntimeType()
+    {
+        BaseInfoResponse cwd = new RootInfoResponse {
+            name = "Volume", hash = "v1_", volumeid = "v1_", isroot = 1, mime = "directory"
+        };
+
+        var json = JsonSerializer.Serialize(cwd, _options);
+
+        StringAssert.Contains(json, "\"isroot\":1");
+    }
+
+    [TestMethod]
+    public void DeclaredTypeAloneStillDropsTheParentHash()
+    {
+        BaseInfoResponse cwd = new DirectoryInfoResponse { name = "test", hash = "v1_XHRlc3Q", phash = "v1_" };
+
+        var json = JsonSerializer.Serialize(cwd, new JsonSerializerOptions());
+
+        Assert.IsFalse(json.Contains("phash"), "Guards the premise of the converter - remove it and the fix is moot");
+    }
+}

--- a/src/Web/Grand.SharedUIResources/Views/Shared/EditorTemplates/Download.cshtml
+++ b/src/Web/Grand.SharedUIResources/Views/Shared/EditorTemplates/Download.cshtml
@@ -24,7 +24,7 @@
                 cache: false,
                 type: "POST",
                 url: "@(Url.Action("SaveDownloadUrl", "Download", new { area }))",
-                data: { "downloadUrl": downloadUrl, DownloadType: '@ViewData["DownloadType"]', ReferenceId: '@ViewData["ReferenceId"]' },
+                data: addAntiForgeryToken({ "downloadUrl": downloadUrl, DownloadType: '@ViewData["DownloadType"]', ReferenceId: '@ViewData["ReferenceId"]' }),
                 success: function (data) {
                     if (data.success) {
                         $('#pnlDownloadURLResult@(randomNumber)').fadeIn("slow").delay(1000).fadeOut("slow");
@@ -120,7 +120,10 @@
                                         DownloadType: '@ViewData["DownloadType"]',
                                         ReferenceId: '@ViewData["ReferenceId"]'
                                     },
-                                    inputName: "file"
+                                    inputName: "file",
+                                    customHeaders: {
+                                        'X-CSRF-TOKEN': $('input[name="__RequestVerificationToken"]').val()
+                                    }
                                 },
                                 template: "@(clientId)-qq-template",
                                 multiple: false

--- a/src/Web/Grand.SharedUIResources/Views/Shared/EditorTemplates/Editor.cshtml
+++ b/src/Web/Grand.SharedUIResources/Views/Shared/EditorTemplates/Editor.cshtml
@@ -4,9 +4,13 @@
 
 @model string
 @inject IPermissionService permissionService
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery antiforgery
 @{
     var allowFileman = await permissionService.Authorize(StandardPermission.HtmlEditorManagePictures);
     var random = CommonHelper.GenerateRandomInteger();
+    //the editor is not always rendered inside a form, so the token comes from IAntiforgery
+    //(which also issues the cookie) rather than from a __RequestVerificationToken input
+    var requestToken = antiforgery.GetAndStoreTokens(Context).RequestToken;
 }
 <div id="s-@(random)-summernote" class="summernote" data-name="null" data-file="null" data-format="null">
     @Html.Raw(ViewData.TemplateInfo.FormattedModelValue)
@@ -18,6 +22,9 @@
     function elfinderDialog@(random)(context) { // <------------------ +context
         var fm = $('<div/>').dialogelfinder({
             url: '@Url.Action("Connector", "ElFinder")',
+            customHeaders: {
+                'X-CSRF-TOKEN': '@requestToken'
+            },
             baseUrl: '@(Grand.SharedUIResources.Constants.WwwRoot)/administration/elfinder/',
             lang: 'en',
             width: 840,

--- a/src/Web/Grand.Web.Admin/Controllers/DownloadController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/DownloadController.cs
@@ -44,9 +44,6 @@ public class DownloadController : BaseAdminController
     }
 
     [HttpPost]
-
-    //do not validate request token (XSRF)
-    [IgnoreAntiforgeryToken]
     public async Task<IActionResult> SaveDownloadUrl(string downloadUrl, DownloadType downloadType = DownloadType.None,
         string referenceId = "")
     {
@@ -65,8 +62,6 @@ public class DownloadController : BaseAdminController
     }
 
     [HttpPost]
-    //do not validate request token (XSRF)
-    [IgnoreAntiforgeryToken]
     public virtual async Task<IActionResult> AsyncUpload(IFormFile file, DownloadType downloadType = DownloadType.None,
         string referenceId = "")
     {

--- a/src/Web/Grand.Web.Admin/Controllers/ElFinderController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/ElFinderController.cs
@@ -31,7 +31,6 @@ public class ElFinderController : BaseAdminController
 
     #region Methods
 
-    [IgnoreAntiforgeryToken]
     public virtual async Task<IActionResult> Connector()
     {
         if (!await _permissionService.Authorize(StandardPermission.HtmlEditorManagePictures))

--- a/src/Web/Grand.Web.Admin/Controllers/LanguageController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/LanguageController.cs
@@ -194,7 +194,6 @@ public class LanguageController : BaseAdminController
 
     [PermissionAuthorizeAction(PermissionActionName.Preview)]
     [HttpPost]
-    [IgnoreAntiforgeryToken]
     public async Task<IActionResult> Resources(string languageId, DataSourceRequest command,
         LanguageResourceFilterModel model)
     {

--- a/src/Web/Grand.Web.AdminShared/Services/BaseInfoResponseConverter.cs
+++ b/src/Web/Grand.Web.AdminShared/Services/BaseInfoResponseConverter.cs
@@ -1,0 +1,37 @@
+using elFinder.Net.Core.Models.FileInfo;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Grand.Web.AdminShared.Services;
+
+/// <summary>
+///     Writes elFinder file info by its runtime type.
+///     OpenResponse.cwd is declared as BaseInfoResponse while the instance is a DirectoryInfoResponse
+///     or a RootInfoResponse, and System.Text.Json serializes the declared type - so phash, volumeid
+///     and dirs never reach the browser. elFinder caches cwd in its file map, overwriting the complete
+///     entry it got from files[] with a parentless one, and can no longer walk a file back to the
+///     volume root. It then builds URLs as volume url + file name, dropping every subdirectory, so
+///     picking a picture out of a subfolder yields a 404.
+/// </summary>
+public class BaseInfoResponseConverter : JsonConverter<BaseInfoResponse>
+{
+    /// <summary>
+    ///     Only the declared base type is intercepted; the nested Write call resolves the runtime type
+    ///     through the default converter and does not re-enter this one.
+    /// </summary>
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert == typeof(BaseInfoResponse);
+    }
+
+    public override BaseInfoResponse Read(ref Utf8JsonReader reader, Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        throw new NotSupportedException("The elFinder connector response is write-only");
+    }
+
+    public override void Write(Utf8JsonWriter writer, BaseInfoResponse value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/src/Web/Grand.Web.AdminShared/Services/ElFinderViewModelService.cs
+++ b/src/Web/Grand.Web.AdminShared/Services/ElFinderViewModelService.cs
@@ -10,11 +10,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
 
 namespace Grand.Web.AdminShared.Services;
 
 public class ElFinderViewModelService : IElFinderViewModelService
 {
+    private readonly JsonSerializerOptions _connectorJsonOptions;
     private readonly IConnector _connector;
     private readonly IDriver _driver;
     private readonly string _fullPathToThumbs;
@@ -36,8 +39,12 @@ public class ElFinderViewModelService : IElFinderViewModelService
         IHttpContextAccessor httpContextAccessor,
         IMediaFileStore mediaFileStore,
         LinkGenerator linkGenerator,
-        MediaSettings mediaSettings)
+        MediaSettings mediaSettings,
+        IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> jsonOptions)
     {
+        _connectorJsonOptions = new JsonSerializerOptions(jsonOptions.Value.JsonSerializerOptions);
+        _connectorJsonOptions.Converters.Add(new BaseInfoResponseConverter());
+
         _driver = driver;
         _connector = connector;
         _httpContextAccessor = httpContextAccessor;
@@ -118,6 +125,11 @@ public class ElFinderViewModelService : IElFinderViewModelService
         var ccTokenSource = ConnectorHelper.RegisterCcTokenSource(_httpContextAccessor.HttpContext);
         var conResult = await _connector.ProcessAsync(cmd, ccTokenSource);
         var actionResult = conResult.ToActionResult(_httpContextAccessor.HttpContext);
+
+        //serialize file info by its runtime type, otherwise cwd loses phash - see BaseInfoResponseConverter
+        if (actionResult is JsonResult jsonResult)
+            jsonResult.SerializerSettings = _connectorJsonOptions;
+
         return actionResult;
     }
 


### PR DESCRIPTION
Type: **bugfix**

## Issue

Two defects in the admin media surface, found while working through the security items in the architecture audit.

**1. Four admin actions opted out of antiforgery validation.** `BaseAdminController` carries `[AutoValidateAntiforgeryToken]`, but these actions disabled it:

| Action | What it does without a token |
|---|---|
| `ElFinderController.Connector` | the **whole** file manager — upload, rename, delete, paste, mkfile |
| `DownloadController.SaveDownloadUrl` | stores an arbitrary URL as a Download record |
| `DownloadController.AsyncUpload` | uploads a file into the database |
| `LanguageController.Resources` | reads the resources grid |

The admin panel is enabled in every installation, so exploiting this needed nothing more than luring a signed-in administrator to a foreign page. To reproduce: sign in to `/admin`, then from any other origin (or the browser console) `POST` to `/admin/ElFinder/Connector` with `cmd=mkfile` — before this change it succeeds and writes a file.

**2. Picking a picture from any media subfolder inserted a URL that 404s.** The subdirectory was missing from it. `OpenResponse.cwd` is declared as `BaseInfoResponse` while the instance is a `DirectoryInfoResponse` or `RootInfoResponse`, which add `phash`, `volumeid` and `dirs`. System.Text.Json serializes the declared type, so those three never reached the browser. elFinder caches `cwd` in its file map, overwriting the complete entry it already had from `files[]` with a parentless one; `path2array` then stops at the current directory instead of walking up to the volume root, and `url()` builds *volume url + file name* with every intermediate directory dropped. Files sitting directly in the media root were unaffected, which is why this went unnoticed.

## Solution

**Antiforgery.** Removed all four `[IgnoreAntiforgeryToken]` attributes. The client side needed no new mechanism — the patterns were already in the repository:

- elFinder and fineUploader now send `customHeaders: { 'X-CSRF-TOKEN': ... }`, the same way `Picture.cshtml` already did for an `AsyncUpload` that never carried the opt-out. The header name comes from `ServiceCollectionExtensions.AddAntiForgery`.
- `Editor.cshtml` takes the token from an injected `IAntiforgery` rather than from a `__RequestVerificationToken` input, because the editor is not always rendered inside a form and `GetAndStoreTokens` issues the cookie as well.
- The language resources grid already called `addAntiForgeryToken` in `additionalData()`, so removing the attribute was enough.

`AntiforgeryOptOutTests` replaces the hand-kept list: it walks the panel assembly and fails if any action carries `IgnoreAntiforgeryTokenAttribute`. Verified that it fails on the old behaviour, naming exactly those four actions.

The opt-outs in `Grand.Module.Api` are left alone — `TokenController` and `TokenWebController` are anonymous JSON endpoints issuing JWTs, with no cookie authentication for CSRF to ride on.

**Picture URLs.** `BaseInfoResponseConverter` writes file info by its runtime type and is attached to the connector's `JsonResult` only, so nothing else in the application changes serialization. It intercepts the declared base type alone, so the nested write resolves through the default converter rather than re-entering.

## Breaking changes

`ElFinderViewModelService` gained a constructor parameter (`IOptions<JsonOptions>`). Resolved through DI everywhere in the repository, so nothing here changes, but code that constructs or derives from this service directly needs the extra argument.

Nothing else: no view model, widget zone, plugin system name, setting, permission or localization resource changed.

## Testing

1. `dotnet build ./GrandNode.sln`
2. `dotnet test src/Tests/Grand.Web.Admin.Tests` — 55 pass, including the three new converter tests and the antiforgery guard.
3. Sign in to `/admin`. In the browser console run:
   ```js
   await fetch('/admin/ElFinder/Connector', {method:'POST', credentials:'same-origin',
     body:new URLSearchParams({cmd:'open', target:'', init:'1'})}).then(r=>r.status)
   ```
   Expect **400**. Repeat for `/admin/Download/SaveDownloadUrl` and `/admin/Language/Resources` — both **400**.
4. Open any entity with a rich text editor (e.g. Catalog → Categories → edit → Description) and click *Manage pictures*. The file tree loads, upload, rename and delete all work.
5. Put an image in a **subfolder** of `wwwroot/assets/images/uploaded` (e.g. `uploaded/test/`). In the file manager open that subfolder and double-click the image: the editor receives `/assets/images/uploaded/test/<name>` and the image renders. Before this change the inserted URL was `/assets/images/uploaded/<name>` and returned 404.
6. Product → Downloadable tab: *Save download URL* and the file upload both succeed.
7. Configuration → Languages → String resources: the grid loads and filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
