### PR TITLE
Add 2.4 migration to rename 'Staff' customer group to 'Store manager'

### DIFF
--- a/src/Modules/Grand.Module.Migration/Migrations/2.4/MigrationUpdateStoreManagerCustomerGroup.cs
+++ b/src/Modules/Grand.Module.Migration/Migrations/2.4/MigrationUpdateStoreManagerCustomerGroup.cs
@@ -1,0 +1,57 @@
+using Grand.Data;
+using Grand.Domain.Customers;
+using Grand.Infrastructure.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Grand.Module.Migration.Migrations._2._4;
+
+/// <summary>
+///     Renames the "Staff" system customer group to "Store manager", matching the earlier rename of
+///     <see cref="SystemCustomerGroupNames.StoreManager" /> (previously <c>Staff</c>). Installations that
+///     existed before that rename still have a <see cref="CustomerGroup" /> document with
+///     SystemName "Staff", seeded by the old installer. Code now looks up the store-manager group by
+///     <see cref="SystemCustomerGroupNames.StoreManager" />, so an un-migrated installation silently loses
+///     that group. This brings the existing document's SystemName (and, if untouched by an operator, its
+///     display Name) in line with the current naming.
+/// </summary>
+public class MigrationUpdateStoreManagerCustomerGroup : IMigration
+{
+    public int Priority => 1;
+    public DbVersion Version => new(2, 4);
+    public Guid Identity => new("3367B869-FA18-4E8F-8721-3FFF82F35D50");
+    public string Name => "Rename 'Staff' customer group to 'Store manager' (StoreManager) 2.4";
+
+    /// <summary>
+    ///     Upgrade process
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    /// <returns></returns>
+    public bool UpgradeProcess(IServiceProvider serviceProvider)
+    {
+        var customerGroupRepository = serviceProvider.GetRequiredService<IRepository<CustomerGroup>>();
+        var logService = serviceProvider.GetRequiredService<ILogger<MigrationUpdateStoreManagerCustomerGroup>>();
+
+        try
+        {
+            var staffGroup = customerGroupRepository.Table.FirstOrDefault(x => x.SystemName == "Staff");
+            if (staffGroup == null) return true;
+
+            staffGroup.SystemName = SystemCustomerGroupNames.StoreManager;
+            if (staffGroup.Name == "Staff")
+                staffGroup.Name = "Store manager";
+
+            customerGroupRepository.Update(staffGroup);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logService.LogError(ex, "UpgradeProcess - MigrationUpdateStoreManagerCustomerGroup (2.4)");
+        }
+        catch (SystemException ex)
+        {
+            logService.LogError(ex, "UpgradeProcess - MigrationUpdateStoreManagerCustomerGroup (2.4)");
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Resolves #issueNumber
Type: **bugfix**

## Issue
Before commit c2d7f7b6a ("Grand.Web.Store – A Store Management Module #570"), the installer seeded the
built-in customer group with `Name = "Staff"` and `SystemName = SystemCustomerGroupNames.Staff` ("Staff").
That commit renamed the system name to `StoreManager` and the display name to "Store manager" for **new**
installations, but existing installations still have the old `CustomerGroup` document in their database
with `SystemName == "Staff"`. Since the codebase now resolves the store-manager group via
`SystemCustomerGroupNames.StoreManager`, any code path that looks the group up by system name (store-manager
permission checks, admin group assignment, etc.) silently fails to find it on an un-migrated, upgraded
installation.

## Solution
Added `MigrationUpdateStoreManagerCustomerGroup`, a `2.4` upgrade migration that finds the existing
`CustomerGroup` with `SystemName == "Staff"` and updates it to `SystemName == "StoreManager"`, also updating
its display `Name` to "Store manager" if the operator hasn't already customized it. The migration is a no-op
if no such group exists (fresh installs) and is idempotent (re-running finds nothing once the rename has
applied, since the lookup is by the old system name).

## Breaking changes
None. This only corrects data left behind by an earlier code rename; the target state ("StoreManager" /
"Store manager") already matches what fresh installations get.

## Testing
1. On a database from before the "Staff" → "StoreManager" rename (or manually seed a `CustomerGroup` with
   `SystemName = "Staff"`, `Name = "Staff"`), run the application so migrations execute.
2. Confirm the `CustomerGroup` document now has `SystemName = "StoreManager"` and `Name = "Store manager"`.
3. Restart the application again and confirm the migration does not run twice (check the migration log /
   `Identity` record) and the document is unchanged.
4. Confirm store-manager permission/group lookups (e.g. assigning a customer to the "Store manager" group in
   Admin → Customers → Customer groups) work as expected.
