### PR TITLE
Batch inventory stock writes into single repository updates

### DIFF
--- a/src/Business/Grand.Business.Catalog/Services/Products/InventoryManageService.cs
+++ b/src/Business/Grand.Business.Catalog/Services/Products/InventoryManageService.cs
@@ -62,8 +62,6 @@ public class InventoryManageService : IInventoryManageService
                 pwi.ReservedQuantity = 0;
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
-
             product.StockQuantity = product.ProductWarehouseInventory.Sum(x => x.StockQuantity);
             product.ReservedQuantity = product.ProductWarehouseInventory.Sum(x => x.ReservedQuantity);
             await UpdateStockProduct(product);
@@ -90,7 +88,6 @@ public class InventoryManageService : IInventoryManageService
                 combination.ReservedQuantity = 0;
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
         else
         {
@@ -107,7 +104,6 @@ public class InventoryManageService : IInventoryManageService
             combination.ReservedQuantity = combination.WarehouseInventory.Sum(x => x.ReservedQuantity);
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
         product.StockQuantity = product.ProductAttributeCombinations.Sum(x => x.StockQuantity);
@@ -187,7 +183,6 @@ public class InventoryManageService : IInventoryManageService
                     pwi.ReservedQuantity = 0;
 
                 await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
-                await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
                 break;
             }
             case ManageInventoryMethod.ManageStock:
@@ -213,8 +208,6 @@ public class InventoryManageService : IInventoryManageService
                     product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
                     await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-                    await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
-
                     await UpdateStockProduct(product);
                 }
                 else
@@ -236,7 +229,6 @@ public class InventoryManageService : IInventoryManageService
                     product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
                     await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-                    await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
                     await UpdateStockProduct(product);
                 }
 
@@ -310,10 +302,11 @@ public class InventoryManageService : IInventoryManageService
                         product.DisableBuyButton = true;
                         product.LowStock = true;
 
-                        await _productRepository.UpdateField(product.Id, x => x.DisableBuyButton,
-                            product.DisableBuyButton);
-                        await _productRepository.UpdateField(product.Id, x => x.LowStock, product.LowStock);
-                        await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+                        await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                            UpdateBuilder<Product>.Create()
+                                .Set(x => x.DisableBuyButton, product.DisableBuyButton)
+                                .Set(x => x.LowStock, product.LowStock));
+
                         //cache
                         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, product.Id));
 
@@ -325,9 +318,10 @@ public class InventoryManageService : IInventoryManageService
                         product.Published = false;
                         product.LowStock = true;
 
-                        await _productRepository.UpdateField(product.Id, x => x.Published, product.Published);
-                        await _productRepository.UpdateField(product.Id, x => x.LowStock, product.LowStock);
-                        await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+                        await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                            UpdateBuilder<Product>.Create()
+                                .Set(x => x.Published, product.Published)
+                                .Set(x => x.LowStock, product.LowStock));
 
                         //cache
                         await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, product.Id));
@@ -350,10 +344,10 @@ public class InventoryManageService : IInventoryManageService
                             product.DisableBuyButton = false;
                             product.LowStock = product.MinStockQuantity <= prevStockQuantity;
 
-                            await _productRepository.UpdateField(product.Id, x => x.DisableBuyButton,
-                                product.DisableBuyButton);
-                            await _productRepository.UpdateField(product.Id, x => x.LowStock, product.LowStock);
-                            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+                            await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                                UpdateBuilder<Product>.Create()
+                                    .Set(x => x.DisableBuyButton, product.DisableBuyButton)
+                                    .Set(x => x.LowStock, product.LowStock));
 
                             //cache
                             await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, product.Id));
@@ -366,9 +360,10 @@ public class InventoryManageService : IInventoryManageService
                             product.Published = true;
                             product.LowStock = product.MinStockQuantity < prevStockQuantity;
 
-                            await _productRepository.UpdateField(product.Id, x => x.Published, product.Published);
-                            await _productRepository.UpdateField(product.Id, x => x.LowStock, product.LowStock);
-                            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+                            await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                                UpdateBuilder<Product>.Create()
+                                    .Set(x => x.Published, product.Published)
+                                    .Set(x => x.LowStock, product.LowStock));
 
                             //cache
                             await _cacheBase.RemoveByPrefix(string.Format(CacheKey.PRODUCTS_BY_ID_KEY, product.Id));
