### PR TITLE
fix: storefront category/brand/collection page crashes when PageSizeOptions is empty

### DIFF
--- a/src/Web/Grand.Web/Features/Handlers/Catalog/GetViewSortSizeOptionsHandler.cs
+++ b/src/Web/Grand.Web/Features/Handlers/Catalog/GetViewSortSizeOptionsHandler.cs
@@ -38,7 +38,6 @@ public class GetViewSortSizeOptionsHandler : IRequestHandler<GetViewSortSizeOpti
 
     private void PrepareSortingOptions(GetViewSortSizeOptions request)
     {
-        ArgumentNullException.ThrowIfNull(request.PageSizeOptions);
         ArgumentNullException.ThrowIfNull(request.Command);
 
         var allDisabled = _catalogSettings.ProductSortingEnumDisabled.Count ==


### PR DESCRIPTION
## Summary
- Fixes an `ArgumentNullException` thrown on the storefront whenever a Category/Brand/Collection/Vendor/ProductTag's admin **Page size options** field is left empty.
- Root cause: `GetViewSortSizeOptionsHandler.PrepareSortingOptions()` had a stray `ArgumentNullException.ThrowIfNull(request.PageSizeOptions)` guard, even though that method never reads `PageSizeOptions`. The actual consumer, `PreparePageSizeOptions()`, already handles `null`/empty correctly and falls back to the entity's default page size.

## Change
- Removed the misplaced guard in `GetViewSortSizeOptionsHandler.PrepareSortingOptions`.

## Testing
- `dotnet build src/Web/Grand.Web/Grand.Web.csproj` — succeeded, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)