### PR TITLE
Assemble the category tree outside the cache

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Categories/CategoryService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Categories/CategoryService.cs
@@ -159,9 +159,27 @@ public class CategoryService : ICategoryService
     public virtual async Task<IList<Category>> GetAllCategoriesByParentCategoryId(string parentCategoryId = "",
         bool showHidden = false, bool includeAllLevels = false)
     {
+        var categories = await GetChildCategories(parentCategoryId, showHidden);
+        if (!includeAllLevels) return categories;
+
+        //walk the tree outside the cache: every level resolves through its own cache entry, so no
+        //semaphore is held while the next level is fetched, and a subtree is stored once rather than
+        //once per ancestor
+        var allLevels = new List<Category>(categories);
+        foreach (var category in categories)
+            allLevels.AddRange(await GetAllCategoriesByParentCategoryId(category.Id, showHidden, true));
+
+        return allLevels;
+    }
+
+    /// <summary>
+    ///     Gets the direct children of a category, filtered by the current customer's groups and store
+    /// </summary>
+    private async Task<IList<Category>> GetChildCategories(string parentCategoryId, bool showHidden)
+    {
         var key = string.Format(CacheKey.CATEGORIES_BY_PARENT_CATEGORY_ID_KEY, parentCategoryId, showHidden,
-            CurrentCustomer.Id, CurrentStore.Id, includeAllLevels);
-        return await _cacheBase.GetAsync(key, async () =>
+            CurrentCustomer.Id, CurrentStore.Id);
+        return await _cacheBase.GetAsync(key, () =>
         {
             var query = _categoryRepository.Table.Where(c => c.ParentCategoryId == parentCategoryId);
             if (!showHidden)
@@ -185,14 +203,7 @@ public class CategoryService : ICategoryService
                         select p;
             }
 
-            var categories = query.OrderBy(x => x.DisplayOrder).ToList();
-            if (!includeAllLevels) return categories;
-            var childCategories = new List<Category>();
-            //add child levels
-            foreach (var category in categories)
-                childCategories.AddRange(await GetAllCategoriesByParentCategoryId(category.Id, showHidden, true));
-            categories.AddRange(childCategories);
-            return categories;
+            return Task.FromResult<IList<Category>>(query.OrderBy(x => x.DisplayOrder).ToList());
         });
     }
 

--- a/src/Core/Grand.Infrastructure/Caching/Constants/CategoryCacheKey.cs
+++ b/src/Core/Grand.Infrastructure/Caching/Constants/CategoryCacheKey.cs
@@ -25,7 +25,7 @@ public static partial class CacheKey
     ///     {3} : store ID
     ///     {4} : include all levels (child)
     /// </remarks>
-    public static string CATEGORIES_BY_PARENT_CATEGORY_ID_KEY => "Grand.category.byparent-{0}-{1}-{2}-{3}-{4}";
+    public static string CATEGORIES_BY_PARENT_CATEGORY_ID_KEY => "Grand.category.byparent-{0}-{1}-{2}-{3}";
 
     /// <summary>
     ///     Key pattern to clear cache

--- a/src/Tests/Grand.Business.Catalog.Tests/Services/Categories/CategoryServiceTreeTests.cs
+++ b/src/Tests/Grand.Business.Catalog.Tests/Services/Categories/CategoryServiceTreeTests.cs
@@ -1,0 +1,92 @@
+using Grand.Business.Catalog.Services.Categories;
+using Grand.Business.Common.Services.Security;
+using Grand.Data;
+using Grand.Data.Tests.MongoDb;
+using Grand.Domain.Catalog;
+using Grand.Domain.Customers;
+using Grand.Domain.Stores;
+using Grand.Infrastructure;
+using Grand.Infrastructure.Caching;
+using Grand.Infrastructure.Configuration;
+using Grand.Infrastructure.Tests.Caching;
+using Grand.Mediator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Grand.Business.Catalog.Tests.Services.Categories;
+
+/// <summary>
+///     The tree is assembled outside the cache, one level per entry. These tests pin the two
+///     properties that depends on: the order callers already relied on, and the fact that the
+///     assembled list is the caller's own rather than a shared cache entry.
+/// </summary>
+[TestClass]
+public class CategoryServiceTreeTests
+{
+    private CategoryService _categoryService;
+    private IRepository<Category> _categoryRepository;
+
+    [TestInitialize]
+    public void InitializeTests()
+    {
+        _categoryRepository = new MongoDBRepositoryTest<Category>();
+        //one customer for the whole fixture: a fresh instance per access would give every call its
+        //own id, hence its own cache key, and the caching under test would never be exercised
+        var customer = new Customer { Id = "customer" };
+        var contextAccessor = new Mock<IContextAccessor>();
+        contextAccessor.Setup(c => c.StoreContext.CurrentStore).Returns(() => new Store { Id = "store" });
+        contextAccessor.Setup(c => c.WorkContext.CurrentCustomer).Returns(() => customer);
+        var mediator = new Mock<IMediator>();
+        var cacheBase = new MemoryCacheBase(MemoryCacheTest.Get(), mediator.Object,
+            new CacheConfig { DefaultCacheTimeMinutes = 1 });
+        _categoryService = new CategoryService(cacheBase, _categoryRepository, contextAccessor.Object,
+            mediator.Object, new AclService(new AccessControlConfig()), new AccessControlConfig());
+    }
+
+    /// <summary>
+    ///     root -> a -> a1, root -> b -> b1
+    /// </summary>
+    private async Task GivenATwoLevelTree()
+    {
+        await _categoryService.InsertCategory(new Category { Id = "a", ParentCategoryId = "root", Published = true, DisplayOrder = 1 });
+        await _categoryService.InsertCategory(new Category { Id = "b", ParentCategoryId = "root", Published = true, DisplayOrder = 2 });
+        await _categoryService.InsertCategory(new Category { Id = "a1", ParentCategoryId = "a", Published = true });
+        await _categoryService.InsertCategory(new Category { Id = "b1", ParentCategoryId = "b", Published = true });
+    }
+
+    [TestMethod]
+    public async Task AllLevels_KeepsTheWholeLevelBeforeEachSubtree()
+    {
+        await GivenATwoLevelTree();
+
+        var result = await _categoryService.GetAllCategoriesByParentCategoryId("root", includeAllLevels: true);
+
+        CollectionAssert.AreEqual(new[] { "a", "b", "a1", "b1" }, result.Select(x => x.Id).ToArray());
+    }
+
+    [TestMethod]
+    public async Task WithoutAllLevels_ReturnsOnlyTheDirectChildren()
+    {
+        await GivenATwoLevelTree();
+
+        var result = await _categoryService.GetAllCategoriesByParentCategoryId("root");
+
+        CollectionAssert.AreEqual(new[] { "a", "b" }, result.Select(x => x.Id).ToArray());
+    }
+
+    /// <summary>
+    ///     The assembled list is built per call, so a caller that mutates it cannot corrupt what the
+    ///     next caller sees.
+    /// </summary>
+    [TestMethod]
+    public async Task AllLevels_HandsBackAListTheCallerOwns()
+    {
+        await GivenATwoLevelTree();
+
+        var first = await _categoryService.GetAllCategoriesByParentCategoryId("root", includeAllLevels: true);
+        first.Clear();
+        var second = await _categoryService.GetAllCategoriesByParentCategoryId("root", includeAllLevels: true);
+
+        Assert.HasCount(4, second);
+    }
+}