@@ -465,7 +460,6 @@ public class InventoryManageService : IInventoryManageService
                 pwi.ReservedQuantity = 0;
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
         //cache
@@ -503,8 +497,8 @@ public class InventoryManageService : IInventoryManageService
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+            await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                UpdateBuilder<Product>.Create().Set(x => x.ReservedQuantity, product.ReservedQuantity));
         }
         else
         {
@@ -522,8 +516,8 @@ public class InventoryManageService : IInventoryManageService
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+            await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                UpdateBuilder<Product>.Create().Set(x => x.ReservedQuantity, product.ReservedQuantity));
         }
 
         //cache
@@ -567,7 +561,6 @@ public class InventoryManageService : IInventoryManageService
                 pwi.ReservedQuantity = 0;
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductWarehouseInventory, z => z.Id == pwi.Id, pwi);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
         //cache
@@ -601,8 +594,8 @@ public class InventoryManageService : IInventoryManageService
             product.ReservedQuantity = product.ProductAttributeCombinations.Sum(x => x.ReservedQuantity);
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+            await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+                UpdateBuilder<Product>.Create().Set(x => x.ReservedQuantity, product.ReservedQuantity));
         }
         else
         {
@@ -617,7 +610,6 @@ public class InventoryManageService : IInventoryManageService
             combination.ReservedQuantity = combination.WarehouseInventory.Sum(x => x.ReservedQuantity);
 
             await _productRepository.UpdateCollectionFieldItem(product.Id, x => x.ProductAttributeCombinations, z => z.Id == combination.Id, combination);
-            await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
         }
 
         //cache
@@ -704,14 +696,15 @@ public class InventoryManageService : IInventoryManageService
         if (product.ReservedQuantity < 0)
             product.ReservedQuantity = 0;
 
-        //update
-        await _productRepository.UpdateField(product.Id, x => x.StockQuantity, product.StockQuantity);
-        await _productRepository.UpdateField(product.Id, x => x.ReservedQuantity, product.ReservedQuantity);
-        await _productRepository.UpdateField(product.Id, x => x.LowStock,
-            (product.MinStockQuantity > 0 &&
-             product.MinStockQuantity >= product.StockQuantity - product.ReservedQuantity) ||
-            product.StockQuantity - product.ReservedQuantity <= 0);
-        await _productRepository.UpdateField(product.Id, x => x.UpdatedOnUtc, DateTime.UtcNow);
+        //update - one write, so the three stock fields never land out of step
+        await _productRepository.UpdateOneAsync(x => x.Id == product.Id,
+            UpdateBuilder<Product>.Create()
+                .Set(x => x.StockQuantity, product.StockQuantity)
+                .Set(x => x.ReservedQuantity, product.ReservedQuantity)
+                .Set(x => x.LowStock,
+                    (product.MinStockQuantity > 0 &&
+                     product.MinStockQuantity >= product.StockQuantity - product.ReservedQuantity) ||
+                    product.StockQuantity - product.ReservedQuantity <= 0));
 
 
         //cache


### PR DESCRIPTION
Type: **bugfix**

## Issue
Inventory stock changes are written one field at a time. `UpdateStockProduct` issues four separate `UpdateField` calls (`StockQuantity`, `ReservedQuantity`, `LowStock`, `UpdatedOnUtc`), the four `LowStockActivity` branches in `AdjustReserved` issue three each, and eight `UpdateCollectionFieldItem` calls are each followed by a redundant `UpdatedOnUtc` write that the repository already performs.

Two consequences:

1. **Torn reads and torn state.** Each `UpdateField` is its own MongoDB update. A concurrent reader between them observes `StockQuantity` already decremented while `ReservedQuantity` and `LowStock` still hold pre-change values. If the process dies mid-sequence, the document stays in that inconsistent state — nothing rolls it back. The `LowStockActivity` branches are the sharpest case: a product can persist as unpublished while `LowStock` is still `false`, or with `DisableBuyButton` set and `LowStock` unset.
2. **Wasted round trips.** A single stock adjustment costs up to four round trips where one suffices. On order placement, shipment booking, and order cancellation this multiplies across every line item, and bundle/associated products recurse into the same paths.

