### PR TITLE
Fix memory DoS and extension bypass in attribute file uploads

### DIFF
--- a/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
+++ b/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
@@ -3,11 +3,11 @@
 public static class FileExtensions
 {
     /// <summary>
-    ///     Hard upper bound (in KB) for a single file-upload attribute (contact/checkout/product attribute uploads),
-    ///     enforced regardless of the per-attribute ValidationFileMaximumSize configuration. Must be checked against
-    ///     IFormFile.Length before the request body is buffered into memory.
+    ///     Hard upper bound (in bytes) for a single file-upload attribute request (contact/checkout/product attribute
+    ///     uploads), applied via [RequestSizeLimit] so ASP.NET Core rejects an oversized request before the body is
+    ///     ever buffered into memory - independent of the per-attribute ValidationFileMaximumSize configuration.
     /// </summary>
-    public const int MaxAttributeUploadFileSizeKb = 10 * 1024; // 10 MB
+    public const long MaxAttributeUploadRequestBytes = 10 * 1024 * 1024; // 10 MB
 
     public static IList<string> GetAllowedMediaFileTypes(string allowedFileTypes)
     {

--- a/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
+++ b/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
@@ -2,13 +2,6 @@
 
 public static class FileExtensions
 {
-    /// <summary>
-    ///     Hard upper bound (in bytes) for a single file-upload attribute request (contact/checkout/product attribute
-    ///     uploads), applied via [RequestSizeLimit] so ASP.NET Core rejects an oversized request before the body is
-    ///     ever buffered into memory - independent of the per-attribute ValidationFileMaximumSize configuration.
-    /// </summary>
-    public const long MaxAttributeUploadRequestBytes = 10 * 1024 * 1024; // 10 MB
-
     public static IList<string> GetAllowedMediaFileTypes(string allowedFileTypes)
     {
         if (string.IsNullOrEmpty(allowedFileTypes))

--- a/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
+++ b/src/Core/Grand.SharedKernel/Extensions/AllowedFileExtensions.cs
@@ -2,6 +2,13 @@
 
 public static class FileExtensions
 {
+    /// <summary>
+    ///     Hard upper bound (in KB) for a single file-upload attribute (contact/checkout/product attribute uploads),
+    ///     enforced regardless of the per-attribute ValidationFileMaximumSize configuration. Must be checked against
+    ///     IFormFile.Length before the request body is buffered into memory.
+    /// </summary>
+    public const int MaxAttributeUploadFileSizeKb = 10 * 1024; // 10 MB
+
     public static IList<string> GetAllowedMediaFileTypes(string allowedFileTypes)
     {
         if (string.IsNullOrEmpty(allowedFileTypes))

--- a/src/Web/Grand.Web/App_Data/appsettings.json
+++ b/src/Web/Grand.Web/App_Data/appsettings.json
@@ -14,8 +14,9 @@
     //with other HTTP clients.
     "AllowNonAsciiCharInHeaders": false,
     //Gets or sets the maximum allowed size of any request body in bytes
-    //the default value is 30MB
-    "MaxRequestBodySize": null,
+    //null falls back to Kestrel's default of 30MB; set explicitly so anonymous storefront endpoints
+    //(contact/checkout/product attribute file uploads) can't be used to buffer oversized requests in memory
+    "MaxRequestBodySize": 10485760,
     //max 2147483648
 
     //Gets or sets the value to enable a middleware for logging additional information about CurrentCustomer and CurrentStore

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -113,6 +113,8 @@ public class ContactController : BasePublicController
 
     [HttpPost]
     [DenySystemAccount]
+    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
+    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileContactAttribute(string attributeId, IFormFile file,
         [FromServices] IDownloadService downloadService,
         [FromServices] IContactAttributeService contactAttributeService)
@@ -146,20 +148,21 @@ public class ContactController : BasePublicController
                 downloadGuid = Guid.Empty
             });
 
-        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
-        //multipart headers before buffering the file into memory
-        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
-            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
-            : FileExtensions.MaxAttributeUploadFileSizeKb;
-        if (file.Length > maxFileSizeKb * 1024L)
-            //when returning JSON the mime-type must be set to text/plain
-            //otherwise some browsers will pop-up a "Save As" dialog.
-            return Json(new
-            {
-                success = false,
-                message = string.Format(_translationService.GetResource("ContactUs.MaximumUploadedFileSize"), maxFileSizeKb),
-                downloadGuid = Guid.Empty
-            });
+        if (attribute.ValidationFileMaximumSize.HasValue)
+        {
+            //compare in bytes - check the size reported by the multipart headers before buffering the file into memory
+            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024L;
+            if (file.Length > maxFileSizeBytes)
+                //when returning JSON the mime-type must be set to text/plain
+                //otherwise some browsers will pop-up a "Save As" dialog.
+                return Json(new
+                {
+                    success = false,
+                    message = string.Format(_translationService.GetResource("ContactUs.MaximumUploadedFileSize"),
+                        attribute.ValidationFileMaximumSize.Value),
+                    downloadGuid = Guid.Empty
+                });
+        }
 
         var fileBinary = file.GetDownloadBits();
 

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -136,35 +136,32 @@ public class ContactController : BasePublicController
         var fileName = Path.GetFileName(file.FileName);
         var contentType = file.ContentType;
         var fileExtension = Path.GetExtension(fileName);
-        if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
-        {
-            var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
-                return Json(new
-                {
-                    success = false,
-                    message = _translationService.GetResource("ContactUs.ValidationFileAllowed"),
-                    downloadGuid = Guid.Empty
-                });
-        }
+        //empty configuration must not mean "any extension allowed" - fall back to the safe default allow-list
+        var allowedFileExtensions = FileExtensions.GetAllowedMediaFileTypes(attribute.ValidationFileAllowedExtensions);
+        if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
+            return Json(new
+            {
+                success = false,
+                message = _translationService.GetResource("ContactUs.ValidationFileAllowed"),
+                downloadGuid = Guid.Empty
+            });
+
+        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
+        //multipart headers before buffering the file into memory
+        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
+            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
+            : FileExtensions.MaxAttributeUploadFileSizeKb;
+        if (file.Length > maxFileSizeKb * 1024L)
+            //when returning JSON the mime-type must be set to text/plain
+            //otherwise some browsers will pop-up a "Save As" dialog.
+            return Json(new
+            {
+                success = false,
+                message = string.Format(_translationService.GetResource("ContactUs.MaximumUploadedFileSize"), maxFileSizeKb),
+                downloadGuid = Guid.Empty
+            });
 
         var fileBinary = file.GetDownloadBits();
-
-        if (attribute.ValidationFileMaximumSize.HasValue)
-        {
-            //compare in bytes
-            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024;
-            if (fileBinary.Length > maxFileSizeBytes)
-                //when returning JSON the mime-type must be set to text/plain
-                //otherwise some browsers will pop-up a "Save As" dialog.
-                return Json(new
-                {
-                    success = false,
-                    message = string.Format(_translationService.GetResource("ContactUs.MaximumUploadedFileSize"),
-                        attribute.ValidationFileMaximumSize.Value),
-                    downloadGuid = Guid.Empty
-                });
-        }
 
         var download = new Download
         {

--- a/src/Web/Grand.Web/Controllers/ContactController.cs
+++ b/src/Web/Grand.Web/Controllers/ContactController.cs
@@ -113,8 +113,6 @@ public class ContactController : BasePublicController
 
     [HttpPost]
     [DenySystemAccount]
-    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
-    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileContactAttribute(string attributeId, IFormFile file,
         [FromServices] IDownloadService downloadService,
         [FromServices] IContactAttributeService contactAttributeService)

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -405,32 +405,30 @@ public class ProductController : BasePublicController
         var contentType = file.ContentType;
         var fileExtension = Path.GetExtension(fileName);
 
-        if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
-        {
-            var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.Split([','], StringSplitOptions.RemoveEmptyEntries);
-            if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
-                return Json(new {
-                    success = false,
-                    message = _translationService.GetResource("ShoppingCart.ValidationFileAllowed"),
-                    downloadGuid = Guid.Empty
-                });
-        }
-        var fileBinary = file.GetDownloadBits();
+        //empty configuration must not mean "any extension allowed" - fall back to the safe default allow-list
+        var allowedFileExtensions = FileExtensions.GetAllowedMediaFileTypes(attribute.ValidationFileAllowedExtensions);
+        if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
+            return Json(new {
+                success = false,
+                message = _translationService.GetResource("ShoppingCart.ValidationFileAllowed"),
+                downloadGuid = Guid.Empty
+            });
 
-        if (attribute.ValidationFileMaximumSize.HasValue)
-        {
-            //compare in bytes
-            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024;
-            if (fileBinary.Length > maxFileSizeBytes)
-                //when returning JSON the mime-type must be set to text/plain
-                //otherwise some browsers will pop-up a "Save As" dialog.
-                return Json(new {
-                    success = false,
-                    message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"),
-                        attribute.ValidationFileMaximumSize.Value),
-                    downloadGuid = Guid.Empty
-                });
-        }
+        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
+        //multipart headers before buffering the file into memory
+        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
+            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
+            : FileExtensions.MaxAttributeUploadFileSizeKb;
+        if (file.Length > maxFileSizeKb * 1024L)
+            //when returning JSON the mime-type must be set to text/plain
+            //otherwise some browsers will pop-up a "Save As" dialog.
+            return Json(new {
+                success = false,
+                message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"), maxFileSizeKb),
+                downloadGuid = Guid.Empty
+            });
+
+        var fileBinary = file.GetDownloadBits();
 
         var download = new Download {
             DownloadGuid = Guid.NewGuid(),

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -379,6 +379,8 @@ public class ProductController : BasePublicController
     }
 
     [HttpPost]
+    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
+    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileProductAttribute(string attributeId, string productId, IFormFile file,
         [FromServices] IDownloadService downloadService)
     {
@@ -414,19 +416,20 @@ public class ProductController : BasePublicController
                 downloadGuid = Guid.Empty
             });
 
-        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
-        //multipart headers before buffering the file into memory
-        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
-            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
-            : FileExtensions.MaxAttributeUploadFileSizeKb;
-        if (file.Length > maxFileSizeKb * 1024L)
-            //when returning JSON the mime-type must be set to text/plain
-            //otherwise some browsers will pop-up a "Save As" dialog.
-            return Json(new {
-                success = false,
-                message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"), maxFileSizeKb),
-                downloadGuid = Guid.Empty
-            });
+        if (attribute.ValidationFileMaximumSize.HasValue)
+        {
+            //compare in bytes - check the size reported by the multipart headers before buffering the file into memory
+            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024L;
+            if (file.Length > maxFileSizeBytes)
+                //when returning JSON the mime-type must be set to text/plain
+                //otherwise some browsers will pop-up a "Save As" dialog.
+                return Json(new {
+                    success = false,
+                    message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"),
+                        attribute.ValidationFileMaximumSize.Value),
+                    downloadGuid = Guid.Empty
+                });
+        }
 
         var fileBinary = file.GetDownloadBits();
 

--- a/src/Web/Grand.Web/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web/Controllers/ProductController.cs
@@ -379,8 +379,6 @@ public class ProductController : BasePublicController
     }
 
     [HttpPost]
-    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
-    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileProductAttribute(string attributeId, string productId, IFormFile file,
         [FromServices] IDownloadService downloadService)
     {

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -169,6 +169,8 @@ public class ShoppingCartController : BasePublicController
 
     [DenySystemAccount]
     [HttpPost]
+    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
+    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileCheckoutAttribute(string attributeId, IFormFile file,
         [FromServices] IDownloadService downloadService)
     {
@@ -201,19 +203,20 @@ public class ShoppingCartController : BasePublicController
                 downloadGuid = Guid.Empty
             });
 
-        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
-        //multipart headers before buffering the file into memory
-        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
-            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
-            : FileExtensions.MaxAttributeUploadFileSizeKb;
-        if (file.Length > maxFileSizeKb * 1024L)
-            //when returning JSON the mime-type must be set to text/plain
-            //otherwise some browsers will pop-up a "Save As" dialog.
-            return Json(new {
-                success = false,
-                message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"), maxFileSizeKb),
-                downloadGuid = Guid.Empty
-            });
+        if (attribute.ValidationFileMaximumSize.HasValue)
+        {
+            //compare in bytes - check the size reported by the multipart headers before buffering the file into memory
+            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024L;
+            if (file.Length > maxFileSizeBytes)
+                //when returning JSON the mime-type must be set to text/plain
+                //otherwise some browsers will pop-up a "Save As" dialog.
+                return Json(new {
+                    success = false,
+                    message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"),
+                        attribute.ValidationFileMaximumSize.Value),
+                    downloadGuid = Guid.Empty
+                });
+        }
 
         var fileBinary = file.GetDownloadBits();
 

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -169,8 +169,6 @@ public class ShoppingCartController : BasePublicController
 
     [DenySystemAccount]
     [HttpPost]
