### PR TITLE
fix: remove unreachable IsStoreManager branches from Admin controllers

### DIFF
--- a/src/Web/Grand.Web.Admin/Controllers/CourseController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CourseController.cs
@@ -1,6 +1,5 @@
 ﻿using Grand.Business.Core.Extensions;
 using Grand.Business.Core.Interfaces.Catalog.Products;
-using Grand.Business.Core.Interfaces.Common.Directory;
 using Grand.Business.Core.Interfaces.Common.Localization;
 using Grand.Business.Core.Interfaces.Marketing.Courses;
 using Grand.Domain.Permissions;
@@ -27,7 +26,6 @@ public class CourseController : BaseAdminController
     private readonly ICourseService _courseService;
     private readonly ICourseSubjectService _courseSubjectService;
     private readonly ICourseViewModelService _courseViewModelService;
-    private readonly IGroupService _groupService;
     private readonly ILanguageService _languageService;
 
     private readonly ITranslationService _translationService;
@@ -41,8 +39,7 @@ public class CourseController : BaseAdminController
         ICourseLessonService courseLessonService,
         ICourseViewModelService courseViewModelService,
         IContextAccessor contextAccessor,
-        ILanguageService languageService,
-        IGroupService groupService)
+        ILanguageService languageService)
     {
         _translationService = translationService;
         _courseLevelService = courseLevelService;
@@ -52,7 +49,6 @@ public class CourseController : BaseAdminController
         _courseViewModelService = courseViewModelService;
         _contextAccessor = contextAccessor;
         _languageService = languageService;
-        _groupService = groupService;
     }
 
 
