### PR TITLE
Take the admin theme switch out of the store panel

### DIFF
--- a/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/GeneralCommon.TabStoreInformationSettings.cshtml
+++ b/src/Web/Grand.Web.Store/Areas/Store/Views/Setting/Partials/GeneralCommon.TabStoreInformationSettings.cshtml
@@ -85,18 +85,6 @@
 </div>
 <div class="form-group">
     <div class="col-8 col-md-4 col-sm-4 text-right">
-        <admin-label asp-for="StoreInformationSettings.AllowToSelectAdminTheme" class="control-label"/>
-    </div>
-    <div class="col-4 col-md-8 col-sm-8">
-        <label class="mt-checkbox mt-checkbox-outline control control-checkbox">
-            <admin-input asp-for="StoreInformationSettings.AllowToSelectAdminTheme"/>
-            <div class="control__indicator"></div>
-        </label>
-        <span asp-validation-for="StoreInformationSettings.AllowToSelectAdminTheme"></span>
-    </div>
-</div>
-<div class="form-group">
-    <div class="col-8 col-md-4 col-sm-4 text-right">
         <admin-label asp-for="StoreInformationSettings.LogoPictureId" class="control-label"/>
     </div>
     <div class="col-4 col-md-8 col-sm-8">

--- a/src/Web/Grand.Web.Store/Controllers/SettingController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/SettingController.cs
@@ -128,7 +128,15 @@ public class SettingController(
         var storeScope = GetStoreScope();
 
         var storeInformationSettings = await settingService.LoadSetting<StoreInformationSettings>(storeScope);
+
+        // Preserve the admin theme selection - store owners cannot change it
+        var allowToSelectAdminTheme = storeInformationSettings.AllowToSelectAdminTheme;
+
         storeInformationSettings = model.StoreInformationSettings.ToEntity(storeInformationSettings);
+
+        // Restore the preserved admin theme selection
+        storeInformationSettings.AllowToSelectAdminTheme = allowToSelectAdminTheme;
+
         await settingService.SaveSetting(storeInformationSettings, storeScope);
 
         var dateTimeSettings = await settingService.LoadSetting<DateTimeSettings>(storeScope);


### PR DESCRIPTION
## What

Removes the **Allow to select admin theme** option from the store panel's general settings (Store information tab) in `Grand.Web.Store`.

- Dropped the `StoreInformationSettings.AllowToSelectAdminTheme` input from `Areas/Store/Views/Setting/Partials/GeneralCommon.TabStoreInformationSettings.cshtml`.
- `SettingController.GeneralCommon` (POST) snapshots the stored value before `ToEntity` and restores it after, so saving the tab no longer writes `false` into the store scope from the now-missing form field.

## Why

The flag drives `StoreThemeContext` / `AdminThemeContext` — panel chrome rather than storefront content — so it is admin-managed. This follows the preserve/restore lock pattern already used for the media file-manager fields in the same controller. The option stays fully manageable in `Grand.Web.Admin`.

## Testing

- `dotnet build src/Web/Grand.Web.Store/Grand.Web.Store.csproj` — succeeded, 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)