### PR DESCRIPTION
Type: **bugfix**

## Issue

`CategoryService.GetAllCategoriesByParentCategoryId` with `includeAllLevels: true` recursed into itself **from inside its own `_cacheBase.GetAsync` lambda**:

```csharp
return await _cacheBase.GetAsync(key, async () => {
    ...
    foreach (var category in categories)
        childCategories.AddRange(await GetAllCategoriesByParentCategoryId(category.Id, showHidden, true));
    ...
});
```

`GetAsync` holds a per-key `SemaphoreSlim` for the whole duration of the acquire. So on a cold cache each level's database query ran with every ancestor's semaphore still held, and concurrent requests for the same menu serialised along the entire path down the tree. The deeper the catalog, the longer the chain of held semaphores.

It also stored the same data repeatedly: a subtree was cached once on its own, and again inside the all-levels entry of every ancestor above it.

This is the storefront menu path, so it runs on essentially every page.

## Solution

The tree is now walked **outside** the cache. Only the direct-children query is cached — one entry per node — so every level takes and releases its own semaphore independently, and a subtree is stored exactly once. The all-levels list is assembled per call from those entries, which is cheap because the pieces come from memory.

`includeAllLevels` leaves the cache key as a result, so `CATEGORIES_BY_PARENT_CATEGORY_ID_KEY` loses its fifth segment. The constant has exactly one user.

Two properties are preserved and pinned by tests:

- **Order is unchanged** — a full level, then each child's subtree in turn, exactly as before.
- **The caller now owns the assembled list** rather than holding the cache's own instance, so clearing it can no longer empty what the next caller sees. This is the property the new tests discriminate on; verified failing on the previous implementation.

While writing those tests I hit the pathology from the sibling PR in my own fixture: a mock returning `new Customer()` per access gave every call a different id, hence a different cache key, so the cache was never exercised. The fixture now holds one customer — worth knowing if you write tests around this service.

## Conflicts with #768

Both PRs touch the same key-building statement in `CategoryService`, and this one also edits the key constant. Whichever merges second needs a one-line resolution: keep this PR's four-argument `string.Format` (no `includeAllLevels`) **and** #768's customer segment (`string.Join(",", CurrentCustomer.GetCustomerGroupIds())` instead of `CurrentCustomer.Id`). They are independent fixes to the same line, not competing ones.

## Breaking changes

None. No signature, model, setting or resource changes. `CATEGORIES_BY_PARENT_CATEGORY_ID_KEY` changes shape, but it is internal to this service; stale entries from a previous build simply never match and expire.

## Testing

1. `dotnet build ./GrandNode.sln` — clean, 0 warnings.
2. `dotnet test src/Tests/Grand.Business.Catalog.Tests` — 352 pass, 3 new. `Grand.Web.Tests` — 9 pass.
3. Build a catalog three levels deep, restart to clear the cache, and open the storefront home page: the menu renders identically to before.
4. Compare a cold-cache load under concurrent requests (e.g. `ab -n 50 -c 10` against the home page) before and after — the serialisation along the tree path is what changes.
5. Check invalidation still works: edit a child category in the admin panel and confirm the storefront menu reflects it (`Grand.category.` prefix clearing is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