@@ -155,9 +151,6 @@ public class CourseController : BaseAdminController
     {
         if (ModelState.IsValid)
         {
-            if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-                model.Stores = [_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId];
-
             var course = await _courseViewModelService.InsertCourseModel(model);
             Success(_translationService.GetResource("Admin.Courses.Course.Added"));
             return continueEditing ? RedirectToAction("Edit", new { id = course.Id }) : RedirectToAction("List");
@@ -176,21 +169,6 @@ public class CourseController : BaseAdminController
         if (course == null)
             //No course found with the specified id
             return RedirectToAction("List");
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-        {
-            if (!course.LimitedToStores || (course.LimitedToStores &&
-                                            course.Stores.Contains(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId) &&
-                                            course.Stores.Count > 1))
-            {
-                Warning(_translationService.GetResource("Admin.Courses.Course.Permissions"));
-            }
-            else
-            {
-                if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                    return RedirectToAction("List");
-            }
-        }
 
         var model = course.ToModel();
         //locales
@@ -220,15 +198,8 @@ public class CourseController : BaseAdminController
             //No course found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = course.Id });
-
         if (ModelState.IsValid)
         {
-            if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-                model.Stores = [_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId];
-
             course = await _courseViewModelService.UpdateCourseModel(course, model);
 
             Success(_translationService.GetResource("Admin.Courses.Course.Updated"));
@@ -257,10 +228,6 @@ public class CourseController : BaseAdminController
         if (course == null)
             //No course found with the specified id
             return RedirectToAction("List");
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = course.Id });
 
         if (ModelState.IsValid)
         {
@@ -394,21 +361,6 @@ public class CourseController : BaseAdminController
             //No course found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-        {
-            if (!course.LimitedToStores || (course.LimitedToStores &&
-                                            course.Stores.Contains(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId) &&
-                                            course.Stores.Count > 1))
-            {
-                Warning(_translationService.GetResource("Admin.Courses.Course.Permissions"));
-            }
-            else
-            {
-                if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                    return RedirectToAction("List");
-            }
-        }
-
         var model = await _courseViewModelService.PrepareCourseLessonModel(courseId);
 
         return View(model);
@@ -423,21 +375,6 @@ public class CourseController : BaseAdminController
         if (course == null)
             //No course found with the specified id
             return RedirectToAction("List");
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-        {
-            if (!course.LimitedToStores || (course.LimitedToStores &&
-                                            course.Stores.Contains(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId) &&
-                                            course.Stores.Count > 1))
-            {
-                Warning(_translationService.GetResource("Admin.Courses.Course.Permissions"));
-            }
-            else
-            {
-                if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                    return RedirectToAction("List");
-            }
-        }
 
         if (ModelState.IsValid)
         {
@@ -468,21 +405,6 @@ public class CourseController : BaseAdminController
             //No course found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-        {
-            if (!course.LimitedToStores || (course.LimitedToStores &&
-                                            course.Stores.Contains(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId) &&
-                                            course.Stores.Count > 1))
-            {
-                Warning(_translationService.GetResource("Admin.Courses.Course.Permissions"));
-            }
-            else
-            {
-                if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                    return RedirectToAction("List");
-            }
-        }
-
         var model = lesson.ToModel();
         model = await _courseViewModelService.PrepareCourseLessonModel(lesson.CourseId, model);
         return View(model);
@@ -503,9 +425,6 @@ public class CourseController : BaseAdminController
             //No category found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = course.Id });
         if (ModelState.IsValid)
         {
             lesson = await _courseViewModelService.UpdateCourseLessonModel(lesson, model);
@@ -541,9 +460,6 @@ public class CourseController : BaseAdminController
             //No category found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!course.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = course.Id });
         await _courseViewModelService.DeleteCourseLesson(lesson);
         Success(_translationService.GetResource("Admin.Courses.Course.Lesson.Deleted"));
 

--- a/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
@@ -696,6 +696,8 @@ public class CustomerController : BaseAdminController
         var model = new OrderListModel {
             CustomerId = customerId
         };
+        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
+            model.StoreId = _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId;
 
         var (orderModels, totalCount) =
             await orderViewModelService.PrepareOrderModel(model, command.Page, command.PageSize);
@@ -720,6 +722,13 @@ public class CustomerController : BaseAdminController
         var order = await orderService.GetOrderById(orderId);
         if (order == null)
             throw new ArgumentException("No order found with the specified id");
+
+        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer) &&
+            order.StoreId != _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId)
+            return Json(new DataSourceResult {
+                Data = null,
+                Total = 0
+            });
 
         var ordermodel = new OrderModel();
         await orderViewModelService.PrepareOrderDetailsModel(ordermodel, order);

--- a/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/CustomerController.cs
@@ -696,8 +696,6 @@ public class CustomerController : BaseAdminController
         var model = new OrderListModel {
             CustomerId = customerId
         };
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            model.StoreId = _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId;
 
         var (orderModels, totalCount) =
             await orderViewModelService.PrepareOrderModel(model, command.Page, command.PageSize);
@@ -722,13 +720,6 @@ public class CustomerController : BaseAdminController
         var order = await orderService.GetOrderById(orderId);
         if (order == null)
             throw new ArgumentException("No order found with the specified id");
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer) &&
-            order.StoreId != _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId)
-            return Json(new DataSourceResult {
-                Data = null,
-                Total = 0
-            });
 
         var ordermodel = new OrderModel();
         await orderViewModelService.PrepareOrderDetailsModel(ordermodel, order);

--- a/src/Web/Grand.Web.Admin/Controllers/DiscountController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/DiscountController.cs
@@ -35,7 +35,6 @@ public class DiscountController : BaseAdminController
         ITranslationService translationService,
         IContextAccessor contextAccessor,
         IDateTimeService dateTimeService,
-        IGroupService groupService,
         IDiscountProviderLoader discountProviderLoader,
         IMediator mediator)
     {
@@ -44,7 +43,6 @@ public class DiscountController : BaseAdminController
         _translationService = translationService;
         _contextAccessor = contextAccessor;
         _dateTimeService = dateTimeService;
-        _groupService = groupService;
         _discountProviderLoader = discountProviderLoader;
         _mediator = mediator;
     }
