### PR TITLE
Move the business layer implementations to the hosts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,8 @@
     <PackageVersion Include="ExcelMapper" Version="6.0.641" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.11" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.6.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />

--- a/src/Build/Grand.Host.props
+++ b/src/Build/Grand.Host.props
@@ -1,0 +1,41 @@
+<Project>
+
+    <!--
+        The business layer implementations, referenced by the hosts - and only by the hosts.
+
+        Nothing in the web layer links a type from these assemblies: the whole solution compiles
+        against the contracts in Grand.Business.Core. What these references are for is presence.
+        Each of the nine projects carries a Startup/StartupApplication.cs, and TypeSearcher finds
+        IStartupApplication by walking the assemblies loaded in the AppDomain
+        (Grand.Infrastructure/TypeSearch/TypeSearcher.cs). An implementation that is not referenced
+        by the host never reaches the host's output, is never loaded, and its services are never
+        registered.
+
+        So this list looks removable and is not. Dropping an entry costs an entire business area's
+        DI registration, and nothing fails at build time - the first sign is a resolution failure
+        on a request at runtime.
+
+        These belong to the host because the host is the composition root. They used to sit in
+        Grand.Web.Common, which meant the shared web layer - and through it every plugin, since
+        Grand.Plugin.props references it - compiled against the entire business layer for no
+        reason at all.
+
+        Private is left at its default: unlike a plugin, the host is exactly where these
+        assemblies are supposed to be copied.
+
+        Paths are anchored to this file so a host can sit at any depth.
+    -->
+
+    <ItemGroup>
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Authentication\Grand.Business.Authentication.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Catalog\Grand.Business.Catalog.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Checkout\Grand.Business.Checkout.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Cms\Grand.Business.Cms.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Common\Grand.Business.Common.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Customers\Grand.Business.Customers.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Marketing\Grand.Business.Marketing.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Messages\Grand.Business.Messages.csproj" />
+        <ProjectReference Include="$(MSBuildThisFileDirectory)..\Business\Grand.Business.Storage\Grand.Business.Storage.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Web/Grand.Web.Admin/Grand.Web.Admin.csproj
+++ b/src/Web/Grand.Web.Admin/Grand.Web.Admin.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Host.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<ServerGarbageCollection>true</ServerGarbageCollection>

--- a/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
+++ b/src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj
@@ -17,5 +17,16 @@
 		     Microsoft.AspNetCore.Http 2.1.1 has a known high severity advisory (GHSA-hxrm-9w7p-39cc).
 		     This reference lifts it to a patched 2.x. Remove only together with elFinder. -->
 		<PackageReference Include="Microsoft.AspNetCore.Http" />
+		<!-- Same story, same package graph. elFinder.Net.Core 1.5.0 brings Newtonsoft.Json 11.0.2
+		     (GHSA-5crp-9r3c-p9vr) and SixLabors.ImageSharp 2.0.0 (GHSA-2cmq-823j-5qj8 and six more),
+		     and neither is used from this project's code.
+
+		     Until Grand.Web.Common referenced the whole business layer, these floors arrived by
+		     accident: Scryber.Core and the rest of that graph outvoted elFinder and the versions
+		     below are exactly what resolved then. Moving those references to the hosts, where they
+		     belong, took the accident away and the vulnerable versions surfaced - so the floor is
+		     stated here on purpose. Remove only together with elFinder. -->
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="SixLabors.ImageSharp" />
 	</ItemGroup>
 </Project>

--- a/src/Web/Grand.Web.Common/Grand.Web.Common.csproj
+++ b/src/Web/Grand.Web.Common/Grand.Web.Common.csproj
@@ -17,18 +17,5 @@
 		<ProjectReference Include="..\..\Core\Grand.Infrastructure\Grand.Infrastructure.csproj" />
 		<ProjectReference Include="..\..\Core\Grand.SharedKernel\Grand.SharedKernel.csproj" />
 	</ItemGroup>
-	
-	<ItemGroup>
-		<ProjectReference Include="..\..\Business\Grand.Business.Authentication\Grand.Business.Authentication.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Catalog\Grand.Business.Catalog.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Checkout\Grand.Business.Checkout.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Cms\Grand.Business.Cms.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Common\Grand.Business.Common.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Customers\Grand.Business.Customers.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Marketing\Grand.Business.Marketing.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Messages\Grand.Business.Messages.csproj" />
-		<ProjectReference Include="..\..\Business\Grand.Business.Storage\Grand.Business.Storage.csproj" />
-	</ItemGroup>
-
 
 </Project>

--- a/src/Web/Grand.Web.Store/Grand.Web.Store.csproj
+++ b/src/Web/Grand.Web.Store/Grand.Web.Store.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\Build\Grand.Common.props" />
+  <Import Project="..\..\Build\Grand.Host.props" />
 	<PropertyGroup>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<ServerGarbageCollection>true</ServerGarbageCollection>