To reproduce (1): place an order for a product with `MinStockQuantity` configured so the low-stock branch fires, and read the product document concurrently. Between the writes it reports `Published: false` with `LowStock: false`.

## Solution
Collapse each field-at-a-time sequence into a single `UpdateOneAsync` + `UpdateBuilder<Product>`, so fields that are only meaningful together commit together:

- `UpdateStockProduct` — 4 writes to 1. `StockQuantity`, `ReservedQuantity`, and `LowStock` now land atomically.
- The four `LowStockActivity` branches in `AdjustReserved` — 3 writes to 1 each. `Published`/`DisableBuyButton` and `LowStock` commit as a pair.
- The two combination paths (`ReserveInventoryCombination`, `UnblockReservedInventoryCombination`) — 3 writes to 2. The positional subdocument update cannot be merged into `UpdateBuilder`, which only exposes `Set` on top-level members.
- Eight redundant `UpdateField(x => x.UpdatedOnUtc, ...)` calls removed. `UpdateCollectionFieldItem` and `UpdateOneAsync` already stamp `UpdatedOnUtc` and `UpdatedBy` through `IAuditInfoProvider`, whose implementation returns `DateTime.UtcNow` — the same value the removed calls wrote.

Roughly 30 repository calls down to 14. All computed values are identical to before; this is a write-batching change, not a logic change.

**What this does not fix:** the lost-update race. Quantities are still derived by read-modify-write on the in-memory `Product`, so two concurrent adjustments on the same product can still overwrite each other. `IRepository<T>.IncField` (atomic `$inc`) exists but has exactly one caller in the whole business layer (`ProductService.cs:370`), and `UpdateBuilder<T>` has no `Inc` at all, so multi-field atomic increment is not currently expressible. That is a separate change and is left as follow-up.

## Breaking changes
None. No public interface, view model, or persisted shape changes — `IInventoryManageService`, `IRepository<T>`, and `UpdateBuilder<T>` are untouched. The written field values are unchanged.

One behavioural edge worth noting: where an `UpdatedOnUtc` write was removed, it followed `UpdateCollectionFieldItem`, which filters on `ElemMatch`. If the in-memory product holds a warehouse entry or attribute combination that no longer exists in the stored document, that update is a no-op and `UpdatedOnUtc` is no longer stamped, whereas the separate write stamped it unconditionally. This affects only the audit timestamp, and only when in-memory and stored state have already diverged.

## Testing
1. `dotnet test src/Tests/Grand.Business.Catalog.Tests/Grand.Business.Catalog.Tests.csproj` — 354 passed, 1 skipped (`SearchProductsTest`, skipped before this change).
2. `dotnet test src/Tests/Grand.Business.Checkout.Tests/Grand.Business.Checkout.Tests.csproj` — 231 passed. Covers the order/shipment handlers that drive `AdjustReserved`, `BookReservedInventory`, and `ReverseBookedInventory`.
3. `dotnet test src/Tests/Grand.Data.Tests/Grand.Data.Tests.csproj` — 80 passed. Covers `UpdateOneAsync` and `UpdateCollectionFieldItem` for both the MongoDB and LiteDB repositories.
4. Manual, standard stock: set a product to Manage stock with `StockQuantity` 10 and `MinStockQuantity` 5, place an order for 6, and confirm the product document has `StockQuantity`, `ReservedQuantity`, and `LowStock` all consistent after a single write, with `UpdatedOnUtc` advanced.
5. Manual, multiple warehouses: enable `UseMultipleWarehouses`, reserve and then ship a quantity, and confirm `ProductWarehouseInventory` totals still roll up into the product-level `StockQuantity` and `ReservedQuantity`.
6. Manual, stock by attributes: on a product managed by attribute combinations, reserve then cancel an order and confirm the combination and product-level reserved quantities return to their starting values.

## Note on validation
The full-solution build could not be completed here: `dotnet build GrandNode.sln` fails with 52 `MSB3021`/`MSB3027` file-lock errors because a running IIS Express worker holds the `Grand.Web` output DLLs. These are copy failures, not compilation errors — zero compiler diagnostics were reported. `Grand.Business.Catalog` builds clean on its own with 0 warnings and 0 errors, as do all four test projects above.
