### PR TITLE
fix(store): drop dead-condition re-check in EditWarningCheck (Product/Collection/Brand/Category/Blog)

### DIFF
--- a/src/Web/Grand.Web.Store/Controllers/BlogController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/BlogController.cs
@@ -46,8 +46,7 @@ public class BlogController(
     protected override void EditWarningCheck(BlogPost blogPost)
     {
         if (!blogPost.LimitedToStores ||
-            (blogPost.LimitedToStores &&
-             blogPost.Stores.Contains(PostScope.DefaultStoreId) &&
+            (blogPost.Stores.Contains(PostScope.DefaultStoreId) &&
              blogPost.Stores.Count > 1))
             Warning(TranslationService.GetResource("Admin.Content.Blog.BlogPosts.Permissions"));
     }

--- a/src/Web/Grand.Web.Store/Controllers/BrandController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/BrandController.cs
@@ -38,8 +38,7 @@ public class BrandController(
     protected override void EditWarningCheck(Brand brand)
     {
         if (!brand.LimitedToStores ||
-            (brand.LimitedToStores &&
-             brand.Stores.Contains(Scope.DefaultStoreId) &&
+            (brand.Stores.Contains(Scope.DefaultStoreId) &&
              brand.Stores.Count > 1))
             Warning(TranslationService.GetResource("Admin.Catalog.Brands.Permissions"));
     }

--- a/src/Web/Grand.Web.Store/Controllers/CategoryController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/CategoryController.cs
@@ -38,8 +38,7 @@ public class CategoryController(
     protected override void EditWarningCheck(Category category)
     {
         if (!category.LimitedToStores ||
-            (category.LimitedToStores &&
-             category.Stores.Contains(Scope.DefaultStoreId) &&
+            (category.Stores.Contains(Scope.DefaultStoreId) &&
              category.Stores.Count > 1))
             Warning(TranslationService.GetResource("Admin.Catalog.Categories.Permissions"));
     }

--- a/src/Web/Grand.Web.Store/Controllers/CollectionController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/CollectionController.cs
@@ -40,8 +40,7 @@ public class CollectionController(
     protected override void EditWarningCheck(Collection collection)
     {
         if (!collection.LimitedToStores ||
-            (collection.LimitedToStores &&
-             collection.Stores.Contains(Scope.DefaultStoreId) &&
+            (collection.Stores.Contains(Scope.DefaultStoreId) &&
              collection.Stores.Count > 1))
             Warning(TranslationService.GetResource("Admin.Catalog.Collections.Permissions"));
     }

--- a/src/Web/Grand.Web.Store/Controllers/ProductController.cs
+++ b/src/Web/Grand.Web.Store/Controllers/ProductController.cs
@@ -50,8 +50,7 @@ public class ProductController(
     protected override void EditWarningCheck(Product product)
     {
         if (!product.LimitedToStores ||
-            (product.LimitedToStores &&
-             product.Stores.Contains(Scope.DefaultStoreId) &&
+            (product.Stores.Contains(Scope.DefaultStoreId) &&
              product.Stores.Count > 1))
             Warning(TranslationService.GetResource("Admin.Catalog.Products.Permissions"));
     }


### PR DESCRIPTION
## Summary
CodeQL flagged a constant-condition finding on PR #809 (Page consolidation): `PageController.EditWarningCheck`'s `if (!x.LimitedToStores || (x.LimitedToStores && ...))` re-checks `x.LimitedToStores` inside the OR's second branch, which is always `true` there since that branch only runs once the first branch's `!x.LimitedToStores` has already evaluated `false`.

The same legacy idiom (predating ARCH-001, inherited via copy across phases) exists identically in five already-merged Store controllers. This PR drops the same dead re-check in all of them, matching the fix applied to `PageController` (#809) and `NewsController` (#810).

- `ProductController.EditWarningCheck`
- `CollectionController.EditWarningCheck`
- `BrandController.EditWarningCheck`
- `CategoryController.EditWarningCheck`
- `BlogController.EditWarningCheck`

No behavior change — purely removing dead code flagged by static analysis.

## Validation
- `dotnet build src/Web/Grand.Web.Store/Grand.Web.Store.csproj` — 0 errors
- `dotnet test src/Tests/Grand.Web.Store.Tests` filtered to Product/Collection/Brand/Category/Blog controller tests — 17/17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)