--- a/src/Web/Grand.Web.Vendor/Grand.Web.Vendor.csproj
+++ b/src/Web/Grand.Web.Vendor/Grand.Web.Vendor.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <Import Project="..\..\Build\Grand.Common.props" />
+    <Import Project="..\..\Build\Grand.Host.props" />
     <PropertyGroup>
         <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
         <ServerGarbageCollection>false</ServerGarbageCollection>

--- a/src/Web/Grand.Web/Grand.Web.csproj
+++ b/src/Web/Grand.Web/Grand.Web.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<Import Project="..\..\Build\Grand.Common.props" />
+	<Import Project="..\..\Build\Grand.Host.props" />
 	<PropertyGroup>
 		<!--The common language runtime (CLR) supports two types of garbage collection:
 		workstation garbage collection, which is available on all systems, and server garbage collection,


### PR DESCRIPTION
Type: **feature**

## Issue

`Grand.Web.Common` referenced all nine `Grand.Business.*` implementations alongside the contracts in `Grand.Business.Core`, while using zero types from any of them — there is not a single `using` of an implementation namespace anywhere in the project.

Because `Grand.Web` builds on `Grand.Web.Common`, `Grand.Web.AdminShared` builds on it, and `src/Build/Grand.Plugin.props` points **every plugin** at it, the shared web layer and each plugin compiled against the entire business layer for no reason. This is the coupling node described in the architecture notes as the largest in the solution.

Reproduce: `dotnet list src/Web/Grand.Web.Common/Grand.Web.Common.csproj reference` — twelve project references, nine of them implementations that nothing in the project links.

## Solution

The references were never about code. Each implementation carries a `Startup/StartupApplication.cs`, and `TypeSearcher` discovers `IStartupApplication` by walking the assemblies present in the `AppDomain` — so an implementation the host does not reference is never loaded and its services are never registered. That makes the host, as the composition root, where they belong.

- New `src/Build/Grand.Host.props` holds the list once, mirroring what `Grand.Plugin.props` already does for plugins, with a comment stating why removing an entry costs an entire business area's DI registration while nothing fails at build time.
- The four hosts (`Grand.Web`, `Grand.Web.Admin`, `Grand.Web.Store`, `Grand.Web.Vendor`) import it.
- The nine references are gone from `Grand.Web.Common`, which drops from twelve project references to three.

Each host's dependency closure is unchanged — the same nine assemblies are referenced, copied to output and written to `deps.json`. Only the compile-time graph shrinks.

**One consequence was not obvious and is worth review attention.** Those references were also an implicit version floor for `Grand.Web.AdminShared`: the `Scryber.Core` graph outvoted `elFinder.Net.*` 1.5.0, and once they were gone elFinder won with `Newtonsoft.Json` 11.0.2 (GHSA-5crp-9r3c-p9vr) and `SixLabors.ImageSharp` 2.0.0 (GHSA-2cmq-823j-5qj8 and six more) — eight new NU1903/NU1902 warnings. The floor is now stated explicitly next to the existing `Microsoft.AspNetCore.Http` pin, which exists for the same package graph and the same reason. Both resolve back to exactly what the accident used to produce: 13.0.3 and 3.1.12.

Side effect worth naming: `SixLabors.ImageSharp` is now a direct reference of `Grand.Web.AdminShared` rather than only transitive. Nothing changes in the shipped artifacts or the licensing position, but it partly reverses #763. The real fix remains replacing elFinder.

## Breaking changes

None. No public interface, view model, widget zone or plugin system name changes. Plugins are unaffected at build and at runtime: `Grand.Plugin.props` references `Grand.Web.Common` with `ExcludeAssets="all"`, and no plugin, module or test project uses an implementation namespace — every `Grand.Business.*.Tests` and `Grand.Mapping.Tests` references its implementation project directly.

## Testing

1. Delete `src/Web/Grand.Web/Plugins` and `src/Web/Grand.Web/Modules` — these are fixed `OutputPath` directories that the build never cleans, so stale copies otherwise mask the result.
2. `dotnet build ./GrandNode.sln` — succeeds; one pre-existing `CS0618` warning, no NU19xx.
3. `dotnet list src/Web/Grand.Web.Common/Grand.Web.Common.csproj reference` — three references, not twelve.
4. Confirm the host output is unchanged: each of the four `src/Web/*/bin/Debug/net10.0/` directories still contains ten `Grand.Business.*.dll` (nine implementations plus `Grand.Business.Core`).
5. Confirm the version floor held: `dotnet list src/Web/Grand.Web.AdminShared/Grand.Web.AdminShared.csproj package --include-transitive` shows `Newtonsoft.Json` 13.0.3 and `SixLabors.ImageSharp` 3.1.12.
6. Run the storefront on Kestrel and request `/`, a category page, and `/search?q=book` — all 200. This is the real test: a `StartupApplication` that stopped being discovered fails on a request, not at startup.
7. Request `/admin/login`, `/vendor/login` and `/store/login` — all 200.
8. `dotnet test` on `Grand.Web.Common.Tests` (15), `Grand.Infrastructure.Tests` (94) and `Grand.Mapping.Tests` (238) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)