@@ -58,7 +56,6 @@ public class DiscountController : BaseAdminController
     private readonly ITranslationService _translationService;
     private readonly IContextAccessor _contextAccessor;
     private readonly IDateTimeService _dateTimeService;
-    private readonly IGroupService _groupService;
     private readonly IDiscountProviderLoader _discountProviderLoader;
     private readonly IMediator _mediator;
 
@@ -110,9 +107,6 @@ public class DiscountController : BaseAdminController
     {
         if (ModelState.IsValid)
         {
-            if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-                model.Stores = [_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId];
-
             var discount = await _discountViewModelService.InsertDiscountModel(model);
             Success(_translationService.GetResource("admin.marketing.discounts.Added"));
             return continueEditing ? RedirectToAction("Edit", new { id = discount.Id }) : RedirectToAction("List");
@@ -133,21 +127,6 @@ public class DiscountController : BaseAdminController
             //No discount found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-        {
-            if (!discount.LimitedToStores || (discount.LimitedToStores &&
-                                              discount.Stores.Contains(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId) &&
-                                              discount.Stores.Count > 1))
-            {
-                Warning(_translationService.GetResource("admin.marketing.discounts.Permissions"));
-            }
-            else
-            {
-                if (!discount.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                    return RedirectToAction("List");
-            }
-        }
-
         var model = discount.ToModel(_dateTimeService);
         await _discountViewModelService.PrepareDiscountModel(model, discount);
 
@@ -164,15 +143,8 @@ public class DiscountController : BaseAdminController
             //No discount found with the specified id
             return RedirectToAction("List");
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!discount.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = discount.Id });
-
         if (ModelState.IsValid)
         {
-            if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-                model.Stores = [_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId];
-
             discount = await _discountViewModelService.UpdateDiscountModel(discount, model);
             Success(_translationService.GetResource("admin.marketing.discounts.Updated"));
             if (continueEditing)
@@ -200,10 +172,6 @@ public class DiscountController : BaseAdminController
         if (discount == null)
             //No discount found with the specified id
             return RedirectToAction("List");
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            if (!discount.AccessToEntityByStore(_contextAccessor.WorkContext.CurrentCustomer.StaffStoreId))
-                return RedirectToAction("Edit", new { id = discount.Id });
 
         var usageHistory = await _mediator.Send(new GetDiscountUsageHistoryQuery { DiscountId = discount.Id });
         if (usageHistory.Count > 0)

--- a/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/HomeController.cs
@@ -53,8 +53,6 @@ public class HomeController : BaseAdminController
         var model = new DashboardActivityModel();
 
         var storeId = string.Empty;
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            storeId = _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId;
 
         model.OrdersPending =
             (await _orderReportService.GetOrderAverageReportLine(storeId, os: (int)OrderStatusSystem.Pending))
@@ -136,9 +134,6 @@ public class HomeController : BaseAdminController
     {
         if (storeid != null)
             storeid = storeid.Trim();
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            returnUrl = Url.Action("Index", "Home", new { area = Constants.AreaAdmin });
 
         var store = await _storeService.GetStoreById(storeid);
         if (store != null || storeid == "")

--- a/src/Web/Grand.Web.Admin/Controllers/NewsLetterSubscriptionController.cs
+++ b/src/Web/Grand.Web.Admin/Controllers/NewsLetterSubscriptionController.cs
@@ -20,7 +20,6 @@ namespace Grand.Web.Admin.Controllers;
 public class NewsLetterSubscriptionController : BaseAdminController
 {
     private readonly IDateTimeService _dateTimeService;
-    private readonly IGroupService _groupService;
     private readonly INewsletterCategoryService _newsletterCategoryService;
     private readonly INewsLetterSubscriptionService _newsLetterSubscriptionService;
     private readonly IStoreService _storeService;
@@ -32,7 +31,6 @@ public class NewsLetterSubscriptionController : BaseAdminController
         IDateTimeService dateTimeService,
         ITranslationService translationService,
         IStoreService storeService,
-        IGroupService groupService,
         IContextAccessor contextAccessor)
     {
         _newsLetterSubscriptionService = newsLetterSubscriptionService;
@@ -40,7 +38,6 @@ public class NewsLetterSubscriptionController : BaseAdminController
         _dateTimeService = dateTimeService;
         _translationService = translationService;
         _storeService = storeService;
-        _groupService = groupService;
         _contextAccessor = contextAccessor;
     }
 
@@ -122,9 +119,6 @@ public class NewsLetterSubscriptionController : BaseAdminController
                 break;
         }
 
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            model.StoreId = _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId;
-
         var newsletterSubscriptions = await _newsLetterSubscriptionService.GetAllNewsLetterSubscriptions(
             model.SearchEmail,
             model.StoreId, isActive, searchCategoryIds, command.Page - 1, command.PageSize);
@@ -188,9 +182,6 @@ public class NewsLetterSubscriptionController : BaseAdminController
                 isActive = false;
                 break;
         }