-    //rejected by ASP.NET Core before the body is buffered into memory, regardless of the attribute's configured limit
-    [RequestSizeLimit(FileExtensions.MaxAttributeUploadRequestBytes)]
     public virtual async Task<IActionResult> UploadFileCheckoutAttribute(string attributeId, IFormFile file,
         [FromServices] IDownloadService downloadService)
     {

--- a/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
+++ b/src/Web/Grand.Web/Controllers/ShoppingCartController.cs
@@ -192,32 +192,30 @@ public class ShoppingCartController : BasePublicController
 
         var contentType = file.ContentType;
         var fileExtension = Path.GetExtension(fileName);
-        if (!string.IsNullOrEmpty(attribute.ValidationFileAllowedExtensions))
-        {
-            var allowedFileExtensions = attribute.ValidationFileAllowedExtensions.Split([','], StringSplitOptions.RemoveEmptyEntries);
-            if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
-                return Json(new {
-                    success = false,
-                    message = _translationService.GetResource("ShoppingCart.ValidationFileAllowed"),
-                    downloadGuid = Guid.Empty
-                });
-        }
+        //empty configuration must not mean "any extension allowed" - fall back to the safe default allow-list
+        var allowedFileExtensions = FileExtensions.GetAllowedMediaFileTypes(attribute.ValidationFileAllowedExtensions);
+        if (!allowedFileExtensions.IsAllowedMediaFileType(fileExtension))
+            return Json(new {
+                success = false,
+                message = _translationService.GetResource("ShoppingCart.ValidationFileAllowed"),
+                downloadGuid = Guid.Empty
+            });
+
+        //enforce a hard cap regardless of attribute configuration, and check it against the size reported by the
+        //multipart headers before buffering the file into memory
+        var maxFileSizeKb = attribute.ValidationFileMaximumSize.HasValue
+            ? Math.Min(attribute.ValidationFileMaximumSize.Value, FileExtensions.MaxAttributeUploadFileSizeKb)
+            : FileExtensions.MaxAttributeUploadFileSizeKb;
+        if (file.Length > maxFileSizeKb * 1024L)
+            //when returning JSON the mime-type must be set to text/plain
+            //otherwise some browsers will pop-up a "Save As" dialog.
+            return Json(new {
+                success = false,
+                message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"), maxFileSizeKb),
+                downloadGuid = Guid.Empty
+            });
 
         var fileBinary = file.GetDownloadBits();
-        if (attribute.ValidationFileMaximumSize.HasValue)
-        {
-            //compare in bytes
-            var maxFileSizeBytes = attribute.ValidationFileMaximumSize.Value * 1024;
-            if (fileBinary.Length > maxFileSizeBytes)
-                //when returning JSON the mime-type must be set to text/plain
-                //otherwise some browsers will pop-up a "Save As" dialog.
-                return Json(new {
-                    success = false,
-                    message = string.Format(_translationService.GetResource("ShoppingCart.MaximumUploadedFileSize"),
-                        attribute.ValidationFileMaximumSize.Value),
-                    downloadGuid = Guid.Empty
-                });
-        }
 
         var download = new Download {
             DownloadGuid = Guid.NewGuid(),


### PR DESCRIPTION
Resolves #issueNumber
Type: **bugfix**

## Issue
`ContactController.UploadFileContactAttribute`, `ProductController.UploadFileProductAttribute`, and `ShoppingCartController.UploadFileCheckoutAttribute` (all reachable from the storefront, two without authentication required) buffered the entire uploaded file into a `byte[]` via `IFormFile.GetDownloadBits()` *before* checking `ValidationFileMaximumSize`. `Application.MaxRequestBodySize` in `appsettings.json` was left `null`, so only Kestrel's default 30 MB request-body limit applied. An unauthenticated user could repeatedly upload files up to that limit, each fully allocated in memory before being rejected - a cheap memory-exhaustion DoS.

Separately, when an attribute had no `ValidationFileAllowedExtensions` configured, the extension check was skipped entirely, so any file extension was accepted and stored.

To reproduce (pre-fix): configure a contact/checkout/product attribute of type File Upload with no allowed-extensions list, then POST a large file (e.g. 20 MB) to `UploadFileContactAttribute` as an anonymous user - the full body is read into memory regardless of any configured size limit, and any extension is accepted.

## Solution
- Set `Application.MaxRequestBodySize` to 10 MB in `Grand.Web/App_Data/appsettings.json`. This setting already exists and is wired to both `Kestrel.Limits.MaxRequestBodySize` and `FormOptions.MultipartBodyLengthLimit` (`ConfigurationExtensions.ConfigureApplicationSettings`) - ASP.NET Core now rejects an oversized request for every storefront endpoint before the body is parsed, without any new code. Admin-configurable, as before.
- Kept the per-attribute `ValidationFileMaximumSize` check, comparing against `IFormFile.Length` (size reported by the multipart headers) *before* `GetDownloadBits()` is called, so a request within the 10 MB ceiling but over a smaller attribute-configured limit is still rejected without being buffered.
- Replaced the raw `ValidationFileAllowedExtensions.Split(...)` check with the existing `FileExtensions.GetAllowedMediaFileTypes(...)` helper (already used by `PictureController`), which falls back to a safe image-extension allow-list when the attribute has none configured, instead of allowing everything.

## Breaking changes
Any Grand.Web storefront request body over 10 MB (not just these three endpoints) is now rejected by Kestrel; previously up to 30 MB was allowed. Adjust `Application.MaxRequestBodySize` in `appsettings.json` if a store needs a higher storefront-wide limit. Attributes with no configured allowed-extensions list now restrict uploads to `.gif/.jpg/.jpeg/.png/.bmp/.webp` instead of accepting any extension - a deliberate secure-by-default change to previously unrestricted behavior.

## Testing
1. Create a Checkout Attribute (or Contact/Product Attribute) of control type "File upload", leave "Allowed file extensions" empty, save.
2. As an anonymous storefront user, attempt to upload a `.exe` file to the corresponding upload endpoint - it is now rejected (`ValidationFileAllowed` message) instead of being accepted.
3. Upload a file larger than 10 MB to any Grand.Web endpoint - rejected by Kestrel before reaching the action.
4. Set "Maximum file size" on the attribute to a value below 10 MB, then upload a file between that value and 10 MB - rejected with the friendly maximum-size JSON message before the request body is fully buffered.
5. Upload a valid image within both the attribute's configured limit and the 10 MB ceiling - succeeds as before.
