### PR TITLE
Make the store scope explicit on the category, brand and collection lists

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Brands/BrandService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Brands/BrandService.cs
@@ -57,8 +57,8 @@ public class BrandService : IBrandService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Brands</returns>
-    public virtual async Task<IPagedList<Brand>> GetAllBrands(string brandName = "",
-        string storeId = "",
+    public virtual async Task<IPagedList<Brand>> GetAllBrands(string brandName,
+        string storeId,
         int pageIndex = 0,
         int pageSize = int.MaxValue,
         bool showHidden = false)

--- a/src/Business/Grand.Business.Catalog/Services/Categories/CategoryService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Categories/CategoryService.cs
@@ -74,8 +74,8 @@ public class CategoryService : ICategoryService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Categories</returns>
-    public virtual async Task<IPagedList<Category>> GetAllCategories(string parentId = null, string categoryName = "",
-        string storeId = "",
+    public virtual async Task<IPagedList<Category>> GetAllCategories(string parentId, string categoryName,
+        string storeId,
         int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false)
     {
         var query = from c in _categoryRepository.Table

--- a/src/Business/Grand.Business.Catalog/Services/Collections/CollectionService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Collections/CollectionService.cs
@@ -61,8 +61,8 @@ public class CollectionService : ICollectionService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Collections</returns>
-    public virtual async Task<IPagedList<Collection>> GetAllCollections(string collectionName = "",
-        string storeId = "",
+    public virtual async Task<IPagedList<Collection>> GetAllCollections(string collectionName,
+        string storeId,
         int pageIndex = 0,
         int pageSize = int.MaxValue,
         bool showHidden = false)

--- a/src/Business/Grand.Business.Core/Interfaces/Catalog/Brands/IBrandService.cs
+++ b/src/Business/Grand.Business.Core/Interfaces/Catalog/Brands/IBrandService.cs
@@ -17,8 +17,8 @@ public interface IBrandService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Brands</returns>
-    Task<IPagedList<Brand>> GetAllBrands(string brandName = "",
-        string storeId = "",
+    Task<IPagedList<Brand>> GetAllBrands(string brandName,
+        string storeId,
         int pageIndex = 0,
         int pageSize = int.MaxValue,
         bool showHidden = false);

--- a/src/Business/Grand.Business.Core/Interfaces/Catalog/Categories/ICategoryService.cs
+++ b/src/Business/Grand.Business.Core/Interfaces/Catalog/Categories/ICategoryService.cs
@@ -15,7 +15,7 @@ public interface ICategoryService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Categories</returns>
-    Task<IPagedList<Category>> GetAllCategories(string parentId = null, string categoryName = "", string storeId = "",
+    Task<IPagedList<Category>> GetAllCategories(string parentId, string categoryName, string storeId,
         int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false);
 
     /// <summary>

--- a/src/Business/Grand.Business.Core/Interfaces/Catalog/Collections/ICollectionService.cs
+++ b/src/Business/Grand.Business.Core/Interfaces/Catalog/Collections/ICollectionService.cs
@@ -17,8 +17,8 @@ public interface ICollectionService
     /// <param name="pageSize">Page size</param>
     /// <param name="showHidden">A value that indicates if it should shows hidden records</param>
     /// <returns>Collections</returns>
-    Task<IPagedList<Collection>> GetAllCollections(string collectionName = "",
-        string storeId = "",
+    Task<IPagedList<Collection>> GetAllCollections(string collectionName,
+        string storeId,
         int pageIndex = 0,
         int pageSize = int.MaxValue,
         bool showHidden = false);

--- a/src/Business/Grand.Business.Messages/Commands/Handlers/Common/GetSitemapXMLCommandHandler.cs
+++ b/src/Business/Grand.Business.Messages/Commands/Handlers/Common/GetSitemapXMLCommandHandler.cs
@@ -231,7 +231,7 @@ public class GetSitemapXmlCommandHandler : IRequestHandler<GetSitemapXmlCommand,
 
     private async Task<IEnumerable<SitemapUrl>> GetBrandUrls(Language language, Store store)
     {
-        var brands = await _brandService.GetAllBrands(storeId: store.Id);
+        var brands = await _brandService.GetAllBrands(brandName: "", storeId: store.Id);
         var brandUrls = new List<SitemapUrl>();
         var storeLocation = GetStoreLocation();
         foreach (var brand in brands)

--- a/src/Tests/Grand.Business.Catalog.Tests/Services/Brands/BrandServiceTests.cs
+++ b/src/Tests/Grand.Business.Catalog.Tests/Services/Brands/BrandServiceTests.cs
@@ -47,7 +47,7 @@ public class BrandServiceTests
         await _brandService.InsertBrand(new Brand { Published = true });
 
         //Act
-        var brand = await _brandService.GetAllBrands();
+        var brand = await _brandService.GetAllBrands(brandName: "", storeId: "");
 
         //Assert
         Assert.HasCount(3, brand);

--- a/src/Tests/Grand.Business.Catalog.Tests/Services/Categories/CategoryServiceDbTests.cs
+++ b/src/Tests/Grand.Business.Catalog.Tests/Services/Categories/CategoryServiceDbTests.cs
@@ -106,7 +106,7 @@ public class CategoryServiceDbTests
     {
         var allCategory = GetMockCategoryList();
         allCategory.ToList().ForEach(x => _categoryService.InsertCategory(x).GetAwaiter().GetResult());
-        var result = await _categoryService.GetAllCategories();
+        var result = await _categoryService.GetAllCategories(parentId: null, categoryName: "", storeId: "");
         Assert.HasCount(5, result);
     }
 

--- a/src/Tests/Grand.Business.Common.Tests/Services/Security/AclServiceTest.cs
+++ b/src/Tests/Grand.Business.Common.Tests/Services/Security/AclServiceTest.cs
@@ -42,4 +42,22 @@ public class AclServiceTest
         _accessControlConfig.IgnoreStoreLimitations = true;
         Assert.IsTrue(_aclService.Authorize(product, "id"));
     }
+
+    /// <summary>
+    ///     Pins the fail-open: an empty store grants access even to an entity that is limited to other
+    ///     stores. Callers therefore carry the whole burden of supplying the store - which is why the
+    ///     list services no longer default that argument away.
+    /// </summary>
+    [TestMethod]
+    public void Authorize_WithoutAStore_GrantsAccessToAnEntityLimitedToOtherStores()
+    {
+        var product = new Product {
+            LimitedToStores = true,
+            Stores = { "another-store" }
+        };
+
+        Assert.IsFalse(_aclService.Authorize(product, "this-store"), "the store is not among the entity's stores");
+        Assert.IsTrue(_aclService.Authorize(product, ""), "fail-open: no store means no check");
+        Assert.IsTrue(_aclService.Authorize(product, (string)null), "fail-open: no store means no check");
+    }
 }

--- a/src/Tests/Grand.Web.Admin.Tests/Extensions/AclMappingExtensionTests.cs
+++ b/src/Tests/Grand.Web.Admin.Tests/Extensions/AclMappingExtensionTests.cs
@@ -1,0 +1,58 @@
+using Grand.Domain.Catalog;
+using Grand.Web.AdminShared.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace Grand.Web.Admin.Tests.Extensions;
+
+[TestClass]
+public class AclMappingExtensionTests
+{
+    /// <summary>
+    ///     Pins the fail-open: an empty store grants access even to an entity limited to another store.
+    /// </summary>
+    [TestMethod]
+    public void AccessToEntityByStore_WithoutAStore_GrantsAccessToAnEntityLimitedToOtherStores()
+    {
+        var product = new Product {
+            LimitedToStores = true,
+            Stores = { "another-store" }
+        };
+
+        Assert.IsFalse(product.AccessToEntityByStore("this-store"));
+        Assert.IsTrue(product.AccessToEntityByStore(""), "fail-open: no store means no check");
+    }
+
+    /// <summary>
+    ///     This check is stricter than AclService.Authorize on the same-sounding question: an entity
+    ///     shared with a second store is refused here, while AclService grants it. Anyone reaching for
+    ///     "does this store own the entity" has to pick deliberately between the two.
+    /// </summary>
+    [TestMethod]
+    public void AccessToEntityByStore_RefusesAnEntitySharedWithASecondStore()
+    {
+        var product = new Product {
+            LimitedToStores = true,
+            Stores = { "this-store", "another-store" }
+        };
+
+        Assert.IsFalse(product.AccessToEntityByStore("this-store"));
+    }
+
+    [TestMethod]
+    public void AccessToEntityByStore_AcceptsAnEntityOwnedByThatStoreAlone()
+    {
+        var product = new Product {
+            LimitedToStores = true,
+            Stores = { "this-store" }
+        };
+
+        Assert.IsTrue(product.AccessToEntityByStore("this-store"));
+    }
+
+    [TestMethod]
+    public void AccessToEntityByStore_RefusesAMissingEntity()
+    {
+        Assert.IsFalse(((Product)null).AccessToEntityByStore("this-store"));
+    }
+}

--- a/src/Web/Grand.Web.Admin/Controllers/BrandController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/BrandController.cs
@@ -273,7 +273,7 @@ public class BrandController : BaseAdminController
     {
         try
         {
-            var bytes = await exportManager.Export(await _brandService.GetAllBrands(showHidden: true));
+            var bytes = await exportManager.Export(await _brandService.GetAllBrands(brandName: "", storeId: "", showHidden: true));
             return File(bytes, "text/xls", "brands.xlsx");
         }
         catch (Exception exc)

--- a/src/Web/Grand.Web.Admin/Controllers/CategoryController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CategoryController.cs
@@ -230,7 +230,7 @@ public class CategoryController : BaseAdminController
     {
         try
         {
-            var bytes = await exportManager.Export(await _categoryService.GetAllCategories(showHidden: true));
+            var bytes = await exportManager.Export(await _categoryService.GetAllCategories(parentId: null, categoryName: "", storeId: "", showHidden: true));
             return File(bytes, "text/xls", "categories.xlsx");
         }
         catch (Exception exc)

--- a/src/Web/Grand.Web.Admin/Controllers/CollectionController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CollectionController.cs
@@ -268,7 +268,7 @@ public class CollectionController : BaseAdminController
     {
         try
         {
-            var bytes = await exportManager.Export(await _collectionService.GetAllCollections(showHidden: true));
+            var bytes = await exportManager.Export(await _collectionService.GetAllCollections(collectionName: "", storeId: "", showHidden: true));
             return File(bytes, "text/xls", "collections.xlsx");
         }
         catch (Exception exc)

--- a/src/Web/Grand.Web.Admin/Controllers/DiscountController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/DiscountController.cs
@@ -513,7 +513,7 @@ public class DiscountController : BaseAdminController
     public async Task<IActionResult> CategoryAddPopupList(DataSourceRequest command,
         DiscountModel.AddCategoryToDiscountModel model, [FromServices] ICategoryService categoryService)
     {
-        var categories = await categoryService.GetAllCategories(categoryName: model.SearchCategoryName,
+        var categories = await categoryService.GetAllCategories(parentId: null, categoryName: model.SearchCategoryName, storeId: "",
             pageIndex: command.Page - 1, pageSize: command.PageSize, showHidden: true);
         var items = new List<CategoryModel>();
         foreach (var item in categories)

--- a/src/Web/Grand.Web.Admin/Controllers/SearchController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/SearchController.cs
@@ -90,7 +90,7 @@ public class SearchController : BaseAdminController
 
             if (result.Count < _adminSearchSettings.MaxSearchResultsCount && _adminSearchSettings.SearchInCategories)
             {
-                var categories = await _categoryService.GetAllCategories(categoryName: searchTerm,
+                var categories = await _categoryService.GetAllCategories(parentId: null, categoryName: searchTerm, storeId: "",
                     pageSize: _adminSearchSettings.MaxSearchResultsCount - result.Count, showHidden:
                     await _groupService.IsAdmin(_contextAccessor.WorkContext.CurrentCustomer));
                 foreach (var category in categories)
@@ -104,7 +104,7 @@ public class SearchController : BaseAdminController
 
             if (result.Count < _adminSearchSettings.MaxSearchResultsCount && _adminSearchSettings.SearchInCollections)
             {
-                var collections = await _collectionService.GetAllCollections(searchTerm,
+                var collections = await _collectionService.GetAllCollections(searchTerm, storeId: "",
                     pageSize: _adminSearchSettings.MaxSearchResultsCount - result.Count, showHidden: true);
                 foreach (var collection in collections)
                     result.Add(new Tuple<object, int>(new
@@ -300,6 +300,7 @@ public class SearchController : BaseAdminController
     {
         var brands = await _brandService.GetAllBrands(
             model.GetNameFilterValue(),
+            storeId: "",
             pageSize: _adminSearchSettings.BrandSizeLimit);
 
         var gridModel = await DataSourceResultHelper.GetSearchResult(brandId, brands, brand => Task.FromResult(brand.Name));

--- a/src/Web/Grand.Web.AdminShared/Services/CategoryViewModelService.cs
+++ b/src/Web/Grand.Web.AdminShared/Services/CategoryViewModelService.cs
@@ -76,6 +76,7 @@ public class CategoryViewModelService : ICategoryViewModelService
         CategoryListModel model, int pageIndex, int pageSize)
     {
         var categories = await _categoryService.GetAllCategories(
+            parentId: null,
             categoryName: model.SearchCategoryName,
             storeId: model.SearchStoreId,
             pageSize: pageSize,

--- a/src/Web/Grand.Web.AdminShared/Services/CollectionViewModelService.cs
+++ b/src/Web/Grand.Web.AdminShared/Services/CollectionViewModelService.cs
@@ -181,7 +181,8 @@ public class CollectionViewModelService : ICollectionViewModelService
         //collections
         model.AvailableCollections.Add(new SelectListItem
             { Text = _translationService.GetResource("Admin.Common.All"), Value = " " });
-        foreach (var m in await _collectionService.GetAllCollections(showHidden: true))
+        foreach (var m in await _collectionService.GetAllCollections(collectionName: "", storeId: "",
+                     showHidden: true))
             model.AvailableCollections.Add(new SelectListItem { Text = m.Name, Value = m.Id });
 
         //stores

--- a/src/Web/Grand.Web.Store/Controllers/DiscountController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/DiscountController.cs
@@ -1,4 +1,4 @@
-using Grand.Business.Core.Interfaces.Catalog.Brands;
+﻿using Grand.Business.Core.Interfaces.Catalog.Brands;
 using Grand.Business.Core.Interfaces.Catalog.Categories;
 using Grand.Business.Core.Interfaces.Catalog.Collections;
 using Grand.Business.Core.Interfaces.Catalog.Discounts;
@@ -515,7 +515,7 @@ public class DiscountController : BaseStoreController
     public async Task<IActionResult> CategoryAddPopupList(DataSourceRequest command,
         DiscountModel.AddCategoryToDiscountModel model, [FromServices] ICategoryService categoryService)
     {
-        var categories = await categoryService.GetAllCategories(categoryName: model.SearchCategoryName,
+        var categories = await categoryService.GetAllCategories(parentId: null, categoryName: model.SearchCategoryName,
             storeId: CurrentStoreId, pageIndex: command.Page - 1, pageSize: command.PageSize, showHidden: true);
         var items = new List<CategoryModel>();
         foreach (var item in categories)

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetBrandAllHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetBrandAllHandler.cs
@@ -47,7 +47,7 @@ public class GetBrandAllHandler : IRequestHandler<GetBrandAll, BrandListModel>
             request.Command.PageSize = _catalogSettings.MaxCatalogPageSize;
 
         var model = new List<BrandModel>();
-        var brands = await _brandService.GetAllBrands(storeId: request.Store.Id,
+        var brands = await _brandService.GetAllBrands(brandName: "", storeId: request.Store.Id,
             pageIndex: request.Command.PageNumber - 1,
             pageSize: request.Command.PageSize
         );

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetCategoryAllHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetCategoryAllHandler.cs
@@ -48,7 +48,7 @@ public class GetCategoryAllHandler : IRequestHandler<GetCategoryAll, CategoryLis
             request.Command.PageSize = _catalogSettings.MaxCatalogPageSize;
 
         var model = new List<CategoryModel>();
-        var categories = await _categoryService.GetAllCategories(storeId: request.Store.Id,
+        var categories = await _categoryService.GetAllCategories(parentId: null, categoryName: "", storeId: request.Store.Id,
             pageIndex: request.Command.PageNumber - 1,
             pageSize: request.Command.PageSize
         );

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetCategorySimpleHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetCategorySimpleHandler.cs
@@ -65,7 +65,7 @@ public class GetCategorySimpleHandler : IRequestHandler<GetCategorySimple, IList
 
             async Task PrepareCategories(string categoryId)
             {
-                var parentCategories = await _categoryService.GetAllCategories(categoryId, storeId: request.Store.Id);
+                var parentCategories = await _categoryService.GetAllCategories(categoryId, categoryName: "", storeId: request.Store.Id);
                 if (parentCategories.Any())
                 {
                     categories.AddRange(parentCategories);
@@ -79,7 +79,7 @@ public class GetCategorySimpleHandler : IRequestHandler<GetCategorySimple, IList
             if (currentCategory != null)
             {
                 var currentCategories =
-                    await _categoryService.GetAllCategories(currentCategory.Id, storeId: request.Store.Id);
+                    await _categoryService.GetAllCategories(currentCategory.Id, categoryName: "", storeId: request.Store.Id);
                 categories.AddRange(currentCategories);
                 await PrepareCategories(currentCategory.ParentCategoryId);
             }

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetCollectionAllHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetCollectionAllHandler.cs
@@ -48,7 +48,7 @@ public class GetCollectionAllHandler : IRequestHandler<GetCollectionAll, Collect
             request.Command.PageSize = _catalogSettings.MaxCatalogPageSize;
 
         var model = new List<CollectionModel>();
-        var collections = await _collectionService.GetAllCollections(storeId: request.Store.Id,
+        var collections = await _collectionService.GetAllCollections(collectionName: "", storeId: request.Store.Id,
             pageIndex: request.Command.PageNumber - 1,
             pageSize: request.Command.PageSize);
 

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetCollectionNavigationHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetCollectionNavigationHandler.cs
@@ -35,7 +35,7 @@ public class GetCollectionNavigationHandler : IRequestHandler<GetCollectionNavig
         {
             var currentCollection = await _collectionService.GetCollectionById(request.CurrentCollectionId);
             var collections =
-                await _collectionService.GetAllCollections(pageSize: _catalogSettings.CollectionsBlockItemsToDisplay,
+                await _collectionService.GetAllCollections(collectionName: "", pageSize: _catalogSettings.CollectionsBlockItemsToDisplay,
                     storeId: request.Store.Id);
             var model = new CollectionNavigationModel {
                 TotalCollections = collections.TotalCount

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetHomepageBrandsHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetHomepageBrandsHandler.cs
@@ -41,7 +41,7 @@ public class GetHomepageBrandsHandler : IRequestHandler<GetHomepageBrands, IList
         var model = await _cacheBase.GetAsync(brandsCacheKey, async () =>
         {
             var modelBrands = new List<BrandModel>();
-            var allBrands = await _brandService.GetAllBrands(storeId: request.Store.Id);
+            var allBrands = await _brandService.GetAllBrands(brandName: "", storeId: request.Store.Id);
             foreach (var x in allBrands.Where(x => x.ShowOnHomePage))
             {
                 var brandModel = x.ToModel(request.Language);

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetHomepageCollectionsHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetHomepageCollectionsHandler.cs
@@ -43,7 +43,7 @@ public class GetHomepageCollectionsHandler : IRequestHandler<GetHomepageCollecti
         var model = await _cacheBase.GetAsync(collectionsCacheKey, async () =>
         {
             var modelCollect = new List<CollectionModel>();
-            var allcollections = await _collectionService.GetAllCollections(storeId: request.Store.Id);
+            var allcollections = await _collectionService.GetAllCollections(collectionName: "", storeId: request.Store.Id);
             foreach (var x in allcollections.Where(x => x.ShowOnHomePage))
             {
                 var _model = x.ToModel(request.Language);

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetMenuHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetMenuHandler.cs
@@ -79,7 +79,7 @@ public class GetMenuHandler : IRequestHandler<GetMenu, MenuModel>
             request.Language.Id, request.Store.Id);
 
         var cachedBrandModel = await _cacheBase.GetAsync(brandCacheKey, async () =>
-            (await _brandService.GetAllBrands(storeId: request.Store.Id))
+            (await _brandService.GetAllBrands(brandName: "", storeId: request.Store.Id))
             .Where(x => x.IncludeInMenu)
             .Select(t => new MenuModel.MenuBrandModel {
                 Id = t.Id,
@@ -94,7 +94,7 @@ public class GetMenuHandler : IRequestHandler<GetMenu, MenuModel>
             request.Language.Id, request.Store.Id);
 
         var cachedCollectionModel = await _cacheBase.GetAsync(collectionCacheKey, async () =>
-            (await _collectionService.GetAllCollections(storeId: request.Store.Id))
+            (await _collectionService.GetAllCollections(collectionName: "", storeId: request.Store.Id))
             .Where(x => x.IncludeInMenu)
             .Select(t => new MenuModel.MenuCollectionModel {
                 Id = t.Id,

--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetSearchHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetSearchHandler.cs
@@ -99,7 +99,7 @@ public class GetSearchHandler : IRequestHandler<GetSearch, SearchModel>
         {
             var categoriesModel = new List<SearchModel.CategoryModel>();
             //all categories
-            var allCategories = await _categoryService.GetAllCategories(storeId: request.Store.Id, pageSize: 100);
+            var allCategories = await _categoryService.GetAllCategories(parentId: null, categoryName: "", storeId: request.Store.Id, pageSize: 100);
             foreach (var c in allCategories)
             {
                 //generate full category name (breadcrumb)
@@ -136,7 +136,7 @@ public class GetSearchHandler : IRequestHandler<GetSearch, SearchModel>
                 });
         }
 
-        var collections = await _collectionService.GetAllCollections(pageSize: 100);
+        var collections = await _collectionService.GetAllCollections(collectionName: "", storeId: request.Store.Id, pageSize: 100);
         if (collections.Any())
         {
             request.Model.AvailableCollections.Add(new SelectListItem {

--- a/src/Web/Grand.Web/Features/Handlers/Common/GetSitemapHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Common/GetSitemapHandler.cs
@@ -78,14 +78,14 @@ public class GetSitemapHandler : IRequestHandler<GetSitemap, SitemapModel>
             //categories
             if (_commonSettings.SitemapIncludeCategories)
             {
-                var categories = await _categoryService.GetAllCategories(storeId: request.Store.Id);
+                var categories = await _categoryService.GetAllCategories(parentId: null, categoryName: "", storeId: request.Store.Id);
                 model.Categories = categories.Select(x => x.ToModel(request.Language)).ToList();
             }
 
             //collections
             if (_commonSettings.SitemapIncludeBrands)
             {
-                var brands = await _brandService.GetAllBrands(storeId: request.Store.Id);
+                var brands = await _brandService.GetAllBrands(brandName: "", storeId: request.Store.Id);
                 model.Brands = brands.Select(x => x.ToModel(request.Language)).ToList();
             }
 


### PR DESCRIPTION
Type: **bugfix**

## Issue

`GetAllCategories`, `GetAllBrands` and `GetAllCollections` all declared `string storeId = ""`, and `AclService.Authorize` returns `true` when the store is empty:

```csharp
if (string.IsNullOrEmpty(storeId))
    //return true if no store specified/found
    return true;
```

So omitting the argument was not a compile error and silently turned tenant filtering off. That is not hypothetical — it had already happened:

**The storefront search page listed collections from every store.** `GetSearchHandler` builds the search filter dropdowns; the category block passes `request.Store.Id`, and ten lines below it the collection block did not:

```csharp
var allCategories = await _categoryService.GetAllCategories(storeId: request.Store.Id, pageSize: 100);
...
var collections = await _collectionService.GetAllCollections(pageSize: 100);   // no store
```

To reproduce: run two stores, give store B a collection limited to B, and open the search page of store A — B's collection appears in the "collection" filter.

## Solution

`storeId` **cannot** simply move to the front of the parameter list. All three methods take `string` parameters before it (`parentId`, `categoryName`, `brandName`, `collectionName`), so reordering would still compile at positional call sites while quietly swapping the arguments' meaning — the very class of bug this PR is about.

Instead, every parameter up to and including `storeId` became required, with the order untouched. The compiler then named all 27 call sites, and no call could change meaning without failing to build.

Twenty-six of those already passed the right scope and only became explicit — admin panel calls that are deliberately global now say `storeId: ""` in as many words. The twenty-seventh is the defect above and now passes the request's store.

`AclServiceTest` and the new `AclMappingExtensionTests` pin the fail-open, so changing it later has to be deliberate. The latter also records a difference nobody had written down: `AclService.Authorize` admits an entity shared with a second store, while `AclMappingExtension.AccessToEntityByStore` refuses it (`Stores.Count == 1`).

This is the first instalment of item 2.3 in the architecture audit. Roughly 150 further `string storeId = ""` declarations remain in the business layer, the CMS services (`BlogService`, `NewsService`, `PageService`) being the natural next batch.

## Breaking changes

**Yes, for third-party plugins.** `ICategoryService.GetAllCategories`, `IBrandService.GetAllBrands` and `ICollectionService.GetAllCollections` no longer default their leading parameters. Plugin code calling them without those arguments will not compile until it passes them; parameter order and types are unchanged, so no call can silently change meaning. This is the point of the change — the scope has to be a decision, not an omission.

Storefront behaviour changes in exactly one place: the search page's collection filter now honours the current store, as the rest of the page already did.

## Testing

1. `dotnet build ./GrandNode.sln` — clean, 0 warnings.
2. `dotnet test` on the affected projects: `Grand.Business.Catalog.Tests` (349), `Grand.Business.Common.Tests` (127), `Grand.Web.Admin.Tests` (55), `Grand.Web.Store.Tests` (17), `Grand.Web.Tests` (9), `Grand.Business.Messages.Tests` (33) — all pass.
3. Set up two stores. In the admin panel create a collection and limit it to store B only.
4. Open the search page of **store A** (`/search`) and expand the collection filter: store B's collection must not appear. Before this change it did.
5. Open the search page of store B: its collection appears.
6. Regression check on the calls that stayed global — admin panel Catalog → Categories / Brands / Collections lists, their export buttons, the admin search box, and the discount "add category/brand/collection" pickers all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