-
-        if (await _groupService.IsStoreManager(_contextAccessor.WorkContext.CurrentCustomer))
-            model.StoreId = _contextAccessor.WorkContext.CurrentCustomer.StaffStoreId;
 
         var subscriptions = await _newsLetterSubscriptionService.GetAllNewsLetterSubscriptions(model.SearchEmail,
             model.StoreId, isActive, searchCategoryIds);


### PR DESCRIPTION
Type: **bugfix**

## Issue
`AuthorizeAdminAttribute` (added in #570, "Grand.Web.Store – A Store Management Module") redirects any store manager to `AdminLogin` before any `Grand.Web.Admin` action executes:

```csharp
if (await groupService.IsStoreManager(...) ||
    !string.IsNullOrEmpty(CurrentCustomer.StaffStoreId))
    filterContext.Result = new RedirectToRouteResult(routeName, ...);
```

`DiscountController`, `CourseController`, `HomeController`, and `NewsLetterSubscriptionController` predate that filter (2021, vs. #570 in 2025) and still carry per-action `if (IsStoreManager) ...` branches that default a model's store or restrict access by store. Since #570 shipped, a store manager can never reach these action bodies at all — the filter already turns them away — so the branches are unreachable dead code left over from before the Store host existed.

## Solution
Removed the dead `if (IsStoreManager) ...` branches (and the else-paths that went with them) from the four affected controllers, and the now-unused `IGroupService` dependency in `DiscountController`, `CourseController`, and `NewsLetterSubscriptionController` — each was the sole remaining consumer. `CustomerController`'s `IGroupService` was left alone; it has other live callers (`IsSalesManager`, `IsAdmin`) unrelated to this issue.

Deliberately did **not** touch `CustomerViewModelService`, `CustomerValidator`, or `ProductViewModelService` — those live in `Grand.Web.AdminShared` and are shared with the Store host, where `IsStoreManager` is genuinely reachable (Store's own `AuthorizeStoreAttribute` requires it to be `true`, the opposite gate).

## Breaking changes
None. Pure dead-code removal — no request that reaches these actions today can have `IsStoreManager` true, verified by inspecting `AuthorizeAdminAttribute` and confirming no action in these controllers opts out via `[AuthorizeAdmin(ignore: true)]`.

## Testing
1. Build `Grand.Web.Admin` — succeeds, 0 errors (verified locally).
2. As a full Administrator, exercise Discount create/edit/delete, Course create/edit/delete/lesson management, the Admin dashboard, and Newsletter subscription list/export — all behave identically to before this change (they always took the `else`/no-op path anyway).
3. As a Store Manager, confirm `/Admin/*` still redirects to `AdminLogin` exactly as before — unchanged, since `AuthorizeAdminAttribute` itself was not modified.
